### PR TITLE
Add mime types for Handlebars / Mustache templates

### DIFF
--- a/mimes.php
+++ b/mimes.php
@@ -983,4 +983,6 @@ return [
     "smv" => "video/x-smv",
     "ice" => "x-conference/x-cooltalk",
     "map" => "application/json",
+    "hbs" => "text/html",
+    "mustache" => "text/html",
 ];


### PR DESCRIPTION
I hope that it's ok to add this here. I'm using Mustache templates in a Laravel project and I had the following error message in all my templates: "Notice: Undefined index: mustache in /Users/jan/.composer/vendor/laravel/valet/drivers/ValetDriver.php on line 97". Adding the mime type to mimes.php fixes this problem.