### PR TITLE
ValetDriver::serves() method should return bool

### DIFF
--- a/drivers/ValetDriver.php
+++ b/drivers/ValetDriver.php
@@ -8,7 +8,7 @@ abstract class ValetDriver
      * @param  string  $sitePath
      * @param  string  $siteName
      * @param  string  $uri
-     * @return void
+     * @return bool
      */
     abstract public function serves($sitePath, $siteName, $uri);
 


### PR DESCRIPTION
Docblock return type is not correct on ValetDriver::serves method. It should return boolean value whether driver serves request or not.