### PR TITLE
Add Generic Driver to point to a public/ folder

### DIFF
--- a/drivers/GenericPublicValetDriver.php
+++ b/drivers/GenericPublicValetDriver.php
@@ -1,0 +1,51 @@
+<?php
+
+class GenericPublicValetDriver extends ValetDriver
+{
+    /**
+     * Determine if the driver serves the request.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return void
+     */
+    public function serves($sitePath, $siteName, $uri)
+    {
+        return is_dir($sitePath);
+    }
+
+    /**
+     * Determine if the incoming request is for a static file.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string|false
+     */
+    public function isStaticFile($sitePath, $siteName, $uri)
+    {
+        if (file_exists($staticFilePath = $sitePath.'/public'.$uri)) {
+            return $staticFilePath;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/public/index.php';
+
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        return $sitePath.'/public/index.php';
+    }
+}

--- a/drivers/ValetDriver.php
+++ b/drivers/ValetDriver.php
@@ -50,6 +50,7 @@ abstract class ValetDriver
         $drivers[] = 'WordPressValetDriver';
         $drivers[] = 'CraftValetDriver';
         $drivers[] = 'StaticValetDriver';
+        $drivers[] = 'GenericPublicValetDriver';
 
         foreach ($drivers as $driver) {
             $driver = new $driver;

--- a/server.php
+++ b/server.php
@@ -68,6 +68,7 @@ require_once __DIR__.'/drivers/StaticValetDriver.php';
 require_once __DIR__.'/drivers/JigsawValetDriver.php';
 require_once __DIR__.'/drivers/WordPressValetDriver.php';
 require_once __DIR__.'/drivers/CraftValetDriver.php';
+require_once __DIR__.'/drivers/GenericPublicValetDriver.php';
 
 $valetDriver = ValetDriver::assign($valetSitePath, $siteName, $uri);
 


### PR DESCRIPTION
Adds Generic Support to a `public/` folder containing an `index.php` file.  Adds support for SlimPHP, Non-Framework PHP apps.