### PR TITLE
Ensure domain is read from the configuration file for dnsmasq

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -27,7 +27,7 @@ class Configuration
         }
 
         if (! file_exists(static::path())) {
-            static::write(['domain' => 'dev', 'paths' => []]);
+            static::write(['paths' => []]);
         }
 
         chown(static::path(), $_SERVER['SUDO_USER']);

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,9 +7,10 @@ class Configuration
     /**
      * Install the Valet configuration file.
      *
+     * @param  string  $domain
      * @return void
      */
-    public static function install()
+    public static function install($domain)
     {
         if (! is_dir($directory = VALET_HOME_PATH)) {
             mkdir($directory, 0755);
@@ -27,7 +28,9 @@ class Configuration
         }
 
         if (! file_exists(static::path())) {
-            static::write(['paths' => []]);
+            static::write(['domain' => $domain, 'paths' => []]);
+        } else {
+            static::write(array_merge(Configuration::read(), ['domain' => $domain]));
         }
 
         chown(static::path(), $_SERVER['SUDO_USER']);

--- a/src/DnsMasq.php
+++ b/src/DnsMasq.php
@@ -74,6 +74,7 @@ class DnsMasq
     protected static function createCustomConfigurationFile()
     {
         $dnsMasqConfigPath = '/Users/'.$_SERVER['SUDO_USER'].'/.valet/dnsmasq.conf';
+        $domain = Configuration::read()['domain'];
 
         copy('/usr/local/opt/dnsmasq/dnsmasq.conf.example', '/usr/local/etc/dnsmasq.conf');
 
@@ -83,7 +84,7 @@ class DnsMasq
 
         chown('/usr/local/etc/dnsmasq.conf', $_SERVER['SUDO_USER']);
 
-        file_put_contents($dnsMasqConfigPath, 'address=/.dev/127.0.0.1'.PHP_EOL);
+        file_put_contents($dnsMasqConfigPath, 'address=/.'.$domain.'/127.0.0.1'.PHP_EOL);
 
         chown($dnsMasqConfigPath, $_SERVER['SUDO_USER']);
     }

--- a/src/DnsMasq.php
+++ b/src/DnsMasq.php
@@ -11,15 +11,16 @@ class DnsMasq
      * Install and configure DnsMasq.
      *
      * @param  OutputInterface  $output
+     * @param  string  $domain
      * @return void
      */
-    public static function install($output)
+    public static function install($output, $domain)
     {
         if (! static::alreadyInstalled()) {
             static::download($output);
         }
 
-        static::createCustomConfigurationFile();
+        static::createCustomConfigurationFile($domain);
 
         static::createResolver();
 
@@ -69,12 +70,12 @@ class DnsMasq
     /**
      * Append the custom DnsMasq configuration file to the main configuration file.
      *
+     * @param  string  $domain
      * @return void
      */
-    protected static function createCustomConfigurationFile()
+    protected static function createCustomConfigurationFile($domain)
     {
         $dnsMasqConfigPath = '/Users/'.$_SERVER['SUDO_USER'].'/.valet/dnsmasq.conf';
-        $domain = Configuration::read()['domain'];
 
         copy('/usr/local/opt/dnsmasq/dnsmasq.conf.example', '/usr/local/etc/dnsmasq.conf');
 

--- a/src/DnsMasq.php
+++ b/src/DnsMasq.php
@@ -70,12 +70,12 @@ class DnsMasq
     /**
      * Append the custom DnsMasq configuration file to the main configuration file.
      *
-     * @param  string  $domain
      * @return void
      */
-    protected static function createCustomConfigurationFile($domain)
+    protected static function createCustomConfigurationFile()
     {
         $dnsMasqConfigPath = '/Users/'.$_SERVER['SUDO_USER'].'/.valet/dnsmasq.conf';
+        $domain = Configuration::read()['domain'];
 
         copy('/usr/local/opt/dnsmasq/dnsmasq.conf.example', '/usr/local/etc/dnsmasq.conf');
 
@@ -91,7 +91,7 @@ class DnsMasq
     }
 
     /**
-     * Create the resolver file to point the "dev" domain to 127.0.0.1.
+     * Create the resolver file to point the custom domain to 127.0.0.1.
      *
      * @return void
      */

--- a/valet.php
+++ b/valet.php
@@ -29,19 +29,21 @@ if (is_dir(VALET_HOME_PATH)) {
 /**
  * Allow Valet to be run more conveniently by allowing the Node proxy to run password-less sudo.
  */
-$app->command('install', function ($output) {
+$app->command('install [domain]', function ($output, $domain) {
     should_be_sudo();
 
     Valet\LaunchDaemon::install();
 
     Valet\Configuration::install();
 
-    Valet\DnsMasq::install($output);
+    Valet\DnsMasq::install($output, $domain);
 
     Valet\LaunchDaemon::restart();
 
     $output->writeln(PHP_EOL.'<info>Valet installed successfully!</info>');
-});
+})->defaults([
+    'domain' => 'dev',
+]);
 
 /**
  * Add the current working directory to the paths configuration.

--- a/valet.php
+++ b/valet.php
@@ -34,7 +34,7 @@ $app->command('install [domain]', function ($output, $domain) {
 
     Valet\LaunchDaemon::install();
 
-    Valet\Configuration::install();
+    Valet\Configuration::install($domain);
 
     Valet\DnsMasq::install($output, $domain);
 


### PR DESCRIPTION
Whilst you can configure the domain via `config.json`, the domain is not read from the configuration file when writing to `dnsmasq.conf`