### PR TITLE
add 'status' command

### DIFF
--- a/src/LaunchDaemon.php
+++ b/src/LaunchDaemon.php
@@ -12,7 +12,7 @@ class LaunchDaemon
     public static function install()
     {
         $contents = str_replace(
-            'SERVER_PATH', realpath(__DIR__.'/../server.php'), file_get_contents(__DIR__.'/../stubs/daemon.plist')
+            'SERVER_PATH', realpath(__DIR__ . '/../server.php'), file_get_contents(__DIR__ . '/../stubs/daemon.plist')
         );
 
         $contents = str_replace('PHP_PATH', exec('which php'), $contents);
@@ -40,6 +40,16 @@ class LaunchDaemon
     public static function stop()
     {
         quietly('launchctl unload /Library/LaunchDaemons/com.laravel.valetServer.plist > /dev/null');
+    }
+
+    /**
+     * Check for an existing Valet daemon.
+     *
+     * @return string | null
+     */
+    public static function status()
+    {
+        return exec('launchctl list | grep valetServer');
     }
 
     /**

--- a/valet
+++ b/valet
@@ -10,7 +10,7 @@ then
     cd $OLDPWD
 fi
 
-if [[ $1 = "install" ]] || [[ $1 = "start" ]] || [[ $1 = "restart" ]] || [[ $1 = "stop" ]] || [[ $1 = "uninstall" ]]
+if [[ $1 = "install" ]] || [[ $1 = "start" ]] || [[ $1 = "restart" ]] || [[ $1 = "stop" ]] || [[ $1 = "status" ]] || [[ $1 = "uninstall" ]]
 then
     sudo php $DIR/valet.php $@
 elif [[ $1 = "share" ]]

--- a/valet.php
+++ b/valet.php
@@ -1,15 +1,15 @@
 #!/usr/bin/env php
 <?php
 
-if (file_exists(__DIR__.'/vendor/autoload.php')) {
-    require __DIR__.'/vendor/autoload.php';
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require __DIR__ . '/vendor/autoload.php';
 } else {
-    require __DIR__.'/../../autoload.php';
+    require __DIR__ . '/../../autoload.php';
 }
 
 should_be_compatible();
 
-define('VALET_HOME_PATH', $_SERVER['HOME'].'/.valet');
+define('VALET_HOME_PATH', $_SERVER['HOME'] . '/.valet');
 
 use Silly\Application;
 
@@ -40,7 +40,7 @@ $app->command('install', function ($output) {
 
     Valet\LaunchDaemon::restart();
 
-    $output->writeln(PHP_EOL.'<info>Valet installed successfully!</info>');
+    $output->writeln(PHP_EOL . '<info>Valet installed successfully!</info>');
 });
 
 /**
@@ -69,14 +69,14 @@ $app->command('link [name]', function ($name, $output) {
 
     $linkPath = Valet\Site::link($name);
 
-    $output->writeln('<info>A ['.$name.'] symbolic link has been created in ['.$linkPath.'].</info>');
+    $output->writeln('<info>A [' . $name . '] symbolic link has been created in [' . $linkPath . '].</info>');
 });
 
 /**
  * Display all of the registered symbolic links.
  */
 $app->command('links', function () {
-    passthru('ls -la '.VALET_HOME_PATH.'/Sites');
+    passthru('ls -la ' . VALET_HOME_PATH . '/Sites');
 });
 
 /**
@@ -86,7 +86,7 @@ $app->command('unlink [name]', function ($name, $output) {
     $name = $name ?: basename(getcwd());
 
     if (Valet\Site::unlink($name)) {
-        $output->writeln('<info>The ['.$name.'] symbolic link has been removed.</info>');
+        $output->writeln('<info>The [' . $name . '] symbolic link has been removed.</info>');
     } else {
         $output->writeln('<fg=red>A symbolic link with this name does not exist.</>');
     }
@@ -96,12 +96,12 @@ $app->command('unlink [name]', function ($name, $output) {
  * Determine which Valet driver the current directory is using.
  */
 $app->command('which', function ($output) {
-    require __DIR__.'/drivers/require.php';
+    require __DIR__ . '/drivers/require.php';
 
     $driver = ValetDriver::assign(getcwd(), basename(getcwd()), '/');
 
     if ($driver) {
-        $output->writeln('<info>This site is served by ['.get_class($driver).'].</info>');
+        $output->writeln('<info>This site is served by [' . get_class($driver) . '].</info>');
     } else {
         $output->writeln('<fg=red>Valet could not determine which driver to use for this site.</>');
     }
@@ -114,7 +114,7 @@ $app->command('logs', function ($output) {
     $files = Valet\Site::logs();
 
     if (count($files) > 0) {
-        passthru('tail -f '.implode(' ', $files));
+        passthru('tail -f ' . implode(' ', $files));
     } else {
         $output->writeln('<fg=red>No log files were found.</>');
     }
@@ -185,6 +185,17 @@ $app->command('stop', function ($output) {
     Valet\LaunchDaemon::stop();
 
     $output->writeln('<info>Valet services have been stopped.</info>');
+});
+
+/**
+ * Check the daemon services.
+ */
+$app->command('status', function ($output) {
+    should_be_sudo();
+
+    $state = Valet\LaunchDaemon::status() ? 'running' : 'stopped';
+
+    $output->writeln("<info>Valet services are {$state}.</info>");
 });
 
 /**


### PR DESCRIPTION
My experience with Homestead had me running `homestead status` as often (or more often) than `up` or `halt`. After leaving for errands, or switching to/from a client project (etc), first thing I'd do is check the `status` upon returning to my Laravel work.

👎 for anecdotal ramble. 👍 for utility 