### PR TITLE
Add Contao CMS driver

### DIFF
--- a/drivers/ContaoValetDriver.php
+++ b/drivers/ContaoValetDriver.php
@@ -1,0 +1,55 @@
+<?php
+
+class ContaoValetDriver extends ValetDriver
+{
+    /**
+     * Determine if the driver serves the request.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return void
+     */
+    public function serves($sitePath, $siteName, $uri)
+    {
+        if (is_dir($sitePath.'/vendor/contao') && file_exists($sitePath.'/web/app.php')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the incoming request is for a static file.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string|false
+     */
+    public function isStaticFile($sitePath, $siteName, $uri)
+    {
+        if (file_exists($staticFilePath = $sitePath.'/web'.$uri) && pathinfo($sitePath.$uri)['extension'] != 'php') {
+            return $staticFilePath;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        if($uri === '/install.php') {
+            return $sitePath.'/web/install.php';
+        }
+
+        return $sitePath.'/web/app.php';
+    }
+}

--- a/drivers/ValetDriver.php
+++ b/drivers/ValetDriver.php
@@ -52,6 +52,7 @@ abstract class ValetDriver
         $drivers[] = 'JigsawValetDriver';
         $drivers[] = 'GenericPhpValetDriver';
         $drivers[] = 'StaticValetDriver';
+        $drivers[] = 'ContaoValetDriver';
 
         foreach ($drivers as $driver) {
             $driver = new $driver;

--- a/drivers/require.php
+++ b/drivers/require.php
@@ -7,5 +7,6 @@ require_once __DIR__.'/StaticValetDriver.php';
 require_once __DIR__.'/JigsawValetDriver.php';
 require_once __DIR__.'/WordPressValetDriver.php';
 require_once __DIR__.'/CraftValetDriver.php';
+require_once __DIR__.'/ContaoValetDriver.php';
 require_once __DIR__.'/SymfonyValetDriver.php';
 require_once __DIR__.'/GenericPhpValetDriver.php';


### PR DESCRIPTION
This driver targets the Contao CMS (quite common in Germany and expanding with it's 4.0 symfony based release https://contao.org/en/).

Contao install documentation: https://docs.contao.org/books/manual/4.0/en/01-installation/installing-contao.html

I've added a double check for the `serves` method to be sure Contao is used in the project && the project is served via the web directory. The `frontControllerPath` checks if the user want to run the installer instead the main file.

