### PR TITLE
Added Magento 2 driver

### DIFF
--- a/drivers/MagentoValetDriver.php
+++ b/drivers/MagentoValetDriver.php
@@ -1,0 +1,77 @@
+<?php
+
+class MagentoValetDriver extends ValetDriver
+{
+    /**
+     * Determine if the driver serves the request.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return void
+     */
+    public function serves($sitePath, $siteName, $uri)
+    {
+        return file_exists($sitePath . '/bin/magento') && file_exists($sitePath.'/pub/index.php');
+    }
+
+    /**
+     * Determine if the incoming request is for a static file.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string|false
+     */
+    public function isStaticFile($sitePath, $siteName, $uri)
+    {
+        $route = parse_url(substr($uri, 1))["path"];
+
+        if (strpos($route, 'pub/errors/default/') === 0) {
+            $route = preg_replace('#pub/errors/default/#', 'errors/default/', $route, 1);
+        }
+
+        if (
+            strpos($route, 'media/') === 0 ||
+            strpos($route, 'opt/') === 0 ||
+            strpos($route, 'static/') === 0 ||
+            strpos($route, 'errors/default/css/') === 0 ||
+            strpos($route, 'errors/default/images/') === 0
+        ) {
+            $magentoPackagePubDir = $sitePath."/pub";
+
+            $file = $magentoPackagePubDir.'/'.$route;
+
+            if (file_exists($file)) {
+                return $magentoPackagePubDir.$uri;
+            } else {
+                if (strpos($route, 'static/') === 0) {
+                    $route = preg_replace('#static/#', '', $route, 1);
+                    $_GET['resource'] = $route;
+                    include($magentoPackagePubDir.'/static.php');
+                    exit;
+                } elseif (strpos($route, 'media/') === 0) {
+                    include($magentoPackagePubDir.'/get.php');
+                    exit;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        return $sitePath.'/pub/index.php';
+
+
+    }
+}

--- a/drivers/ValetDriver.php
+++ b/drivers/ValetDriver.php
@@ -52,6 +52,7 @@ abstract class ValetDriver
         $drivers[] = 'StatamicValetDriver';
         $drivers[] = 'SymfonyValetDriver';
         $drivers[] = 'WordPressValetDriver';
+        $drivers[] = 'MagentoValetDriver';
 
         $drivers[] = 'BasicValetDriver';
 

--- a/drivers/require.php
+++ b/drivers/require.php
@@ -16,3 +16,4 @@ require_once __DIR__.'/SculpinValetDriver.php';
 require_once __DIR__.'/StatamicValetDriver.php';
 require_once __DIR__.'/SymfonyValetDriver.php';
 require_once __DIR__.'/WordPressValetDriver.php';
+require_once __DIR__.'/MagentoValetDriver.php';


### PR DESCRIPTION
Just because it works (and I like Zend people at the Laravel docs looking how to install Valet) :-)

Magento composer install I've used for testing the driver:
http://devdocs.magento.com/guides/v2.0/install-gde/prereq/integrator_install.html

Magento was quite tricky because they serve their static assets via a php file - but they had a solution for this in their included phpserver.

I also updated my branch to the newest Valet version and squashed all my commits into one for easy review.