### PR TITLE
Sites Manifest Page

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -1,0 +1,66 @@
+<?php
+
+$domain = $valetConfig['domain'];
+
+$paths = [];
+
+foreach ($valetConfig['paths'] as $path) {
+    $paths[$path] = [];
+    foreach (scandir($path) as $directory) {
+        if (is_dir($path.'/'.$directory) && !in_array($directory, ['.', '..'])) {
+            $paths[$path][] = "http://{$directory}.$domain";
+        }
+    }
+    $paths[$path] = array_filter($paths[$path]);
+}
+
+$paths = array_filter($paths);
+
+?>
+<html>
+    <head>
+        <title>Valet</title>
+
+        <style>
+            body {
+                font-family: monospace;
+                margin: 20px;
+            }
+            ul {
+                padding-top: .2em;
+                padding-bottom: .2em;
+            }
+            li {
+                padding: .2em 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h2>Your <a href="https://laravel.com/docs/valet">Valet</a> Sites</h2>
+        <?php
+
+        if (count($paths)) {
+
+            echo '<ul>'.PHP_EOL;
+            foreach ($paths as $path => $sites) {
+                echo '<li>'.PHP_EOL;
+                    echo $path.PHP_EOL;
+                    echo '<ul>'.PHP_EOL;
+                        foreach ($sites as $site) {
+                            echo "<li><a href=\"$site\">$site</a></li>".PHP_EOL;
+                        }
+                    echo '</ul>'.PHP_EOL;
+                echo '</li>'.PHP_EOL;
+            }
+            echo '</ul>'.PHP_EOL;
+
+        } else {
+
+            echo '<p>No <a href="https://laravel.com/docs/valet#serving-sites">served sites</a> found.</p>'.PHP_EOL;
+
+        }
+
+        ?>
+        </ul>
+    </body>
+</html>

--- a/server.php
+++ b/server.php
@@ -21,6 +21,16 @@ function show_valet_404()
 }
 
 /**
+ * Show the Valet manifest page.
+ */
+function show_valet_manifest($valetConfig)
+{
+    http_response_code(200);
+    require __DIR__.'/manifest.php';
+    exit;
+}
+
+/**
  * Load the Valet configuration.
  */
 $valetConfig = json_decode(
@@ -41,6 +51,13 @@ $siteName = basename(
 
 if (strpos($siteName, 'www.') === 0) {
     $siteName = substr($siteName, 4);
+}
+
+/**
+ * Display the sites manifest if requested.
+ */
+if ($siteName === $valetConfig['manifest']) {
+    show_valet_manifest($valetConfig);
 }
 
 /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -27,7 +27,7 @@ class Configuration
         }
 
         if (! file_exists(static::path())) {
-            static::write(['domain' => 'dev', 'paths' => []]);
+            static::write(['domain' => 'dev', 'manifest' => 'valet', 'paths' => []]);
         }
 
         chown(static::path(), $_SERVER['SUDO_USER']);

--- a/valet.php
+++ b/valet.php
@@ -59,6 +59,13 @@ $app->command('domain domain', function ($domain, $output) {
 });
 
 /**
+ * Get the domain currently being used by Valet.
+ */
+$app->command('current-domain', function ($output) {
+    $output->writeln(Valet\Configuration::read()['domain']);
+});
+
+/**
  * Change the sites manifest url currently being used by Valet.
  */
 $app->command('manifest manifest', function ($manifest, $output) {
@@ -70,10 +77,12 @@ $app->command('manifest manifest', function ($manifest, $output) {
 });
 
 /**
- * Get the domain currently being used by Valet.
+ * Get the sites manifest url currently being used by Valet.
  */
-$app->command('current-domain', function ($output) {
-    $output->writeln(Valet\Configuration::read()['domain']);
+$app->command('manifest-url', function ($output) {
+    $config = Valet\Configuration::read();
+
+    $output->writeln('http://'.$config['manifest'].'.'.$config['domain']);
 });
 
 /**

--- a/valet.php
+++ b/valet.php
@@ -59,6 +59,17 @@ $app->command('domain domain', function ($domain, $output) {
 });
 
 /**
+ * Change the sites manifest url currently being used by Valet.
+ */
+$app->command('manifest manifest', function ($manifest, $output) {
+    Valet\Configuration::updateKey('manifest', $manifest);
+
+    $domain = Valet\Configuration::read()['domain'];
+
+    $output->writeln('<info>Your Valet manifest url has been updated to [http://'.$manifest.'.'.$domain.'].</info>');
+});
+
+/**
  * Get the domain currently being used by Valet.
  */
 $app->command('current-domain', function ($output) {


### PR DESCRIPTION
Displays a simple sites manifest page via "http://[manifest].[domain]" (defaults to "http://valet.dev").

![valet-manifest](https://cloud.githubusercontent.com/assets/1914481/15091962/d1e50cc4-149e-11e6-979f-6145a1f6cb21.png)

The manifest name is configurable via the "manifest [manifest]" command.

![valet-manifest-command](https://cloud.githubusercontent.com/assets/1914481/15091963/d3703370-149e-11e6-9b69-0d90332cc1a4.png)

The manifest URL can be checked via the "manifest-url" command.

![valet-manifest-url-command](https://cloud.githubusercontent.com/assets/1914481/15092070/a6922c2a-14a1-11e6-9e39-f2d2483cfe38.png)