### PR TITLE
Update Caddyfile

### DIFF
--- a/stubs/Caddyfile
+++ b/stubs/Caddyfile
@@ -5,6 +5,5 @@ fastcgi / 127.0.0.1:9000 php {
 }
 
 rewrite {
-    r .*
-    to /server.php?{query}
+    to {path} {path}/ /server.php?{query}
 }


### PR DESCRIPTION
The regexp is can be ommited as it is a wildcard. 
`{path}` and `{path}/` ensures valid files (especially static files) and directories are served.