### PR TITLE
Add simple commands to manage caddy's server blocks

### DIFF
--- a/src/ServerBlock.php
+++ b/src/ServerBlock.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Valet;
+
+class ServerBlock
+{
+    public static function install()
+    {
+        if (! is_dir($serverBlocksDirectory = VALET_HOME_PATH.'/ServerBlocks')) {
+            mkdir($serverBlocksDirectory, 0755);
+
+            chown($serverBlocksDirectory, $_SERVER['SUDO_USER']);
+        }
+
+        touch($serverBlocksDirectory.'/.keep');
+
+        chown($serverBlocksDirectory.'/.keep', $_SERVER['SUDO_USER']);
+    }
+
+    /**
+     * Adds a custom server block to VALET_HOME/Caddy based on a stub file
+     * @param $domain
+     * @param $file
+     * @param $data
+     */
+    public static function add($domain, $file, $data)
+    {
+        $serverBlockContent = file_get_contents($file);
+
+        $dataArray = ['keys' => [], 'values' => []];
+        foreach($data as $datapoint) {
+            $keyValue = explode('=', $datapoint);
+            $dataArray['keys'] = $keyValue[0];
+            $dataArray['values'] = $keyValue[1];
+        }
+
+        $serverBlockContent = str_replace($dataArray['keys'], $dataArray['values'], $serverBlockContent);
+
+        $serverBlockContent = str_replace([
+            'DOMAIN', 'CWD', 'PUBLIC_PATH', 'HOME_PATH'
+        ], [
+            $domain, getcwd(), 'public', $_SERVER['HOME']
+        ], $serverBlockContent);
+
+        file_put_contents(VALET_HOME_PATH.'/Caddy/'.$domain.'.conf', $serverBlockContent);
+
+        PhpFpm::restart();
+        Caddy::restart();
+    }
+
+    /**
+     * Removes a custom server block from VALET_HOME/Caddy
+     * @param $domain
+     */
+    public static function remove($domain)
+    {
+        unlink(VALET_HOME_PATH.'/Caddy/'.$domain.'.conf');
+
+        PhpFpm::restart();
+        Caddy::restart();
+    }
+
+
+    /**
+     * Rename all server blocks to match the new domain
+     * @param $oldDomain
+     * @param $domain
+     */
+    public static function renameBlocks($oldDomain, $domain)
+    {
+        if ($handle = opendir(VALET_HOME_PATH.'/Caddy')) {
+            while (false !== ($filename = readdir($handle))) {
+                if($filename === '.' || $filename === '..' || $filename === '.keep') {
+                    continue;
+                }
+
+                $content = file_get_contents(VALET_HOME_PATH.'/Caddy/'.$filename);
+                file_put_contents(VALET_HOME_PATH.'/Caddy/'.$filename,
+                    str_replace($oldDomain.':80', $domain.':80', $content));
+                rename(VALET_HOME_PATH.'/Caddy/'.$filename,
+                    str_replace('.'.$oldDomain.'.conf', '.'.$domain.'.conf', VALET_HOME_PATH.'/Caddy/'.$filename));
+            }
+            closedir($handle);
+        }
+    }
+    
+    public static function generateDomain($domain)
+    {
+        return trim($domain).'.'.Configuration::read()['domain'];
+    }
+}

--- a/src/ServerBlock.php
+++ b/src/ServerBlock.php
@@ -88,7 +88,7 @@ class ServerBlock
     }
 
     /**
-     * Trim and the string and append current tld
+     * Trim the string and append current tld
      * @param $domain
      * @return string
      */

--- a/src/ServerBlock.php
+++ b/src/ServerBlock.php
@@ -4,6 +4,9 @@ namespace Valet;
 
 class ServerBlock
 {
+    /**
+     * Prepares the ServerBlocks folder in VALET_HOME_PATH/ServerBlocks
+     */
     public static function install()
     {
         if (! is_dir($serverBlocksDirectory = VALET_HOME_PATH.'/ServerBlocks')) {
@@ -83,7 +86,12 @@ class ServerBlock
             closedir($handle);
         }
     }
-    
+
+    /**
+     * Trim and the string and append current tld
+     * @param $domain
+     * @return string
+     */
     public static function generateDomain($domain)
     {
         return trim($domain).'.'.Configuration::read()['domain'];

--- a/stubs/ServerBlocks/static.conf
+++ b/stubs/ServerBlocks/static.conf
@@ -1,0 +1,3 @@
+DOMAIN:80 {
+    root CWD
+}

--- a/stubs/serverblocks/homestead.conf
+++ b/stubs/serverblocks/homestead.conf
@@ -1,0 +1,7 @@
+DOMAIN:80 {
+    proxy / 192.168.10.10 {
+        proxy_header Host {host}
+        proxy_header X-Real-IP {remote}
+        proxy_header X-Forwarded-Proto {scheme}
+    }
+}

--- a/valet
+++ b/valet
@@ -10,7 +10,7 @@ then
     cd "$OLDPWD"
 fi
 
-if [[ "$1" = "install" ]] || [[ "$1" = "domain" ]] || [[ "$1" = "start" ]] || [[ "$1" = "restart" ]] || [[ "$1" = "stop" ]] || [[ "$1" = "uninstall" ]]
+if [[ "$1" = "install" ]] || [[ "$1" = "domain" ]] || [[ "$1" = "start" ]] || [[ "$1" = "restart" ]] || [[ "$1" = "stop" ]] || [[ "$1" = "uninstall" ]] || [[ "$1" = "serve" ]] || [[ "$1" = "unserve" ]]
 then
     sudo php "$DIR/valet.php" "$@"
 elif [[ "$1" = "share" ]]

--- a/valet.php
+++ b/valet.php
@@ -251,12 +251,16 @@ $app->command('serve domain serverblock [-d|--data=]*', function($domain, $serve
         if(!file_exists($serverblockStub)) {
             $serverblockStub = $fallbackServerblockStub; // Use fallback stub file when custom file not exists
         }
-        
+
         Valet\ServerBlock::add(\Valet\ServerBlock::generateDomain($domain), $serverblockStub, $data);
 
         $output->writeln('<info>Valet is now serving your custom server block for the domain "'.$domain.'".</info>');
     }
-});
+})->descriptions('Adds a custom server block to Valet', [
+    'domain'   => 'Which domain do you want to use for the server block?',
+    'serverblock' => 'What type of server block is it? e.g. homestead',
+    '--data' => 'Used to provide extra data for the server block'
+]);
 
 /**
  * Remove a custom server block from Caddy
@@ -267,7 +271,9 @@ $app->command('unserve domain', function($domain, $output) {
     Valet\ServerBlock::remove(\Valet\ServerBlock::generateDomain($domain));
 
     $output->writeln('<info>Removed custom server block for "'.$domain.'" from Valet.</info>');
-});
+})->descriptions('Remove a custom server block from Valet', [
+    'domain'   => 'Which domain do you want to remove?'
+]);
 
 /**
  * Run the application.

--- a/valet.php
+++ b/valet.php
@@ -42,6 +42,8 @@ $app->command('install', function ($output) {
 
     Valet\DnsMasq::install($output);
 
+    Valet\ServerBlock::install();
+
     Valet\Caddy::restart();
 
     $output->writeln(PHP_EOL.'<info>Valet installed successfully!</info>');
@@ -57,7 +59,12 @@ $app->command('domain domain', function ($domain, $output) {
 
     Valet\DnsMasq::updateDomain(Valet\Configuration::read()['domain'], $domain);
 
+    Valet\ServerBlock::renameBlocks(Valet\Configuration::read()['domain'], $domain);
+
     Valet\Configuration::updateKey('domain', $domain);
+
+    Valet\PhpFpm::restart();
+    Valet\Caddy::restart();
 
     $output->writeln('<info>Your Valet domain has been updated to ['.$domain.'].</info>');
 });
@@ -225,6 +232,41 @@ $app->command('uninstall', function ($output) {
     Valet\Caddy::uninstall();
 
     $output->writeln('<info>Valet has been uninstalled.</info>');
+});
+
+/**
+ * Add a custom server block to Caddy
+ */
+$app->command('serve domain serverblock [-d|--data=]*', function($domain, $serverblock, $data, $output) {
+    should_be_sudo();
+
+    $serverblockStub = VALET_HOME_PATH.'/ServerBlocks/'.$serverblock.'.conf';
+    $fallbackServerblockStub = __DIR__ . '/stubs/ServerBlocks/' .$serverblock.'.conf';
+
+    if(!file_exists($serverblockStub) && !file_exists($fallbackServerblockStub)) {
+        $output->writeln('<error>Unable to find server block stub file.</error>');
+        return;
+    }
+    else {
+        if(!file_exists($serverblockStub)) {
+            $serverblockStub = $fallbackServerblockStub; // Use fallback stub file when custom file not exists
+        }
+        
+        Valet\ServerBlock::add(\Valet\ServerBlock::generateDomain($domain), $serverblockStub, $data);
+
+        $output->writeln('<info>Valet is now serving your custom server block for the domain "'.$domain.'".</info>');
+    }
+});
+
+/**
+ * Remove a custom server block from Caddy
+ */
+$app->command('unserve domain', function($domain, $output) {
+    should_be_sudo();
+
+    Valet\ServerBlock::remove(\Valet\ServerBlock::generateDomain($domain));
+
+    $output->writeln('<info>Removed custom server block for "'.$domain.'" from Valet.</info>');
 });
 
 /**


### PR DESCRIPTION
With Caddy we have the possibility to use multiple server blocks and @taylorotwell used the power of zonda to create a Caddyfile that allows us to add custom config files to ~/.valet/Caddy/. Because I wanted Valet to be my entrypoint to all local projects, I added two commands to manage custom server blocks:

`valet serve domain serverblock [-d | --data=]*`  : Uses a stub file from ~/.valet/ServerBlocks/{serverblock}.conf or {VALET_INSTALL}/stubs/ServerBlocks/{serverblock}.conf to add a new config file to the ~/.valet/Caddy/ folder. Some basic variables like "DOMAIN" or "CWD" will be replaced by default.
All other variables in the stub file can be replaced by providing the -d option with key-value data e.g. -d GIT_REPO=git@github.com/laravel/laravel.git .

and

`valet unnerve domain` : Removes .conf file from the Caddy folder and restarts Valet.

With this commands I managed to add all my bigger projects, running in my homestead box, fluently with an simple `valet serve {domain} homestead`. 

I also tested the git directive, custom caddy binary needed, and a custom fastcgi directive. That all worked perfectly for me even after changing the tld of Valet.