### PR TITLE
Remove Automatic Linking of storage/public files

### DIFF
--- a/drivers/LaravelValetDriver.php
+++ b/drivers/LaravelValetDriver.php
@@ -30,10 +30,6 @@ class LaravelValetDriver extends ValetDriver
             return $staticFilePath;
         }
 
-        if (file_exists($sitePath.'/storage/public'.$uri)) {
-            return $sitePath.'/public'.$uri;
-        }
-
         return false;
     }
 


### PR DESCRIPTION
The storage/public folder is usually not symlinked to the public/ folder.
In fact it's impossible to symlink it unless you move the main index.php file.

A specific issue I'm having here is that folders in my storage/public directory actually match resource URL's

Example:

Users Controller points to: **example.dev/users**
Users uploaded files: **storage/public/users**