### PR TITLE
Support Statamic static caching

### DIFF
--- a/drivers/StatamicValetDriver.php
+++ b/drivers/StatamicValetDriver.php
@@ -52,6 +52,10 @@ class StatamicValetDriver extends ValetDriver
             $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
         }
 
+        if (file_exists($staticPath = preg_replace('#(^|[^:])//+#', '\\1/', $sitePath.'/static/'.$uri.'/index.html'))) {
+            return $staticPath;
+        }
+
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         if (strpos($_SERVER['REQUEST_URI'], '/index.php') === 0) {

--- a/drivers/StatamicValetDriver.php
+++ b/drivers/StatamicValetDriver.php
@@ -52,7 +52,7 @@ class StatamicValetDriver extends ValetDriver
             $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
         }
 
-        if (file_exists($staticPath = preg_replace('#(^|[^:])//+#', '\\1/', $sitePath.'/static/'.$uri.'/index.html'))) {
+        if (file_exists($staticPath = $sitePath.'/static'.$uri.'/index.html')) {
             return $staticPath;
         }
 


### PR DESCRIPTION
Statamic has a feature that saves fully rendered versions of pages to `.html` files located in `static`. Normally nginx or htaccess should be set up to load these. Now Valet can serve them out of the box.

To test in Statamic, open `site/settings/caching.yaml` and add:

```
static_caching_enabled: true
static_caching_type: file
```

Visit a page, and it'll get written to `static/url/of/page/index.html`. Visit the page again and now the response time should drop.