### PR TITLE
WordPress Driver: Fix undefined offset error in wp-admin

### DIFF
--- a/drivers/WordPressValetDriver.php
+++ b/drivers/WordPressValetDriver.php
@@ -14,4 +14,19 @@ class WordPressValetDriver extends BasicValetDriver
     {
         return is_dir($sitePath.'/wp-admin');
     }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        $_SERVER['PHP_SELF'] = $uri;
+
+        return parent::frontControllerPath($sitePath, $siteName, $uri);
+    }
 }


### PR DESCRIPTION
This fixes an error which is produced in wp-admin.  Although wp-admin seems to work fine already, it is silently triggering this error as WordPress does not show/log errors by default.  You can see this by adding `define('WP_DEBUG', true);` to `wp-config.php`

![image](https://cloud.githubusercontent.com/assets/1621608/15122983/89f9d0e6-15ef-11e6-90dd-240d16ccda62.png)

Basically, WP uses the `PHP_SELF` sever global to determine which admin page it is on, which is currently `server.php` everywhere.

`/wp-includes/vars.php`
![image](https://cloud.githubusercontent.com/assets/1621608/15123032/bfd53eee-15ef-11e6-8752-31d21fbe4583.png)

This PR ensures that the global is defined in a way which should work with what WP expects.
