### PR TITLE
Add driver for Wordpress installed as a Composer dependancy

### DIFF
--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -46,6 +46,7 @@ abstract class ValetDriver
 
         $drivers[] = 'LaravelValetDriver';
 
+        $drivers[] = 'WordpressComposerInstallValetDriver';
         $drivers[] = 'WordPressValetDriver';
         $drivers[] = 'SymfonyValetDriver';
         $drivers[] = 'CraftValetDriver';

--- a/cli/drivers/WordpressComposerInstallValetDriver.php
+++ b/cli/drivers/WordpressComposerInstallValetDriver.php
@@ -13,7 +13,6 @@ class WordpressComposerInstallValetDriver extends ValetDriver
     public function serves($sitePath, $siteName, $uri)
     {
         if (file_exists($composerFile = $sitePath .'/composer.json')) {
-
             if (file_exists($sitePath .'/wp-config.php')) {
                 return true;
             }
@@ -61,7 +60,7 @@ class WordpressComposerInstallValetDriver extends ValetDriver
     {
         if (is_dir($staticFilePath = $sitePath . $uri)) {
             return $sitePath . $uri . '/index.php';
-        } else if ($this->fileIsPHP($uri)) {
+        } elseif ($this->fileIsPHP($uri)) {
             $_SERVER['PHP_SELF'] = $uri;
             return $sitePath . preg_replace('/\/$/', '', $uri);
         }

--- a/cli/drivers/WordpressComposerInstallValetDriver.php
+++ b/cli/drivers/WordpressComposerInstallValetDriver.php
@@ -14,7 +14,8 @@ class WordpressComposerInstallValetDriver extends ValetDriver
     {
         if (file_exists($sitePath . '/composer.json')
             && (file_exists($sitePath . '/wp-config.php')
-                || is_dir($sitePath . '/vendor/johnpbloch/wordpress-core-installer'))
+                || $this->isJohnpblochInstall($sitePath)
+                || $this->isWebrootInstall($sitePath))
         ) {
             return true;
         }
@@ -37,8 +38,16 @@ class WordpressComposerInstallValetDriver extends ValetDriver
             $sitePath .= '/web';
         }
 
-        if (file_exists($staticFilePath = $sitePath . $uri) && !$this->fileIsPHP($uri) && !is_dir($staticFilePath)) {
-            return $staticFilePath;
+        if ($this->getStaticFilePath($sitePath, $uri)) {
+            return $this->getStaticFilePath($sitePath, $uri);
+        }
+
+        if ($this->isWebrootInstall($sitePath)) {
+            $sitePath = $this->getWebrootInstallPath($sitePath);
+
+            if ($this->getStaticFilePath($sitePath, $uri)) {
+                return $this->getStaticFilePath($sitePath, $uri);
+            }
         }
 
         return false;
@@ -59,14 +68,17 @@ class WordpressComposerInstallValetDriver extends ValetDriver
             $sitePath .= '/web';
         }
 
-        if (is_dir($staticFilePath = $sitePath . $uri)) {
-            return $staticFilePath . '/index.php';
-        } elseif ($this->fileIsPHP($uri)) {
-            $_SERVER['PHP_SELF'] = $uri;
-            return $sitePath . preg_replace('/\/$/', '', $uri);
+        if ($this->getFrontControllerPath($sitePath, $uri)) {
+            return $this->getFrontControllerPath($sitePath, $uri);
         }
 
-        return $sitePath . '/index.php';
+        if ($this->isWebrootInstall($sitePath)) {
+            $webrootSitePath = $this->getWebrootInstallPath($sitePath);
+
+            if ($this->getFrontControllerPath($webrootSitePath, $uri)) {
+                return $this->getFrontControllerPath($webrootSitePath, $uri);
+            }
+        }
     }
 
     /**
@@ -81,6 +93,77 @@ class WordpressComposerInstallValetDriver extends ValetDriver
                 && file_exists($path . '/web/wp-config.php')
                 && file_exists($path . '/config/application.php'))
         );
+    }
+
+    /**
+     * Checks if current install is using [fancyguy/webroot-installer](https://github.com/fancyguy/webroot-installer)
+     * @param  string  $path
+     * @return boolean
+     */
+    private function isJohnpblochInstall($path)
+    {
+        return (is_dir($path . '/vendor/johnpbloch/wordpress-core-installer'));
+    }
+
+    /**
+     * Checks if current install is using [fancyguy/webroot-installer](https://github.com/fancyguy/webroot-installer)
+     * @param  string  $path
+     * @return boolean
+     */
+    private function isWebrootInstall($path)
+    {
+        return (is_dir($path . '/vendor/fancyguy/webroot-installer'));
+    }
+
+    /**
+     * parses composer.json for the install path defined for fancyguy/webroot-installer
+     * @param  string $path
+     * @return string
+     */
+    private function getWebrootInstallPath($path)
+    {
+        $composer = json_decode(file_get_contents($path . '/composer.json'), true);
+        return $path .= '/'. $composer['extra']['webroot-dir'];
+    }
+
+    /**
+     * Helper function to determine whether to serve a static file.
+     * @param  string $path
+     * @param  string $uri
+     * @return string|bool
+     */
+    private function getStaticFilePath($path, $uri)
+    {
+        if (file_exists($staticPath = $path . $uri) && !$this->fileIsPHP($uri) && !is_dir($staticPath)) {
+            return $staticPath;
+        }
+
+        return false;
+    }
+
+    /**
+     * Helper function to determine what file should process request.
+     * @param  string $path
+     * @param  string $uri
+     * @return string|bool
+     */
+    private function getFrontControllerPath($path, $uri)
+    {
+        // If request is for real directory, check for index.php (e.g. /wp-admin/)
+        if (is_dir($staticPath = $path . $uri) && file_exists($indexedStaticPath = $staticPath . '/index.php')) {
+            return $indexedStaticPath;
+
+        // If request is for specific php file, use it if it exists (e.g. /wp-admin/edit.php, /wp-admin/upload.php)
+        } elseif ($this->fileIsPHP($uri) && file_exists($phpFile = $path . $uri)) {
+            $_SERVER['PHP_SELF'] = $uri;
+            return preg_replace('/\/$/', '', $phpFile);
+
+        // If nothing else, check the provided site path for an index.php (i.e. lets WP rewrite rules handle things)
+        } elseif (file_exists($rootIndex = $path . '/index.php')) {
+            return $rootIndex;
+        }
+
+        return false;
     }
 
     /**

--- a/cli/drivers/WordpressComposerInstallValetDriver.php
+++ b/cli/drivers/WordpressComposerInstallValetDriver.php
@@ -12,8 +12,8 @@ class WordpressComposerInstallValetDriver extends ValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
-        if (file_exists($composerFile = $sitePath .'/composer.json')) {
-            if (file_exists($sitePath .'/wp-config.php')) {
+        if (file_exists($composerFile = $sitePath . '/composer.json')) {
+            if (file_exists($sitePath . '/wp-config.php')) {
                 return true;
             }
 
@@ -41,6 +41,11 @@ class WordpressComposerInstallValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
+        // Look in public web directory
+        if ($this->isBedrockInstall($sitePath)) {
+            $sitePath .= '/web';
+        }
+
         if (file_exists($staticFilePath = $sitePath . $uri) && !$this->fileIsPHP($uri) && !is_dir($staticFilePath)) {
             return $staticFilePath;
         }
@@ -58,6 +63,11 @@ class WordpressComposerInstallValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        // Look in public web directory
+        if ($this->isBedrockInstall($sitePath)) {
+            $sitePath .= '/web';
+        }
+
         if (is_dir($staticFilePath = $sitePath . $uri)) {
             return $staticFilePath . '/index.php';
         } elseif ($this->fileIsPHP($uri)) {
@@ -68,6 +78,26 @@ class WordpressComposerInstallValetDriver extends ValetDriver
         return $sitePath . '/index.php';
     }
 
+    /**
+     * Checks if current install is [roots/bedrock](https://github.com/roots/bedrock)
+     * @param  string  $path
+     * @return boolean
+     */
+    private function isBedrockInstall($path)
+    {
+        return (file_exists($path . '/web/app/mu-plugins/bedrock-autoloader.php')
+            || (is_dir($path . '/web/app/')
+                && file_exists($path . '/web/wp-config.php')
+                && file_exists($path . '/config/application.php')
+            )
+        );
+    }
+
+    /**
+     * Check if the uri points to a PHP file
+     * @param  string $uri
+     * @return bool
+     */
     private function fileIsPHP($uri)
     {
         return (pathinfo($uri, PATHINFO_EXTENSION) === 'php');

--- a/cli/drivers/WordpressComposerInstallValetDriver.php
+++ b/cli/drivers/WordpressComposerInstallValetDriver.php
@@ -12,20 +12,11 @@ class WordpressComposerInstallValetDriver extends ValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
-        if (file_exists($composerFile = $sitePath . '/composer.json')) {
-            if (file_exists($sitePath . '/wp-config.php')) {
-                return true;
-            }
-
-            $composerJson = json_decode(file_get_contents($composerFile));
-
-            if (isset($composerJson->extra)) {
-                $extra = (array) $composerJson->extra;
-
-                if (isset($extra['wordpress-install-dir'])) {
-                    return true;
-                }
-            }
+        if (file_exists($sitePath . '/composer.json')
+            && (file_exists($sitePath . '/wp-config.php')
+                || is_dir($sitePath . '/vendor/johnpbloch/wordpress-core-installer'))
+        ) {
+            return true;
         }
 
         return false;
@@ -88,8 +79,7 @@ class WordpressComposerInstallValetDriver extends ValetDriver
         return (file_exists($path . '/web/app/mu-plugins/bedrock-autoloader.php')
             || (is_dir($path . '/web/app/')
                 && file_exists($path . '/web/wp-config.php')
-                && file_exists($path . '/config/application.php')
-            )
+                && file_exists($path . '/config/application.php'))
         );
     }
 

--- a/cli/drivers/WordpressComposerInstallValetDriver.php
+++ b/cli/drivers/WordpressComposerInstallValetDriver.php
@@ -1,0 +1,76 @@
+<?php
+
+class WordpressComposerInstallValetDriver extends ValetDriver
+{
+    /**
+     * Determine if the driver serves the request.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return void
+     */
+    public function serves($sitePath, $siteName, $uri)
+    {
+        if (file_exists($composerFile = $sitePath .'/composer.json')) {
+
+            if (file_exists($sitePath .'/wp-config.php')) {
+                return true;
+            }
+
+            $composerJson = json_decode(file_get_contents($composerFile));
+
+            if (isset($composerJson->extra)) {
+                $extra = (array) $composerJson->extra;
+
+                if (isset($extra['wordpress-install-dir'])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the incoming request is for a static file.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string|false
+     */
+    public function isStaticFile($sitePath, $siteName, $uri)
+    {
+        if (file_exists($staticFilePath = $sitePath . $uri) && !$this->fileIsPHP($uri) && !is_dir($staticFilePath)) {
+            return $staticFilePath;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        if (is_dir($staticFilePath = $sitePath . $uri)) {
+            return $sitePath . $uri . '/index.php';
+        } else if ($this->fileIsPHP($uri)) {
+            $_SERVER['PHP_SELF'] = $uri;
+            return $sitePath . preg_replace('/\/$/', '', $uri);
+        }
+
+        return $sitePath . '/index.php';
+    }
+
+    private function fileIsPHP($uri)
+    {
+        return (pathinfo($uri, PATHINFO_EXTENSION) === 'php');
+    }
+}

--- a/cli/drivers/WordpressComposerInstallValetDriver.php
+++ b/cli/drivers/WordpressComposerInstallValetDriver.php
@@ -59,7 +59,7 @@ class WordpressComposerInstallValetDriver extends ValetDriver
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
         if (is_dir($staticFilePath = $sitePath . $uri)) {
-            return $sitePath . $uri . '/index.php';
+            return $staticFilePath . '/index.php';
         } elseif ($this->fileIsPHP($uri)) {
             $_SERVER['PHP_SELF'] = $uri;
             return $sitePath . preg_replace('/\/$/', '', $uri);

--- a/cli/drivers/require.php
+++ b/cli/drivers/require.php
@@ -21,3 +21,4 @@ require_once __DIR__.'/WordPressValetDriver.php';
 require_once __DIR__.'/ContaoValetDriver.php';
 require_once __DIR__.'/KatanaValetDriver.php';
 require_once __DIR__.'/CakeValetDriver.php';
+require_once __DIR__.'/WordpressComposerInstallValetDriver.php';


### PR DESCRIPTION
Wordpress can be installed as a dependance using the "johnpbloch/wordpress" package. This driver should account for the idiosyncrasies involved with that setup (and likely variations).

EDIT: I noticed after I created this that there is already pull request #49 for a Bedrock driver, this driver will now account for a bedrock install as well as more generic setups.