### PR TITLE
Allows Valet to run under PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.5
   - 5.6
   - 7.0
 

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -41,7 +41,9 @@ class Brew
      */
     function hasInstalledPhp()
     {
-        return $this->installed('php70') || $this->installed('php56');
+        return $this->installed('php70')
+            || $this->installed('php56')
+            || $this->installed('php55');
     }
 
     /**
@@ -140,6 +142,8 @@ class Brew
             return 'php70';
         } elseif (strpos($resolvedPath, 'php56') !== false) {
             return 'php56';
+        } elseif (strpos($resolvedPath, 'php55' !== false) {
+            return 'php55';
         } else {
             throw new DomainException("Unable to determine linked PHP.");
         }

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -142,7 +142,7 @@ class Brew
             return 'php70';
         } elseif (strpos($resolvedPath, 'php56') !== false) {
             return 'php56';
-        } elseif (strpos($resolvedPath, 'php55' !== false) {
+        } elseif (strpos($resolvedPath, 'php55') !== false) {
             return 'php55';
         } else {
             throw new DomainException("Unable to determine linked PHP.");

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -2,6 +2,7 @@
 
 namespace Valet;
 
+use DomainException;
 use Exception;
 use Symfony\Component\Process\Process;
 
@@ -35,7 +36,9 @@ class PhpFpm
      */
     function install()
     {
-        if (! $this->brew->installed('php70') && ! $this->brew->installed('php56')) {
+        if (! $this->brew->installed('php70')
+            && ! $this->brew->installed('php56')
+            && ! $this->brew->installed('php55')) {
             $this->brew->ensureInstalled('php70', $this->taps);
         }
 
@@ -80,7 +83,7 @@ class PhpFpm
      */
     function stop()
     {
-        $this->brew->stopService('php56', 'php70');
+        $this->brew->stopService('php55', 'php56', 'php70');
     }
 
     /**
@@ -92,8 +95,12 @@ class PhpFpm
     {
         if ($this->brew->linkedPhp() === 'php70') {
             return '/usr/local/etc/php/7.0/php-fpm.d/www.conf';
-        } else {
+        } elseif ($this->brew->linkedPhp() === 'php56') {
             return '/usr/local/etc/php/5.6/php-fpm.conf';
+        } elseif ($this->brew->linkedPhp() === 'php55' {
+            return '/usr/local/etc/php/5.5/php-fpm.conf';
+        } else {
+            throw new DomainException('Unable to find php-fpm config.');
         }
     }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -97,7 +97,7 @@ class PhpFpm
             return '/usr/local/etc/php/7.0/php-fpm.d/www.conf';
         } elseif ($this->brew->linkedPhp() === 'php56') {
             return '/usr/local/etc/php/5.6/php-fpm.conf';
-        } elseif ($this->brew->linkedPhp() === 'php55' {
+        } elseif ($this->brew->linkedPhp() === 'php55') {
             return '/usr/local/etc/php/5.5/php-fpm.conf';
         } else {
             throw new DomainException('Unable to find php-fpm config.');

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": ">=4.8.24"
     },
     "bin": [
         "valet"

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -68,16 +68,19 @@ php7');
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->once()->with('php70')->andReturn(true);
         $brew->shouldReceive('installed')->with('php56')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php55')->andReturn(true);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->once()->with('php70')->andReturn(true);
         $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php55')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->once()->with('php70')->andReturn(false);
         $brew->shouldReceive('installed')->once()->with('php56')->andReturn(false);
+        $brew->shouldReceive('installed')->once()->with('php55')->andReturn(false);
         $this->assertFalse($brew->hasInstalledPhp());
     }
 


### PR DESCRIPTION
Nothing in the code base seemed particularly hostile to PHP 5.5, so I decided to add support for it.