### PR TITLE
Fix spaces in path when using 'valet link'

### DIFF
--- a/cli/Valet/Filesystem.php
+++ b/cli/Valet/Filesystem.php
@@ -227,7 +227,7 @@ class Filesystem
             $this->unlink($link);
         }
 
-        CommandLineFacade::runAsUser('ln -s '.quote($target).' '.quote($link));
+        CommandLineFacade::runAsUser('ln -s '.escapeshellarg($target).' '.escapeshellarg($link));
     }
 
     /**

--- a/cli/Valet/Filesystem.php
+++ b/cli/Valet/Filesystem.php
@@ -227,7 +227,7 @@ class Filesystem
             $this->unlink($link);
         }
 
-        CommandLineFacade::runAsUser('ln -s '.$target.' '.$link);
+        CommandLineFacade::runAsUser('ln -s '.quote($target).' '.quote($link));
     }
 
     /**

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -133,15 +133,3 @@ function user()
 
     return $_SERVER['SUDO_USER'];
 }
-
-/**
- * Quote the given string.
- *
- * @param  string  $string
- * @param  string  $quote_character
- * @return string
- */
-function quote( $string, $quote_character = '"' )
-{
-    return $quote_character . $string . $quote_character;
-}

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -133,3 +133,15 @@ function user()
 
     return $_SERVER['SUDO_USER'];
 }
+
+/**
+ * Quote the given string.
+ *
+ * @param  string  $string
+ * @param  string  $quote_character
+ * @return string
+ */
+function quote( $string, $quote_character = '"' )
+{
+    return $quote_character . $string . $quote_character;
+}


### PR DESCRIPTION
- Adds helper function `quote ( $string, $quote_character = '"' )`
- Uses `quote()` on `$target` when running `symlinkAsUser($target, $link)`