### PR TITLE
Allow HTTPS

### DIFF
--- a/cli/Valet/Caddy.php
+++ b/cli/Valet/Caddy.php
@@ -27,9 +27,23 @@ class Caddy
      */
     function install()
     {
+        $this->installSSLCertificate();
         $this->installCaddyFile();
         $this->installCaddyDirectory();
         $this->installCaddyDaemon();
+    }
+
+    /**
+     * Make the certificate we're going to use when serving over HTTPS
+     * 
+     * Place in the ~/.valet/certs directory.
+     *
+     * @return void
+     */
+
+    function installSSLCertificate()
+    {
+        $this->cli->runAsUser('sh '.$this->files->realpath(__DIR__.'/..').'/scripts/make-certificate.sh dev');
     }
 
     /**

--- a/cli/Valet/Caddy.php
+++ b/cli/Valet/Caddy.php
@@ -34,7 +34,7 @@ class Caddy
     }
 
     /**
-     * Make the certificate we're going to use when serving over HTTPS
+     * Make the certificate we're going to use when serving over HTTPS.
      * 
      * Place in the ~/.valet/certs directory.
      *

--- a/cli/scripts/make-certificate.sh
+++ b/cli/scripts/make-certificate.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+ 
+tld=$1
+domain=*.$tld
+commonname=$domain
+ 
+country=US
+state=Arkansas
+locality=LittleRock
+organization=TopSecretDevelopment
+organizationalunit=Zonda
+email=zonda@laravel.com
+ 
+if [ -z "$tld" ]
+then
+    echo "Argument not present."
+    echo "Useage $0 [tld]"
+ 
+    exit 99
+fi
+
+certs=$HOME/.valet/Certificates
+fn=$certs/$1
+
+mkdir $certs
+rm -f $fn.key $fn.pem $fn.csr $fn.crt
+ 
+openssl genrsa -out $fn.key 2048 -noout
+openssl req -new -key $fn.key -out $fn.csr \
+    -subj "/C=$country/ST=$state/L=$locality/O=$organization/OU=$organizationalunit/CN=$commonname/emailAddress=$email"
+openssl x509 -req -days 365 -in $fn.csr -signkey $fn.key -out $fn.crt
+
+cat $fn.crt $fn.key | tee $fn.pem

--- a/cli/stubs/Caddyfile
+++ b/cli/stubs/Caddyfile
@@ -9,3 +9,14 @@ import VALET_HOME_PATH/Caddy/*
         to /server.php?{query}
     }
 }
+
+:443 {
+    fastcgi / 127.0.0.1:9000 php {
+        index server.php
+    }
+
+    rewrite {
+        to /server.php?{query}
+    }
+    tls VALET_HOME_PATH/Certificates/dev.pem VALET_HOME_PATH/Certificates/dev.key
+}


### PR DESCRIPTION
Add :443 definition to Caddyfile, create SSL Cert upon install. Requires a `valet install` to get going and openssl available.