### PR TITLE
Detect WordPress by configuration file

### DIFF
--- a/cli/drivers/WordPressValetDriver.php
+++ b/cli/drivers/WordPressValetDriver.php
@@ -12,7 +12,7 @@ class WordPressValetDriver extends BasicValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
-        return is_dir($sitePath.'/wp-admin');
+        return file_exists($sitePath.'/wp-config.php');
     }
 
     /**


### PR DESCRIPTION
WordPress supports being placed in [it's own directory](https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory), but in both setups the `wp-config.php` file will be in the site's root directory.