### PR TITLE
Evaluates that brew command is installed even it's not in its typical instalation

### DIFF
--- a/cli/includes/compatibility.php
+++ b/cli/includes/compatibility.php
@@ -17,7 +17,7 @@ if (version_compare(PHP_VERSION, '5.5.9', '<')) {
     exit(1);
 }
 
-if (exec('which brew') != '/usr/local/bin/brew' && ! $inTestingEnvironment) {
+if (exec('which brew') == '' && ! $inTestingEnvironment) {
     echo 'Valet requires Brew to be installed on your Mac.';
 
     exit(1);


### PR DESCRIPTION
Maybe some people has their homebrew command in other path, like me that was made with github's boxen in `/opt/boxen/homebrew/bin/brew`.

So Valet evaluates that homebrew command is in `/usr/local/bin/brew`. But the case that brew is not found by `which` shows `brew not found` in bash. Now using php's `exec` function with that the returned value is an empty string. So valet can evaluate if `exec('which brew')` returns empty string then there's no brew commad.