### PR TITLE
Don't strip www from SiteName

### DIFF
--- a/server.php
+++ b/server.php
@@ -35,10 +35,6 @@ $siteName = basename(
     '.'.$valetConfig['domain']
 );
 
-if (strpos($siteName, 'www.') === 0) {
-    $siteName = substr($siteName, 4);
-}
-
 /**
  * Determine the fully qualified path to the site.
  */


### PR DESCRIPTION
I personally like to run my sites in the form of `www.my-company.com.dev`. 

Whenever I run `valet link www.my-company.com` and try to open it, it says "Not found".

When I remove this line from `server.php` it suddenly works.

Why is this line in place?