### PR TITLE
Populate SERVER_ADDR to avoid undefined index notices in WordPress

### DIFF
--- a/cli/drivers/WordPressValetDriver.php
+++ b/cli/drivers/WordPressValetDriver.php
@@ -25,7 +25,8 @@ class WordPressValetDriver extends BasicValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        $_SERVER['PHP_SELF'] = $uri;
+        $_SERVER['PHP_SELF']    = $uri;
+        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
 
         return parent::frontControllerPath($sitePath, $siteName, $uri);
     }


### PR DESCRIPTION
Common in plugins unfortunately.