### PR TITLE
Error with valet on windows 7

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -50,24 +50,21 @@ $app->command('install', function () {
 })->descriptions('Install the Valet services');
 
 /**
- * Change the domain currently being used by Valet.
+ * Get or set the domain currently being used by Valet.
  */
-$app->command('domain domain', function ($domain) {
-    DnsMasq::updateDomain(
-        Configuration::read()['domain'], $domain = trim($domain, '.')
-    );
+$app->command('domain [domain]', function ($domain = null) {
+    if ($domain === null) {
+        info(Configuration::read()['domain']);
+    } else {
+        DnsMasq::updateDomain(
+            Configuration::read()['domain'], $domain = trim($domain, '.')
+        );
 
-    Configuration::updateKey('domain', $domain);
+        Configuration::updateKey('domain', $domain);
 
-    info('Your Valet domain has been updated to ['.$domain.'].');
-})->descriptions('Set the domain used for Valet sites');
-
-/**
- * Get the domain currently being used by Valet.
- */
-$app->command('current-domain', function () {
-    info(Configuration::read()['domain']);
-})->descriptions('Get the current Valet domain');
+        info('Your Valet domain has been updated to ['.$domain.'].');
+    }
+})->descriptions('Get or set the domain used for Valet sites');
 
 /**
  * Add the current working directory to the paths configuration.

--- a/valet
+++ b/valet
@@ -43,7 +43,7 @@ then
 elif [[ "$1" = "share" ]]
 then
     HOST="${PWD##*/}"
-    DOMAIN=$(php "$DIR/cli/valet.php" current-domain)
+    DOMAIN=$(php "$DIR/cli/valet.php" domain)
 
     for linkname in ~/.valet/Sites/*; do
         if [[ "$(readlink $linkname)" = "$PWD" ]]


### PR DESCRIPTION
Hey there, I'm using valet on windows 7, and when I access to *.dev in the browser (chrome) I got this error: 
```
«Warning: Unknown: failed to open stream: No such file or directory in Unknown on line 0
Fatal error: Unknown: Failed opening required 'C:\Users\....' (include_path='.;C:/laragon/bin/php/php-5.6.13/PEAR') in Unknown on line `0».`
```
Can u help?
Sorry if I «pulled» a request in a wrong place 'cause I'm new to Github World ‼