### PR TITLE
Add support for custom sub-domain for valet share.

### DIFF
--- a/bin/lt
+++ b/bin/lt
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+var lt_client = require('../client');
+var open_url = require('openurl');
+
+var argv = require('yargs')
+    .usage('Usage: $0 --port [num] <options>')
+    .option('h', {
+        alias: 'host',
+        describe: 'Upstream server providing forwarding',
+        default: 'http://localtunnel.me'
+    })
+    .option('s', {
+        alias: 'subdomain',
+        describe: 'Request this subdomain'
+    })
+    .option('l', {
+        alias: 'local-host',
+        describe: 'Tunnel traffic to this host instead of localhost, override Host header to this host'
+    })
+    .options('o', {
+        alias: 'open',
+        describe: 'opens url in your browser'
+    })
+    .option('p', {
+        alias: 'port',
+        describe: 'Internal http server port',
+    })
+    .require('port')
+    .help('help', 'Show this help and exit')
+    .version(require('../package').version)
+    .argv;
+
+if (typeof argv.port !== 'number') {
+    require('yargs').showHelp();
+    console.error('port must be a number');
+    process.exit(1);
+}
+
+var opt = {
+    host: argv.host,
+    port: argv.port,
+    local_host: argv['local-host'],
+    subdomain: argv.subdomain,
+};
+
+lt_client(opt.port, opt, function(err, tunnel) {
+    if (err) {
+        throw err;
+    }
+
+    console.log('your url is: %s', tunnel.url);
+
+    if (argv.open) {
+        open_url.open(tunnel.url);
+    }
+
+    tunnel.on('error', function(err) {
+        throw err;
+    });
+});
+
+// vim: ft=javascript

--- a/valet
+++ b/valet
@@ -52,9 +52,16 @@ then
         fi
     done
 
-    # Fetch Ngrok URL In Background...
-    bash "$DIR/cli/scripts/fetch-share-url.sh" &
-    sudo -u $(logname) "$DIR/bin/ngrok" http -host-header=rewrite "$HOST.$DOMAIN:80"
+    if [[ -n $2 ]]
+    then
+      #Use localtunnel.me for serving with a custom sub-domain.
+      echo "https://$2.localtunnel.me" | pbcopy
+      sudo -u $(logname) lt --port 80 --local-host "$HOST.$DOMAIN" --subdomain "$2"    
+    else
+      # Fetch Ngrok URL In Background...
+      bash "$DIR/cli/scripts/fetch-share-url.sh" &
+      sudo -u $(logname) "$DIR/bin/ngrok" http -host-header=rewrite "$HOST.$DOMAIN:80"
+    fi
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
  Current version uses ngrok only, where custom sub-domain is a paid feature,
  Introduced http://localtunnel.me as an option.
  Usage e.g: valet share subdomain

This feature happened to be a must-have for our project where we wanted the url to be static.
