### PR TITLE
Added support for changing ngrok region

### DIFF
--- a/valet
+++ b/valet
@@ -52,9 +52,17 @@ then
         fi
     done
 
+    # Determine which region to pass along to ngrok...
+    if [[ -z "$2" ]]
+    then
+        REGION="us"
+    else
+        REGION="$2"
+    fi
+
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
-    sudo -u $(logname) "$DIR/bin/ngrok" http -host-header=rewrite "$HOST.$DOMAIN:80"
+    sudo -u $(logname) "$DIR/bin/ngrok" http -host-header=rewrite -region="$REGION" "$HOST.$DOMAIN:80"
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
Recently, ngrok announced [multiregion service to general availability](https://ngrok.com/global), which allow users to change to a datacenter region closer to themselves.

The default region is the US, which may cause a high response time for developers in other regions. I live in Norway, and I'm getting around 400 to 500 ms response times according to the Chrome Devtools when using the default **us** region. When switching to the **eu** region, the response times drop to around 100 ms. A huge improvement!

--

This PR allows you to run the following command:

    valet share <region-code>
    
    # For example...
    valet share eu

I'm not sure if I love this approach, but you may think of this as a proof of concept. Maybe some bash master could improve the code? I'm definitely open for suggestions.

Perhaps adding a new command like `valet region eu` - which would set the region in some config file - would be better? This way you won't have to specify the region every time you want to share the site.

--

Currently, the following regions are supported by ngrok:
- Default: United States (**us**)
- Europe (**eu**)
- Asia Pacific (**ap**)
- Australia (**au**)

--

### Try it out:

    ~/.composer/vendor/laravel/valet/bin/ngrok http -host-header=rewrite -region=eu "site-name.dev:80"

Replace `site-name` with your project's directory name. If you're not using the default **.dev** domain, then replace that too.
