### PR TITLE
Helper tap method conflict fix

### DIFF
--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -108,18 +108,20 @@ function should_be_sudo()
     }
 }
 
-/**
- * Tap the given value.
- *
- * @param  mixed  $value
- * @param  callable  $callback
- * @return mixed
- */
-function tap($value, callable $callback)
-{
-    $callback($value);
+if (! function_exists('tap')) {
+    /**
+     * Tap the given value.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @return mixed
+     */
+    function tap($value, callable $callback)
+    {
+        $callback($value);
 
-    return $value;
+        return $value;
+    }
 }
 
 /**

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -108,20 +108,18 @@ function should_be_sudo()
     }
 }
 
-if (! function_exists('tap')) {
-    /**
-     * Tap the given value.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @return mixed
-     */
-    function tap($value, callable $callback)
-    {
-        $callback($value);
+/**
+ * Tap the given value.
+ *
+ * @param  mixed  $value
+ * @param  callable  $callback
+ * @return mixed
+ */
+function tap($value, callable $callback)
+{
+    $callback($value);
 
-        return $value;
-    }
+    return $value;
 }
 
 /**


### PR DESCRIPTION
After doing a `composer global update` today, I started receiving PHP Fatal Errors when running valet like this: 

```
PHP Fatal error:  Cannot redeclare tap() (previously declared in /Users/nateritter/.composer/vendor/illuminate/support/helpers.php:811) in /Users/nateritter/.composer/vendor/laravel/valet/cli/includes/helpers.php on line 123

Fatal error: Cannot redeclare tap() (previously declared in /Users/nateritter/.composer/vendor/illuminate/support/helpers.php:811) in /Users/nateritter/.composer/vendor/laravel/valet/cli/includes/helpers.php on line 123
```

To fix this, I simply wrapped the helpers.php tap() method in a function_exits conditional and voila.  Thought I'd share.