### PR TITLE
Adds the option to view Caddy access- and error-log

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -27,6 +27,7 @@ class Configuration
         $this->createDriversDirectory();
         $this->createSitesDirectory();
         $this->createExtensionsDirectory();
+        $this->createLogDirectory();
         $this->writeBaseConfiguration();
 
         $this->files->chown($this->path(), user());
@@ -79,6 +80,18 @@ class Configuration
     function createExtensionsDirectory()
     {
         $this->files->ensureDirExists(VALET_HOME_PATH.'/Extensions', user());
+    }
+
+    /**
+     * Create the directory for Caddy log.
+     *
+     * @return void
+     */
+    function createLogDirectory()
+    {
+        $this->files->ensureDirExists(VALET_HOME_PATH.'/Log', user());
+        $this->files->touch(VALET_HOME_PATH.'/Log/access.log');
+        $this->files->touch(VALET_HOME_PATH.'/Log/error.log');
     }
 
     /**

--- a/cli/stubs/Caddyfile
+++ b/cli/stubs/Caddyfile
@@ -8,4 +8,20 @@ import VALET_HOME_PATH/Caddy/*
     rewrite {
         to /server.php?{query}
     }
+
+    log VALET_HOME_PATH/Log/access.log {
+        rotate {
+            size 10
+            age 3
+            keep 1
+        }
+    }
+
+    errors {
+        log VALET_HOME_PATH/Log/error.log {
+            size 10
+            age 3
+            keep 1
+         }
+    }
 }

--- a/cli/stubs/SecureCaddyfile
+++ b/cli/stubs/SecureCaddyfile
@@ -12,4 +12,20 @@ https://VALET_SITE:443 {
     rewrite {
         to /server.php?{query}
     }
+
+    log VALET_HOME_PATH/Log/access.log {
+        rotate {
+            size 10
+            age 3
+            keep 1
+        }
+    }
+
+    errors {
+        log VALET_HOME_PATH/Log/error.log {
+            size 10
+            age 3
+            keep 1
+         }
+    }
 }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -173,6 +173,23 @@ $app->command('logs', function () {
 })->descriptions('Stream all of the logs for all Laravel sites registered with Valet');
 
 /**
+ * Stream Caddy access- and error-log.
+ */
+$app->command('server-log', function () {
+    $files = Filesystem::scandir(VALET_HOME_PATH.'/Log');
+
+    $files = collect($files)->transform(function ($file) {
+        return escapeshellarg(VALET_HOME_PATH.'/Log/'.$file);
+    })->all();
+
+    if (count($files) > 0) {
+        passthru('tail -f '.implode(' ', $files));
+    } else {
+        warning('No log files were found.');
+    }
+})->descriptions('Stream Caddy access- and error-log.');
+
+/**
  * Display all of the registered paths.
  */
 $app->command('paths', function () {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -39,6 +39,14 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         resolve(Configuration::class)->createDriversDirectory();
     }
 
+    public function test_log_directory_is_created_with_log_files_if_it_doesnt_exist()
+    {
+        $files = Mockery::mock(Filesystem::class.'[ensureDirExists,touch]');
+        $files->shouldReceive('ensureDirExists')->with(VALET_HOME_PATH.'/Log', user());
+        $files->shouldReceive('touch')->twice();
+        swap(Filesystem::class, $files);
+        resolve(Configuration::class)->createLogDirectory();
+    }
 
     public function test_add_path_adds_a_path_to_the_paths_array_and_removes_duplicates()
     {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -39,15 +39,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         resolve(Configuration::class)->createDriversDirectory();
     }
 
-    public function test_log_directory_is_created_with_log_files_if_it_doesnt_exist()
-    {
-        $files = Mockery::mock(Filesystem::class.'[isDir,mkdirAsUser,touch]');
-        $files->shouldReceive('isDir')->with(VALET_HOME_PATH.'/Log')->andReturn(false);
-        $files->shouldReceive('mkdirAsUser')->with(VALET_HOME_PATH.'/Log');
-        $files->shouldReceive('touch');
-        swap(Filesystem::class, $files);
-        resolve(Configuration::class)->createLogDirectory();
-    }
 
     public function test_add_path_adds_a_path_to_the_paths_array_and_removes_duplicates()
     {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -39,6 +39,15 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         resolve(Configuration::class)->createDriversDirectory();
     }
 
+    public function test_log_directory_is_created_with_log_files_if_it_doesnt_exist()
+    {
+        $files = Mockery::mock(Filesystem::class.'[isDir,mkdirAsUser,touch]');
+        $files->shouldReceive('isDir')->with(VALET_HOME_PATH.'/Log')->andReturn(false);
+        $files->shouldReceive('mkdirAsUser')->with(VALET_HOME_PATH.'/Log');
+        $files->shouldReceive('touch');
+        swap(Filesystem::class, $files);
+        resolve(Configuration::class)->createLogDirectory();
+    }
 
     public function test_add_path_adds_a_path_to_the_paths_array_and_removes_duplicates()
     {


### PR DESCRIPTION
This PR adds the option to view the Caddy access- and error-log using 
```valet server-log```

The both logfiles are stored in the ~/.valet/Log directory.