### PR TITLE
Convert static file path extension to lowercase

### DIFF
--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -118,7 +118,7 @@ abstract class ValetDriver
      */
     public function serveStaticFile($staticFilePath, $sitePath, $siteName, $uri)
     {
-        $extension = pathinfo($staticFilePath)['extension'];
+        $extension = strtolower(pathinfo($staticFilePath)['extension']);
 
         $mimes = require(__DIR__.'/../mimes.php');
 


### PR DESCRIPTION
Static files with uppercase extensions are being served with the mime-type 'application/octet-stream' because the keys in the mime-types array are all lowercase. This patch converts the static files' extensions to lowercase so static files are served with the correct 'Content-Type'.