### PR TITLE
unlink command: fix for the empty $name issue 

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -108,7 +108,7 @@ $app->command('links', function () {
  * Unlink a link from the Valet links directory.
  */
 $app->command('unlink [name]', function ($name) {
-    Site::unlink($name ?: basename(getcwd()));
+    Site::unlink($name = $name ?: basename(getcwd()));
 
     info('The ['.$name.'] symbolic link has been removed.');
 })->descriptions('Remove the specified Valet link');


### PR DESCRIPTION
fix for the empty $name issue in unlink command, e.g.    
The [] symbolic link has been removed.