### PR TITLE
Support for multiple domains

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -2,7 +2,6 @@
 
 namespace Valet;
 
-use Exception;
 use Symfony\Component\Process\Process;
 
 class DnsMasq
@@ -12,6 +11,8 @@ class DnsMasq
     var $resolverPath = '/etc/resolver';
     var $configPath = '/usr/local/etc/dnsmasq.conf';
     var $exampleConfigPath = '/usr/local/opt/dnsmasq/dnsmasq.conf.example';
+
+    var $domainAddressPattern = 'address=/.%s/127.0.0.1';
 
     /**
      * Create a new DnsMasq instance.
@@ -44,7 +45,7 @@ class DnsMasq
 
         $this->createDomainResolver($domain);
 
-        $this->brew->restartService('dnsmasq');
+        $this->restart();
     }
 
     /**
@@ -61,7 +62,7 @@ class DnsMasq
 
         $this->appendCustomConfigImport($customConfigPath);
 
-        $this->files->putAsUser($customConfigPath, 'address=/.'.$domain.'/127.0.0.1'.PHP_EOL);
+        $this->files->putAsUser($customConfigPath, sprintf($this->domainAddressPattern, $domain).PHP_EOL);
     }
 
     /**
@@ -107,7 +108,41 @@ class DnsMasq
     }
 
     /**
-     * Create the resolver file to point the "dev" domain to 127.0.0.1.
+     * Add new domain.
+     *
+     * @param  string $domain
+     * @return void
+     */
+    function addDomain($domain)
+    {
+        $this->createDomainResolver($domain);
+
+        $this->addDomainToCustomConfig($domain);
+
+        $this->restart();
+    }
+
+    /**
+     * Add domain to custom configuration file.
+     *
+     * @param  string $domain
+     * @return void
+     */
+    function addDomainToCustomConfig($domain)
+    {
+        $config = $this->files->get($this->customConfigPath());
+
+        $domainAddress = sprintf($this->domainAddressPattern, $domain);
+
+        if (strpos($config, $domainAddress) !== false) {
+            return;
+        }
+
+        $this->files->appendAsUser($this->customConfigPath(), $domainAddress.PHP_EOL);
+    }
+
+    /**
+     * Create the resolver file to point the given domain to 127.0.0.1.
      *
      * @param  string  $domain
      * @return void
@@ -120,17 +155,130 @@ class DnsMasq
     }
 
     /**
-     * Update the domain used by DnsMasq.
+     * Rename existing domain.
      *
      * @param  string  $oldDomain
      * @param  string  $newDomain
      * @return void
      */
-    function updateDomain($oldDomain, $newDomain)
+    function renameDomain($oldDomain, $newDomain)
     {
-        $this->files->unlink($this->resolverPath.'/'.$oldDomain);
+        $this->renameDomainResolver($oldDomain, $newDomain);
 
-        $this->install($newDomain);
+        $this->renameDomainInCustomConfig($oldDomain, $newDomain);
+
+        $this->restart();
+    }
+
+    /**
+     * Rename domain to custom configuration file.
+     *
+     * @param  string $oldDomain
+     * @param  string $newDomain
+     * @return void
+     */
+    function renameDomainInCustomConfig($oldDomain, $newDomain)
+    {
+        $customConfigPath = $this->customConfigPath();
+
+        $this->files->putAsUser($customConfigPath, str_replace(
+            sprintf($this->domainAddressPattern, $oldDomain),
+            sprintf($this->domainAddressPattern, $newDomain),
+            $this->files->get($customConfigPath)
+        ));
+    }
+
+    /**
+     * Rename domain resolver file
+     *
+     * @param  string $oldDomain
+     * @param  string $newDomain
+     * @return void
+     */
+    function renameDomainResolver($oldDomain, $newDomain)
+    {
+        $this->files->ensureDirExists($this->resolverPath);
+
+        $this->files->rename($this->resolverPath.'/'.$oldDomain, $this->resolverPath.'/'.$newDomain);
+    }
+
+    /**
+     * Delete existing domain.
+     *
+     * @param  string $domain
+     * @return void
+     */
+    function deleteDomain($domain)
+    {
+        $this->deleteDomainResolver($domain);
+
+        $this->removeDomainFromCustomConfig($domain);
+
+        $this->restart();
+    }
+
+    /**
+     * Delete domain resolver file
+     *
+     * @param  string $domain
+     * @return void
+     */
+    function deleteDomainResolver($domain)
+    {
+        $this->files->ensureDirExists($this->resolverPath);
+
+        $this->files->unlink($this->resolverPath.'/'.$domain);
+    }
+
+    /**
+     * Remove domain from custom configuration file.
+     *
+     * @param  string $domain
+     * @return void
+     */
+    function removeDomainFromCustomConfig($domain)
+    {
+        $customConfigPath = $this->customConfigPath();
+
+        $this->files->putAsUser($customConfigPath, collect(file($customConfigPath))->reject(function($domainAddress) use ($domain) {
+            return strpos($domainAddress, '.' . $domain) !== false;
+        })->implode(''));
+    }
+
+    /**
+     * Flush DNS cache
+     *
+     * @return void
+     */
+    function flushDnsCache()
+    {
+        // Determine current OS X version
+        list($majorVersion, $minorVersion, $buildVersion) = explode('.', shell_exec('sw_vers -productVersion'));
+
+        if ($majorVersion == 10 && in_array($minorVersion, [5, 6])) {
+            // OS X 10.5 - 10.6
+            $this->cli->quietlyAsUser('dscacheutil -flushcache');
+        } elseif ($majorVersion == 10 && $minorVersion == 10 && in_array($buildVersion, [0, 1, 2, 3])) {
+            // OS X 10.10.0 - 10.10.3
+            $this->cli->quietlyAsUser('discoveryutil mdnsflushcache');
+        } else {
+            // OS X 10.7 - 10.9
+            // OS X 10.10.4
+            // OS X 10.11
+            $this->cli->quietlyAsUser('killall -HUP mDNSResponder');
+        }
+    }
+
+    /**
+     * Restart DnsMasq
+     *
+     * @return void
+     */
+    function restart()
+    {
+        $this->flushDnsCache();
+
+        $this->brew->restartService('dnsmasq');
     }
 
     /**

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Container\Container;
-use Symfony\Component\Process\Process;
+use Valet\Configuration;
 
 /**
  * Define the ~/.valet path as a constant.
@@ -60,7 +60,7 @@ function resolve($class)
  * Swap the given class implementation in the container.
  *
  * @param  string  $class
- * @param  mixed  $instance
+ * @param  mixed   $instance
  * @return void
  */
 function swap($class, $instance)
@@ -69,12 +69,24 @@ function swap($class, $instance)
 }
 
 /**
+ * Check if domain exists
+ *
+ * @param  string  $domain
+ * @return bool
+ */
+function domain_exists($domain)
+{
+    return resolve(Configuration::class)->doesDomainExist($domain);
+}
+
+/**
  * Retry the given function N times.
  *
  * @param  int  $retries
- * @param  callable  $retries
+ * @param  callable  $fn
  * @param  int  $sleep
  * @return mixed
+ * @throws \Exception
  */
 function retry($retries, $fn, $sleep = 0)
 {
@@ -100,6 +112,7 @@ function retry($retries, $fn, $sleep = 0)
  * Verify that the script is currently running as "sudo".
  *
  * @return void
+ * @throws \Exception
  */
 function should_be_sudo()
 {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -44,21 +44,34 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
-            'paths' => ['path-1', 'path-2'],
+            'domains' => [[
+                'domain' => 'dev',
+                'paths' => ['path-1', 'path-2'],
+            ]]
         ]);
         $config->shouldReceive('write')->with([
-            'paths' => ['path-1', 'path-2', 'path-3'],
+            'domains' => [[
+                'domain' => 'dev',
+                'paths' => ['path-1', 'path-2', 'path-3']
+            ]]
         ]);
-        $config->addPath('path-3');
+        $config->addPath('dev','path-3');
 
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
-            'paths' => ['path-1', 'path-2', 'path-3'],
+            'domains' => [[
+                'domain' => 'dev',
+                'paths' => ['path-1', 'path-2', 'path-3'],
+            ]]
         ]);
+
         $config->shouldReceive('write')->with([
-            'paths' => ['path-1', 'path-2', 'path-3'],
+            'domains' => [[
+                'domain' => 'dev',
+                'paths' => ['path-1', 'path-2', 'path-3'],
+            ]]
         ]);
-        $config->addPath('path-3');
+        $config->addPath('dev', 'path-3');
     }
 
 
@@ -66,12 +79,18 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
-            'paths' => ['path-1', 'path-2'],
+            'domains' => [[
+                'domain' => 'dev',
+                'paths' => ['path-1', 'path-2'],
+            ]]
         ]);
         $config->shouldReceive('write')->with([
-            'paths' => ['path-1'],
+            'domains' => [[
+                'domain' => 'dev',
+                'paths' => ['path-1'],
+            ]]
         ]);
-        $config->removePath('path-2');
+        $config->removePath('dev', 'path-2');
     }
 
 
@@ -84,10 +103,16 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $files->shouldReceive('isDir')->with('path-2')->andReturn(false);
         $config = Mockery::mock(Configuration::class.'[read,write]', [$files]);
         $config->shouldReceive('read')->andReturn([
-            'paths' => ['path-1', 'path-2'],
+            'domains' => [[
+                'domain' => 'dev',
+                'paths' => ['path-1', 'path-2'],
+            ]]
         ]);
         $config->shouldReceive('write')->with([
-            'paths' => ['path-1'],
+            'domains' => [[
+                'domain' => 'dev',
+                'paths' => ['path-1'],
+            ]]
         ]);
         $config->prune();
     }
@@ -102,14 +127,5 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $config->shouldReceive('read')->never();
         $config->shouldReceive('write')->never();
         $config->prune();
-    }
-
-
-    public function test_update_key_updates_the_specified_configuration_key()
-    {
-        $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
-        $config->shouldReceive('read')->once()->andReturn(['foo' => 'bar']);
-        $config->shouldReceive('write')->once()->with(['foo' => 'bar', 'bar' => 'baz']);
-        $config->updateKey('bar', 'baz');
     }
 }

--- a/tests/DnsMasqTest.php
+++ b/tests/DnsMasqTest.php
@@ -35,6 +35,8 @@ class DnsMasqTest extends PHPUnit_Framework_TestCase
 
         $dnsMasq = resolve(StubForCreatingCustomDnsMasqConfigFiles::class);
 
+        $dnsMasq->setTestPaths();
+
         $dnsMasq->install('dev');
 
         $this->assertSame('nameserver 127.0.0.1'.PHP_EOL, file_get_contents(__DIR__.'/output/resolver/dev'));
@@ -47,8 +49,14 @@ conf-file='.__DIR__.'/output/custom-dnsmasq.conf
 
     public function test_rename_domain_resolver_and_rename_in_configuration_file()
     {
-        $dnsMasq = Mockery::mock(StubForCreatingCustomDnsMasqConfigFiles::class.'[restart]', [resolve(Brew::class), resolve(CommandLine::class), new Filesystem]);
-        $dnsMasq->shouldReceive('restart');
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('ensureInstalled')->once()->with('dnsmasq');
+        $brew->shouldReceive('restartService')->twice()->with('dnsmasq');
+        swap(Brew::class, $brew);
+
+        $dnsMasq = resolve(StubForCreatingCustomDnsMasqConfigFiles::class);
+
+        $dnsMasq->setTestPaths();
 
         $dnsMasq->install('dev');
 
@@ -59,8 +67,14 @@ conf-file='.__DIR__.'/output/custom-dnsmasq.conf
 
     public function test_delete_domain_resolver_and_remove_from_configuration_file()
     {
-        $dnsMasq = Mockery::mock(StubForCreatingCustomDnsMasqConfigFiles::class.'[restart]', [resolve(Brew::class), resolve(CommandLine::class), new Filesystem]);
-        $dnsMasq->shouldReceive('restart');
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('ensureInstalled')->once()->with('dnsmasq');
+        $brew->shouldReceive('restartService')->twice()->with('dnsmasq');
+        swap(Brew::class, $brew);
+
+        $dnsMasq = resolve(StubForCreatingCustomDnsMasqConfigFiles::class);
+
+        $dnsMasq->setTestPaths();
 
         $dnsMasq->install('dev');
 
@@ -73,9 +87,17 @@ conf-file='.__DIR__.'/output/custom-dnsmasq.conf
 
 class StubForCreatingCustomDnsMasqConfigFiles extends DnsMasq
 {
-    public $exampleConfigPath = __DIR__.'/files/dnsmasq.conf';
-    public $configPath = __DIR__.'/output/dnsmasq.conf';
-    public $resolverPath = __DIR__.'/output/resolver';
+    public function flushDnsCache()
+    {
+        return;
+    }
+
+    public function setTestPaths()
+    {
+        $this->exampleConfigPath = __DIR__.'/files/dnsmasq.conf';
+        $this->configPath = __DIR__.'/output/dnsmasq.conf';
+        $this->resolverPath = __DIR__.'/output/resolver';
+    }
 
     public function customConfigPath()
     {

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -17,8 +17,8 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        exec('rm -rf '.__DIR__.'/output');
-        mkdir(__DIR__.'/output');
+        exec('rm -rf '.__DIR__.'/output/dev');
+        mkdir(__DIR__.'/output/dev/', 0777);
         touch(__DIR__.'/output/.gitkeep');
 
         Mockery::close();
@@ -28,49 +28,49 @@ class SiteTest extends PHPUnit_Framework_TestCase
     public function test_symlink_creates_symlink_to_given_path()
     {
         $files = Mockery::mock(Filesystem::class);
-        $files->shouldReceive('ensureDirExists')->once()->with(VALET_HOME_PATH.'/Sites', user());
+        $files->shouldReceive('ensureDirExists')->once()->with(VALET_HOME_PATH.'/Sites/dev', user());
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('prependPath')->once()->with(VALET_HOME_PATH.'/Sites');
-        $files->shouldReceive('symlinkAsUser')->once()->with('target', VALET_HOME_PATH.'/Sites/link');
+        $config->shouldReceive('prependPath')->once()->with('dev', VALET_HOME_PATH.'/Sites/dev');
+        $files->shouldReceive('symlinkAsUser')->once()->with('target', VALET_HOME_PATH.'/Sites/dev/link');
 
         swap(Filesystem::class, $files);
         swap(Configuration::class, $config);
 
-        $linkPath = resolve(Site::class)->link('target', 'link');
-        $this->assertSame(VALET_HOME_PATH.'/Sites/link', $linkPath);
+        $linkPath = resolve(Site::class)->link('dev', 'target', 'link');
+        $this->assertSame(VALET_HOME_PATH.'/Sites/dev/link', $linkPath);
     }
-
 
     public function test_unlink_removes_existing_symlink()
     {
         file_put_contents(__DIR__.'/output/file.out', 'test');
-        symlink(__DIR__.'/output/file.out', __DIR__.'/output/link');
+        symlink(__DIR__.'/output/file.out', __DIR__.'/output/dev/link');
         $site = resolve(StubForRemovingLinks::class);
-        $site->unlink('link');
-        $this->assertFileNotExists(__DIR__.'/output/link');
+        $site->unlink('dev', 'link');
+        $this->assertFileNotExists(__DIR__.'/output/dev/link');
 
         $site = resolve(StubForRemovingLinks::class);
-        $site->unlink('link');
-        $this->assertFileNotExists(__DIR__.'/output/link');
+        $site->unlink('dev', 'link');
+        $this->assertFileNotExists(__DIR__.'/output/dev/link');
     }
-
 
     public function test_prune_links_removes_broken_symlinks_in_sites_path()
     {
         file_put_contents(__DIR__.'/output/file.out', 'test');
-        symlink(__DIR__.'/output/file.out', __DIR__.'/output/link');
+        symlink(__DIR__.'/output/file.out', __DIR__.'/output/dev/link');
         unlink(__DIR__.'/output/file.out');
         $site = resolve(StubForRemovingLinks::class);
         $site->pruneLinks();
-        $this->assertFileNotExists(__DIR__.'/output/link');
+        $this->assertFileNotExists(__DIR__.'/output/dev/link');
     }
-
 
     public function test_logs_method_returns_array_of_log_files()
     {
-        $logs = resolve(Site::class)->logs([__DIR__.'/test-directory-for-logs']);
-        $this->assertSame(__DIR__.'/test-directory-for-logs/project/storage/logs/laravel.log', $logs[0]);
-        unlink(__DIR__.'/test-directory-for-logs/project/storage/logs/laravel.log');
+        $logs = resolve(Site::class)->logs([[
+            'domain' => 'dev',
+            'paths' => [__DIR__.'/test-directory-for-logs/dev']
+        ]]);
+        $this->assertSame(__DIR__ . '/test-directory-for-logs/dev/project/storage/logs/laravel.log', $logs[0]);
+        unlink(__DIR__ . '/test-directory-for-logs/dev/project/storage/logs/laravel.log');
     }
 }
 

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -18,6 +18,7 @@ class SiteTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         exec('rm -rf '.__DIR__.'/output/dev');
+        exec('rm -rf '.__DIR__.'/output/file.out');
         mkdir(__DIR__.'/output/dev/', 0777);
         touch(__DIR__.'/output/.gitkeep');
 
@@ -42,6 +43,10 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
     public function test_unlink_removes_existing_symlink()
     {
+        $config = Mockery::mock(Configuration::class, [new Filesystem]);
+        $config->shouldReceive('removePath');
+        swap(Configuration::class, $config);
+
         file_put_contents(__DIR__.'/output/file.out', 'test');
         symlink(__DIR__.'/output/file.out', __DIR__.'/output/dev/link');
         $site = resolve(StubForRemovingLinks::class);

--- a/valet
+++ b/valet
@@ -43,7 +43,15 @@ then
 elif [[ "$1" = "share" ]]
 then
     HOST="${PWD##*/}"
-    DOMAIN=$(php "$DIR/cli/valet.php" domain)
+    DOMAIN="$2"
+
+    # Make sure a domain has been given
+    if [[ -z "$DOMAIN" ]]
+    then
+        echo -e
+        echo -e "No domain name was given"
+        exit
+    fi
 
     for linkname in ~/.valet/Sites/*; do
         if [[ "$(readlink $linkname)" = "$PWD" ]]


### PR DESCRIPTION
# Support for multiple domains in Valet

Hi, I'm [Morten](http://twitter.com/DuGi). I work as PHP developer for a danish agency - [Nodes](http://nodesagency.com) - and I'm in love ❤️.
In love with Valet 👔

#### 🙈 Disclaimer

This is my first ever pull request to an open-source project. Apologies if I've missed anything that you usually should say, do or add when doing a pull request. So please let me know if anything is missing. 

Thank you ☺️

#### 🤔 Why?

Like every other developer I love a nice hobby project outside of work. Which I obviously wants to run on Valet. But I would love to separate my hobby projects from my work projects. Unfortunately this is a bit difficult since Valet can only use _one_ domain 😏

Therefore I made my mission to add support for running multiple domains with Valet. And here is my result. I've been running with it for almost a week now. And it works and runs like a charm 😎

#### 🌟 Purpose of multiple domains

Other than the obvious one like structure and separation of projects, I believe it will make Valet much more flexible in the future. In a nearby time I will submit another pull request, which will add support for environment settings on a domain level.

Imagine having a `.dev` domain and a `.staging` domain using the same code, but which different settings. That would be pretty neat and easy to test your code before deploying.

#### 🎁 New features

- You can now manage multiple domains. Add, rename and delete as you like.
- You can park/link the same folder to multiple domains
- OS X DNS cache will automatically be flushed when adding, renaming or deleting a domain.
- If only one domain is installed, commands will always use that. Otherwise they'll ask you to specify a domain.
- Added new command to list all available domains.
- Added unit tests for the new features.


#### ⚙ Changelog

- Updated `config.json` to support multiple domains _(**See** 💥 Potential breaking changes)_.
- Updated most of the `valet [<command>]` to support multiple domains _(**See** 🤖 Commands).
- Fixed unit tests to work with multiple domains.
- Listing commands now group their list by domains but can be filtered to a specific domain.
- Logs will now streams across all domains but can be filtered to a specific domain.
- A bit of _Housekeeping_ here and there. Removing unused classes and fixed misc. DocBlocks.
- Added missing command descriptions to a few existing commands.

#### 💥 Potential breaking change

There is a potential breaking change. Since the current format of `config.json` doesn't support multiple domains, I've had to adjust it a bit with a new format. This would break people's Valet if they just pulled my code down without doing anything else.

But following the official upgrade guide, it specifically tells you to run `valet install` again after an upgrade. And inside this method, I've added a method, which automatically updates the current `config.json` file to the new format - while keeping the existing domain and paths 😉

So if you follow the official upgrade guide, you should be good 😎👌🏻

#### 🤖 Commands

I've had to modify most of the commands to add support for multiple domains. Here's a quick run down of which has been changed and what the change is.

###### `valet domain [<action>] [<domain>] [<newDomain>]`

This is command you use to "manage" your domains. The command now requires an action before specifying a domain.

Available actions are: `add`, `rename` and `delete`.

```
$ valet domain add work
Valet domain [work] has been added.
```


###### `valet forget [<domain>]`

If  you only have **one** domain installed it will automatically use that. If you have more than one, it will ask you do specify on which domain, you want to forget the current working directory from.

```
$ valet park

Please choose which domain you want to park current directory to.

Available domains:
- dev
- work
```

###### `valet forget [<domain>]`

If your current working directory is parked with more than one domain it'll ask you to specify which of the domains, you wish to remove the directory from. It'll show a list of the domains found, that current directory is registered to.

```
$ valet forget

Directory is registered with multiple domains.

Following domains are registered with directory:
- dev
- work
```

###### `valet forget [<domain>]`

If your current working directory is parked with more than one domain it'll ask you to specify which of the domains, you wish to remove the directory from. It'll show a list of the domains found, that current directory is registered to.

```
$ valet forget

Directory is registered with multiple domains.

Following domains are registered with directory:
- dev
- work
```

###### `valet link [<domain>] [<name>]`

If you have more than one domain installed, it'll ask you do specify which domain, you want to _symlink_ the current working directory to.

###### `valet unlink [<domain>] [<name>]`

If current working directory is _symlinked_ to more than one domain, it'll ask you to specify which domain, you want to "unlink" the current working directory from.

##### `valet secure [<domain>] [<name>]`

If your current working directory is connected to more than one domain, it'll ask you to specify domain, you want to secure the current working directory on.

##### `valet unsecure [<domain>] [<name>]`

If your current working directory is secured on multiple domains, it'll ask you to specify which domain, you want to unsecure the current working directory on.

##### `valet paths [<domain>]`

This command now groups the paths in all available domains. If you wish the command to only list paths of one specific domain, you can do that as well.

##### `valet logs [<domain>]`

This command now streams all the logs from your Laravel sites across all your domains. If you wish the command to only stream the logs from a specific domain, you can do that as well.

###### `valet domains` 🆕

A new command that lists all installed domains.