### PR TITLE
WordPressValetDriver: Redirect wp-admin to wp-admin/

### DIFF
--- a/cli/drivers/WordPressValetDriver.php
+++ b/cli/drivers/WordPressValetDriver.php
@@ -28,6 +28,23 @@ class WordPressValetDriver extends BasicValetDriver
         $_SERVER['PHP_SELF']    = $uri;
         $_SERVER['SERVER_ADDR'] = '127.0.0.1';
 
-        return parent::frontControllerPath($sitePath, $siteName, $uri);
+        return parent::frontControllerPath(
+            $sitePath, $siteName, $this->forceTrailingSlash($uri)
+        );
+    }
+
+    /**
+     * Redirect to uri with trailing slash.
+     *
+     * @param  string $uri
+     * @return string
+     */
+    private function forceTrailingSlash($uri)
+    {
+        if (substr($uri, -1 * strlen('/wp-admin')) == '/wp-admin') {
+            header('Location: '.$uri.'/'); die;
+        }
+
+        return $uri;
     }
 }


### PR DESCRIPTION
When attempting to access `/wp-admin` while unauthenticated, WordPress redirects to login `/wp-login.php`. After completing the login form you are then redirected to `wp-admin` instead of `wp-admin/` which causes issues with all the links in the admin until you add the trailing slash.