### PR TITLE
Added the ability to set an alias for a site.

### DIFF
--- a/server.php
+++ b/server.php
@@ -52,6 +52,19 @@ foreach ($valetConfig['paths'] as $path) {
     }
 }
 
+/**
+ * If no path is found, check if this request is set as an alias.
+ */
+
+if (isset($valetConfig['aliases'])){
+	if (isset($valetConfig['aliases'][$siteName])){
+		$aliasName = $valetConfig['aliases'][$siteName];
+		if (is_dir($path.'/'.$aliasName)) {
+			$valetSitePath = $path.'/'.$aliasName;
+		}
+	}
+}
+
 if (is_null($valetSitePath)) {
     show_valet_404();
 }


### PR DESCRIPTION
For testing on local network, it can be useful to set an alias for a website. 
In the valet config.json, set 
`"aliases":{"192.168.0.1":"my-project"}`
(replace with your ip-address) 
to make Valet forward requests directly to your ip to the website my-project.
