### PR TITLE
Add basic changes to allow php71

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -40,7 +40,8 @@ class Brew
      */
     function hasInstalledPhp()
     {
-        return $this->installed('php70')
+        return $this->installed('php71')
+            || $this->installed('php70')
             || $this->installed('php56')
             || $this->installed('php55');
     }
@@ -137,7 +138,9 @@ class Brew
 
         $resolvedPath = $this->files->readLink('/usr/local/bin/php');
 
-        if (strpos($resolvedPath, 'php70') !== false) {
+        if (strpos($resolvedPath, 'php71') !== false) {
+            return 'php71';
+        } elseif (strpos($resolvedPath, 'php70') !== false) {
             return 'php70';
         } elseif (strpos($resolvedPath, 'php56') !== false) {
             return 'php56';

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -36,7 +36,8 @@ class PhpFpm
      */
     public function install()
     {
-        if (! $this->brew->installed('php70') &&
+        if (! $this->brew->installed('php71') &&
+            ! $this->brew->installed('php70') &&
             ! $this->brew->installed('php56') &&
             ! $this->brew->installed('php55')) {
             $this->brew->ensureInstalled('php70', $this->taps);
@@ -83,7 +84,7 @@ class PhpFpm
      */
     public function stop()
     {
-        $this->brew->stopService('php55', 'php56', 'php70');
+        $this->brew->stopService('php55', 'php56', 'php70', 'php71');
     }
 
     /**
@@ -93,7 +94,9 @@ class PhpFpm
      */
     public function fpmConfigPath()
     {
-        if ($this->brew->linkedPhp() === 'php70') {
+        if ($this->brew->linkedPhp() === 'php71') {
+            return '/usr/local/etc/php/7.1/php-fpm.d/www.conf';
+        } elseif ($this->brew->linkedPhp() === 'php70') {
             return '/usr/local/etc/php/7.0/php-fpm.d/www.conf';
         } elseif ($this->brew->linkedPhp() === 'php56') {
             return '/usr/local/etc/php/5.6/php-fpm.conf';

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -66,18 +66,21 @@ php7');
     public function test_has_installed_php_indicates_if_php_is_installed_via_brew()
     {
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->once()->with('php70')->andReturn(true);
+        $brew->shouldReceive('installed')->once()->with('php71')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(true);
         $brew->shouldReceive('installed')->with('php56')->andReturn(true);
         $brew->shouldReceive('installed')->with('php55')->andReturn(true);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->once()->with('php70')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $brew->shouldReceive('installed')->with('php55')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->once()->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->once()->with('php70')->andReturn(false);
         $brew->shouldReceive('installed')->once()->with('php56')->andReturn(false);
         $brew->shouldReceive('installed')->once()->with('php55')->andReturn(false);


### PR DESCRIPTION
Now that homebrew allows for installation of PHP 7.1 (albeit beta-1), if one is using php71 valet won't install (gives "Unable to determine linked PHP").