### PR TITLE
Add missing descriptions

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -119,7 +119,7 @@ class Configuration
     }
 
     /**
-     * Add the given path to the configuration.
+     * Remove the given path from the configuration.
      *
      * @param  string  $path
      * @return void

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -126,7 +126,7 @@ $app->command('secure [domain]', function ($domain = null) {
     Caddy::restart();
 
     info('The ['.$url.'] site has been secured with a fresh TLS certificate.');
-});
+})->descriptions('Secure the given domain with a trusted TLS certificate');
 
 $app->command('unsecure [domain]', function ($domain = null) {
     $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
@@ -138,7 +138,7 @@ $app->command('unsecure [domain]', function ($domain = null) {
     Caddy::restart();
 
     info('The ['.$url.'] site will now serve traffic over HTTP.');
-});
+})->descriptions('Deconfigure the given domain from using a TLS certificate, and serve HTTP again');
 
 /**
  * Determine which Valet driver the current directory is using.


### PR DESCRIPTION
Running `valet list` showed descriptions for everything except `secure` and `unsecure`.