### PR TITLE
Pass parameters to ngrok

### DIFF
--- a/valet
+++ b/valet
@@ -46,7 +46,7 @@ then
 
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
-    sudo -u $(logname) "$DIR/bin/ngrok" http -host-header=rewrite "$HOST.$DOMAIN:80"
+    sudo -u $(logname) "$DIR/bin/ngrok" http "$HOST.$DOMAIN:80" -host-header=rewrite ${*:2}
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
This patch enables passing custom parameters like --region or -subdomain.

valet share --region=eu -subdomain=my_custom_domain

If you have a paid version of Ngrok the subdomain param is available, which is very handy when working with customers. Share the link once, instead of sharing a new random link every time you want your client to look at your progress.