### PR TITLE
Do not try to read folder as static file

### DIFF
--- a/cli/drivers/LaravelValetDriver.php
+++ b/cli/drivers/LaravelValetDriver.php
@@ -26,7 +26,9 @@ class LaravelValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        if (file_exists($staticFilePath = $sitePath.'/public'.$uri)) {
+        $staticFilePath = $sitePath.'/public'.$uri;
+        
+        if (file_exists($staticFilePath) AND is_file($staticFilePath)) {
             return $staticFilePath;
         }
 

--- a/cli/drivers/LaravelValetDriver.php
+++ b/cli/drivers/LaravelValetDriver.php
@@ -28,7 +28,7 @@ class LaravelValetDriver extends ValetDriver
     {
         $staticFilePath = $sitePath.'/public'.$uri;
         
-        if (file_exists($staticFilePath) AND is_file($staticFilePath)) {
+        if (file_exists($staticFilePath) && is_file($staticFilePath)) {
             return $staticFilePath;
         }
 


### PR DESCRIPTION
Hi,

In a Laravel project, if you make a query string matching a folder into "public", Valet try to read the folder as a static file. This launch a dirty download of the following error : 

```
<br />
<b>Notice</b>:  Undefined index: extension in <b>/path/to/.composer/vendor/laravel/valet/cli/drivers/ValetDriver.php</b> on line <b>122</b><br />
```

As you can make Laravel routes in your application with the same name of your folders it may be interesting to prioritize a dynamic call (routes) instead of a non working static call.

My PR just add a check on the type of the target : if it is a folder, do not handle the static handling.

Thanks !