### PR TITLE
Update WordPressValetDriver.php to fix issue 123

### DIFF
--- a/cli/drivers/WordPressValetDriver.php
+++ b/cli/drivers/WordPressValetDriver.php
@@ -27,6 +27,8 @@ class WordPressValetDriver extends BasicValetDriver
     {
         $_SERVER['PHP_SELF']    = $uri;
         $_SERVER['SERVER_ADDR'] = '127.0.0.1';
+        $_SERVER['SERVER_NAME'] = $siteName.'.dev'
+
 
         return parent::frontControllerPath(
             $sitePath, $siteName, $this->forceTrailingSlash($uri)


### PR DESCRIPTION
Add $_SERVER['SERVER_NAME'] = $siteName.'.dev'

issue #123; credit goes to evansvince for providing this bugfix