### PR TITLE
Fix valet share over TLS secure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 error.log
+.idea/

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -122,6 +122,20 @@ class Site
     }
 
     /**
+     * Check if a given host has TLS.
+     *
+     * @param  string  $url
+     * @return bool
+     */
+    function isSecured($url)
+    {
+        $secured = $this->secured();
+        $site = $url.'.'.$this->config->read()['domain'];
+
+        return in_array($site, $secured);
+    }
+
+    /**
      * Secure the given host with TLS.
      *
      * @param  string  $url

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -141,21 +141,30 @@ $app->command('secure [domain]', function ($domain = null) {
 /**
  * Check if a given domain has a trusted TLS certificate.
  */
-$app->command('secured [domain]', function ($domain = null) {
-    if (!$domain) {
-        warning('Try the following syntax command: valet secured [domain]');
+$app->command('secured [domain]', function ($domain) {
+    $domain = $domain ?: Site::host(getcwd());
+
+    if (Site::isSecured($domain)) {
+        output('YES');
+    } else {
+        warning('NO');
+    }
+})->descriptions('Check if a given domain has a trusted TLS certificate');
+
+/**
+ * List all secured domains with a trusted TLS certificate.
+ */
+$app->command('secures', function () {
+    $items = Site::secured();
+
+    if ($items == null) {
+        warning('There are no secured domains with a TLS certificate.');
     }
 
-    $domains = Site::secured();
-
-    foreach ($domains as $item) {
-        $host = explode('.', $item)[0];
-
-        if ($domain && $host === $domain) {
-            info('The ['.$item.'] site has been secured with a TLS certificate.');
-        }
+    foreach ($items as $item) {
+        info('The ['.$item.'] site has been secured with a TLS certificate.');
     }
-})->descriptions('List all secured domain with a trusted TLS certificate');
+})->descriptions('List all secured domains with a trusted TLS certificate');
 
 /**
  * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -152,21 +152,6 @@ $app->command('secured [domain]', function ($domain) {
 })->descriptions('Check if a given domain has a trusted TLS certificate');
 
 /**
- * List all secured domains with a trusted TLS certificate.
- */
-$app->command('secures', function () {
-    $items = Site::secured();
-
-    if ($items == null) {
-        warning('There are no secured domains with a TLS certificate.');
-    }
-
-    foreach ($items as $item) {
-        info('The ['.$item.'] site has been secured with a TLS certificate.');
-    }
-})->descriptions('List all secured domains with a trusted TLS certificate');
-
-/**
  * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.
  */
 $app->command('unsecure [domain]', function ($domain = null) {

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -139,6 +139,25 @@ $app->command('secure [domain]', function ($domain = null) {
 })->descriptions('Secure the given domain with a trusted TLS certificate');
 
 /**
+ * Check if a given domain has a trusted TLS certificate.
+ */
+$app->command('secured [domain]', function ($domain = null) {
+    if (!$domain) {
+        warning('Try the following syntax command: valet secured [domain]');
+    }
+
+    $domains = Site::secured();
+
+    foreach ($domains as $item) {
+        $host = explode('.', $item)[0];
+
+        if ($domain && $host === $domain) {
+            info('The ['.$item.'] site has been secured with a TLS certificate.');
+        }
+    }
+})->descriptions('List all secured domain with a trusted TLS certificate');
+
+/**
  * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.
  */
 $app->command('unsecure [domain]', function ($domain = null) {

--- a/valet
+++ b/valet
@@ -44,9 +44,21 @@ then
         fi
     done
 
+    COMMAND=$(php "$DIR/cli/valet.php" secured $HOST)
+
+    if [ -n "$COMMAND" ]; then
+        HOST="valet.$HOST"
+        echo $(php "$DIR/cli/valet.php" link $HOST)
+    fi
+
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
     sudo -u $(logname) "$DIR/bin/ngrok" http "$HOST.$DOMAIN:80" -host-header=rewrite ${*:2}
+
+    if [ -n "$COMMAND" ]; then
+        echo $(php "$DIR/cli/valet.php" unlink $HOST)
+    fi
+
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool

--- a/valet
+++ b/valet
@@ -46,7 +46,7 @@ then
 
     COMMAND=$(php "$DIR/cli/valet.php" secured $HOST)
 
-    if [ -n "$COMMAND" ]; then
+    if [ "$COMMAND" == 'YES' ]; then
         HOST="valet.$HOST"
         echo $(php "$DIR/cli/valet.php" link $HOST)
     fi
@@ -55,7 +55,7 @@ then
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
     sudo -u $(logname) "$DIR/bin/ngrok" http "$HOST.$DOMAIN:80" -host-header=rewrite ${*:2}
 
-    if [ -n "$COMMAND" ]; then
+    if [ "$COMMAND" == 'YES' ]; then
         echo $(php "$DIR/cli/valet.php" unlink $HOST)
     fi
 


### PR DESCRIPTION
Now when we have a link secured over TLS the command valet share will create other link for an unsecure link and this unsecure link will be used for ngrok.

When the ngrok url is closed that unsecure link is destroyed again.
The stack for this PR is at #148.
Please, see this: @adamwathan @drbyte 
