### PR TITLE
Add a concrete5 driver that provides the environment

### DIFF
--- a/cli/drivers/Concrete5ValetDriver.php
+++ b/cli/drivers/Concrete5ValetDriver.php
@@ -1,0 +1,36 @@
+<?php
+
+class Concrete5ValetDriver extends BasicValetDriver
+{
+
+    /**
+     * If a concrete directory exists, it's probably c5
+     * @param string $sitePath
+     * @param string $siteName
+     * @param string $uri
+     * @return bool
+     */
+    public function serves($sitePath, $siteName, $uri)
+    {
+        return file_exists($sitePath . "/concrete");
+    }
+
+    /**
+     * @param string $sitePath
+     * @param string $siteName
+     * @param string $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        if (!getenv('CONCRETE5_ENV')) {
+            putenv('CONCRETE5_ENV=valet');
+        }
+
+        $_SERVER['SCRIPT_FILENAME'] = $sitePath . '/index.php';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        return $sitePath . '/index.php';
+    }
+
+}

--- a/cli/drivers/Concrete5ValetDriver.php
+++ b/cli/drivers/Concrete5ValetDriver.php
@@ -12,7 +12,7 @@ class Concrete5ValetDriver extends BasicValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
-        return file_exists($sitePath . "/concrete");
+        return file_exists($sitePath . "/concrete/config/install/base");
     }
 
     /**
@@ -25,6 +25,18 @@ class Concrete5ValetDriver extends BasicValetDriver
     {
         if (!getenv('CONCRETE5_ENV')) {
             putenv('CONCRETE5_ENV=valet');
+        }
+
+        $matches = [];
+        if (preg_match('/^\/(.*?)\.php/', $uri, $matches)) {
+            $filename = $matches[0];
+
+            if (file_exists($sitePath.$filename) && ! is_dir($sitePath.$filename)) {
+                $_SERVER['SCRIPT_FILENAME'] = $sitePath.$filename;
+                $_SERVER['SCRIPT_NAME'] = $filename;
+
+                return $sitePath . $filename;
+            }
         }
 
         $_SERVER['SCRIPT_FILENAME'] = $sitePath . '/index.php';

--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -60,6 +60,7 @@ abstract class ValetDriver
         $drivers[] = 'KatanaValetDriver';
         $drivers[] = 'JoomlaValetDriver';
         $drivers[] = 'DrupalValetDriver';
+        $drivers[] = 'Concrete5ValetDriver';
 
         $drivers[] = 'BasicValetDriver';
 

--- a/cli/drivers/require.php
+++ b/cli/drivers/require.php
@@ -24,3 +24,4 @@ require_once __DIR__.'/KatanaValetDriver.php';
 require_once __DIR__.'/CakeValetDriver.php';
 require_once __DIR__.'/JoomlaValetDriver.php';
 require_once __DIR__.'/DrupalValetDriver.php';
+require_once __DIR__.'/Concrete5ValetDriver.php';


### PR DESCRIPTION
This driver makes a defines the `CONCRETE5_ENV` environment variable available for use in concrete5 if one isn't set. We determine if it should serve by detecting the "/concrete/config/tests/base" directory as this directory exists in the widest range of concrete5 versions.
