### PR TITLE
Use sockets instead of port 9000

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -44,6 +44,7 @@ class PhpFpm
         }
 
         $this->files->ensureDirExists('/usr/local/var/log', user());
+        $this->files->ensureDirExists('/var/run/valet', user());
 
         $this->updateConfiguration();
 
@@ -61,6 +62,7 @@ class PhpFpm
 
         $contents = preg_replace('/^user = .+$/m', 'user = '.user(), $contents);
         $contents = preg_replace('/^group = .+$/m', 'group = staff', $contents);
+        $contents = preg_replace('/^listen = .+$/m', 'listen = /var/run/valet/fpm.socket', $contents);
 
         $this->files->put($this->fpmConfigPath(), $contents);
     }

--- a/cli/stubs/Caddyfile
+++ b/cli/stubs/Caddyfile
@@ -6,7 +6,7 @@ import VALET_HOME_PATH/Caddy/*
     # Slight hack, see: https://github.com/mholt/caddy/issues/1020
     internal /dev/null
 
-    fastcgi / 127.0.0.1:9000 php {
+    fastcgi / /var/run/valet/fpm.socket php {
         index VALET_SERVER_PATH
     }
 

--- a/cli/stubs/SecureCaddyfile
+++ b/cli/stubs/SecureCaddyfile
@@ -10,7 +10,7 @@ https://VALET_SITE:443 {
 
     tls VALET_CERT VALET_KEY
 
-    fastcgi / 127.0.0.1:9000 php {
+    fastcgi / /var/run/valet/fpm.socket php {
         index VALET_SERVER_PATH
     }
 


### PR DESCRIPTION
This pr updates caddy and php-fpm to use a socket instead of port 9000. I figured if we were going to do this in the most straight forward way I might as well do the work. If you have different requirements I'd be happy to change my pr.

See #157 for reasoning behind this. 