### PR TITLE
Add composer cache to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ sudo: false
 before_install:
   - travis_retry composer self-update
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 install:
   - if [[ $setup = 'basic' ]]; then travis_retry composer install --no-interaction --prefer-dist; fi
   - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable; fi


### PR DESCRIPTION
This makes it so that travis doesn't have to redownload the composer vendor files each time it runs. This helps prevent download inflation on packagist (Might be a negative 😄) and makes travis tests run a lot faster.