### PR TITLE
Bedrock: Redirect wp/wp-admin to wp/wp-admin/

### DIFF
--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -51,10 +51,25 @@ class BedrockValetDriver extends BasicValetDriver
 
         if (strpos($uri, '/wp/') === 0) {
             return is_dir($sitePath.'/web'.$uri)
-                            ? $sitePath.'/web'.$uri.'/index.php'
+                            ? $sitePath.'/web'.$this->forceTrailingSlash($uri).'/index.php'
                             : $sitePath.'/web'.$uri;
         }
 
         return $sitePath.'/web/index.php';
+    }
+
+    /**
+     * Redirect to uri with trailing slash.
+     *
+     * @param  string $uri
+     * @return string
+     */
+    private function forceTrailingSlash($uri)
+    {
+        if (substr($uri, -1 * strlen('/wp/wp-admin')) == '/wp/wp-admin') {
+            header('Location: '.$uri.'/'); die;
+        }
+
+        return $uri;
     }
 }


### PR DESCRIPTION
This is the same as #96 but solves the problem with Bedrock driver.

When attempting to access `wp/wp-admin` unauthenticated, WordPress redirects to `wp/wp-admin` instead of `wp/wp-admin/` which causes issues with all the links in the admin until you add the trailing slash.