### PR TITLE
Fix 502 bad gateway after reboot

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -44,7 +44,6 @@ class PhpFpm
         }
 
         $this->files->ensureDirExists('/usr/local/var/log', user());
-        $this->files->ensureDirExists('/var/run/valet', user());
 
         $this->updateConfiguration();
 
@@ -62,7 +61,7 @@ class PhpFpm
 
         $contents = preg_replace('/^user = .+$/m', 'user = '.user(), $contents);
         $contents = preg_replace('/^group = .+$/m', 'group = staff', $contents);
-        $contents = preg_replace('/^listen = .+$/m', 'listen = /var/run/valet/fpm.socket', $contents);
+        $contents = preg_replace('/^listen = .+$/m', 'listen = /var/run/fpm-valet.socket', $contents);
 
         $this->files->put($this->fpmConfigPath(), $contents);
     }

--- a/cli/stubs/Caddyfile
+++ b/cli/stubs/Caddyfile
@@ -1,7 +1,7 @@
 import VALET_HOME_PATH/Caddy/*
 
 :80 {
-    fastcgi / /var/run/valet/fpm.socket php {
+    fastcgi / /var/run/valet/fpm-valet.socket php {
         index VALET_SERVER_PATH
     }
 

--- a/cli/stubs/SecureCaddyfile
+++ b/cli/stubs/SecureCaddyfile
@@ -5,7 +5,7 @@ http://VALET_SITE:80 {
 https://VALET_SITE:443 {
     tls VALET_CERT VALET_KEY
 
-    fastcgi / /var/run/valet/fpm.socket php {
+    fastcgi / /var/run/valet/fpm-valet.socket php {
         index VALET_SERVER_PATH
     }
 


### PR DESCRIPTION
**Short Description**

PHP-FPM cannot be startet after reboot, because the socket `/var/run/valet/fpm.sock` can't be created.

The PHP-FPM log says: _unable to bind listening socket for address_

**Why this happens**

All manually created subdirectories in `/var/run` will be removed upon reboot and must be created again after reboot.

Valet creates the subdirectory `/var/run/valet` only upon installation (`valet install`)

**Resolution**

PHP-FPM should use a socket file that is located directly in `/var/run` without using any subdirectory (see PR changes)

**Drawbacks**

Currently, users would have to update their caddy files for any existing site manually after updating to a valet version containing this PR.

Running `valet install` would only update the PHP-FPM configuration, but none of the existing caddy files.