### PR TITLE
Adding function_exists to retry

### DIFF
--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -69,31 +69,33 @@ function swap($class, $instance)
     Container::getInstance()->instance($class, $instance);
 }
 
-/**
- * Retry the given function N times.
- *
- * @param  int  $retries
- * @param  callable  $retries
- * @param  int  $sleep
- * @return mixed
- */
-function retry($retries, $fn, $sleep = 0)
-{
-    beginning:
-    try {
-        return $fn();
-    } catch (Exception $e) {
-        if (! $retries) {
-            throw $e;
+if (! function_exists('retry')) {
+    /**
+     * Retry the given function N times.
+     *
+     * @param  int  $retries
+     * @param  callable  $retries
+     * @param  int  $sleep
+     * @return mixed
+     */
+    function retry($retries, $fn, $sleep = 0)
+    {
+        beginning:
+        try {
+            return $fn();
+        } catch (Exception $e) {
+            if (! $retries) {
+                throw $e;
+            }
+
+            $retries--;
+
+            if ($sleep > 0) {
+                usleep($sleep * 1000);
+            }
+
+            goto beginning;
         }
-
-        $retries--;
-
-        if ($sleep > 0) {
-            usleep($sleep * 1000);
-        }
-
-        goto beginning;
     }
 }
 


### PR DESCRIPTION
Same problem we had with `tap` function...

````
PHP Fatal error:  Cannot redeclare retry() (previously declared in /Users/mac/.composer/vendor/illuminate/support/helpers.php:618) in /Users/mac/.composer/vendor/laravel/valet/cli/includes/helpers.php on line 98

Fatal error: Cannot redeclare retry() (previously declared in /Users/mac/.composer/vendor/illuminate/support/helpers.php:618) in /Users/mac/.composer/vendor/laravel/valet/cli/includes/helpers.php on line 98
````