### PR TITLE
Fix potential launch failure by removing .DS_Store file from Caddy directory

### DIFF
--- a/cli/Valet/Caddy.php
+++ b/cli/Valet/Caddy.php
@@ -108,7 +108,7 @@ class Caddy
     function restart()
     {
         $this->cli->quietly('sudo launchctl unload '.$this->daemonPath);
-
+        $this->files->unlink(VALET_HOME_PATH.'/Caddy/.DS_Store');
         $this->cli->quietly('sudo launchctl load '.$this->daemonPath);
     }
 


### PR DESCRIPTION
If a `.DS_Store` file winds up being created in the Caddy directory (which would happen if any files are added or removed from that directory via Finder), the `import` in the first line of the Caddyfile will pull it in; this causes Caddy's startup to fail silently with a `Parse error: Unknown directive ':80'` error, and Valet will appear to boot, but sites will not be accessible.

Any attempt to ignore that file in the `import` directive also causes Caddy to balk (unless I just didn't get my glob syntax right). The solution in this PR is to delete any `.DS_Store` files in `.valet/Caddy/` whenever Caddy tries to start or restart.
