### PR TITLE
Issue #198: Check if command being run requires sudo access

### DIFF
--- a/valet
+++ b/valet
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
+SUDOCMDS="install start stop secure share"
 
 # If the current source is a symbolic link, we need to resolve it to an
 # actual directory name. We'll use PHP to do this easier than we can
@@ -23,10 +24,13 @@ fi
 # If the command is one of the commands that requires "sudo" privileges
 # then we'll proxy the incoming CLI request using sudo, which allows
 # us to never require the end users to manually specify each sudo.
-if [[ "$EUID" -ne 0 ]]
+if [[ $SUDOCMDS =~ $1 ]]
 then
-    sudo $SOURCE "$@"
-    exit
+    if [[ "$EUID" -ne 0 ]]
+    then
+        sudo $SOURCE "$@"
+        exit
+    fi
 fi
 
 # If the command is the "share" command we will need to resolve out any


### PR DESCRIPTION
This will do a 'fuzzy match' on the command being run to determine whether it needs to be proxied through sudo.  Without this, _all_ commands get proxied through sudo on macOS Sierra.  This change seems to resolve that, and should not have adverse effects on earlier versions of OSX.

Since it's a 'fuzzy match' `start` will be a match for `start` and `restart`, etc.