### PR TITLE
Support a custom driver on a per-site basis

### DIFF
--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -42,7 +42,13 @@ abstract class ValetDriver
      */
     public static function assign($sitePath, $siteName, $uri)
     {
-        $drivers = static::driversIn(VALET_HOME_PATH.'/Drivers');
+        $drivers = [];
+        
+        if ($customSiteDriver = static::customSiteDriver($sitePath)) {
+            $drivers[] = $customSiteDriver;
+        }
+        
+        $drivers = array_merge($drivers, static::driversIn(VALET_HOME_PATH.'/Drivers'));
 
         $drivers[] = 'LaravelValetDriver';
 
@@ -70,6 +76,23 @@ abstract class ValetDriver
                 return $driver;
             }
         }
+    }
+    
+    /**
+     * Get the custom driver class from the site path, if one exists.
+     *
+     * @param  string  $sitePath
+     * @return string
+     */
+    public static function customSiteDriver($sitePath)
+    {
+        if (! file_exists($sitePath.'/SiteValetDriver.php')) {
+            return;
+        }
+        
+        require_once $sitePath.'/SiteValetDriver.php';
+        
+        return 'SiteValetDriver';
     }
 
     /**


### PR DESCRIPTION
This PR allows you to add a `SiteValetDriver.php` to your project root to be used for the driver.

This might be useful if the site is set up in a different way than the bundled drivers expect.

For example, Statamic allows you to localize your site by creating a separate index.php files, but you're free to place them anywhere - potentially inside subfolders. The bundled driver can't know where you've placed additional index.php files. 

Now I can drop a custom driver in the root and override the `frontControllerPath` logic.

```
<?php

class SiteValetDriver extends StatamicValetDriver
{
    public function frontControllerPath($sitePath, $siteName, $uri)
    {
        // some custom logic...
    }
}
```

Another usage example could be to support `public_html` (or whatever) instead of a `public` folder.

Not married to this PR. Won't be offended if it's thrown out. :) A better solution is probably to allow the drivers to read site specific config files. Also, naming the file `SiteValetDriver.php` is kinda lame. ¯\\\_(ツ)\_/¯