### PR TITLE
Fix potential resolve() helper function conflict

### DIFF
--- a/cli/includes/facades.php
+++ b/cli/includes/facades.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Container\Container;
+
 class Facade
 {
     /**
@@ -21,7 +23,9 @@ class Facade
      */
     public static function __callStatic($method, $parameters)
     {
-        return call_user_func_array([resolve(static::containerKey()), $method], $parameters);
+        $resolvedInstance = Container::getInstance()->make(static::containerKey());
+
+        return call_user_func_array([$resolvedInstance, $method], $parameters);
     }
 }
 

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -46,15 +46,17 @@ function output($output)
     (new Symfony\Component\Console\Output\ConsoleOutput)->writeln($output);
 }
 
-/**
- * Resolve the given class from the container.
- *
- * @param  string  $class
- * @return mixed
- */
-function resolve($class)
-{
-    return Container::getInstance()->make($class);
+if (! function_exists('resolve')) {
+    /**
+     * Resolve the given class from the container.
+     *
+     * @param  string  $class
+     * @return mixed
+     */
+    function resolve($class)
+    {
+        return Container::getInstance()->make($class);
+    }
 }
 
 /**


### PR DESCRIPTION
Composer's "hoa" package also has a global helper function named "resolve". I added a function exists check to prevent the error I was getting:

```
PHP Fatal error:  Cannot redeclare resolve() (previously declared in /Users/calebporzio/.composer/vendor/hoa/core/Protocol.php:1140) in /Users/calebporzio/.composer/vendor/laravel/valet/cli/includes/helpers.php on line 57
```

With one exception, that helper function is only used in tests. It seems Facades would break if this function was overwritten, so I took the liberty of using the Container facade directly in facades.php

Also, [other people online](https://laracasts.com/discuss/channels/laravel/laravelvalet-getting-error) have run into this issue - thanks!

