### PR TITLE
Adds localization support to the Craft CMS driver

### DIFF
--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -42,10 +42,140 @@ class CraftValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/public/index.php';
-        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
-        $_SERVER['SCRIPT_NAME'] = '/index.php';
+        // Default index path
+        $indexPath = $sitePath.'/public/index.php';
+        $scriptName = '/index.php';
 
-        return $sitePath.'/public/index.php';
+        // Check if the first URL segment matches any of the defined locales
+        $locales = [
+            'ar',
+            'ar_sa',
+            'bg',
+            'bg_bg',
+            'ca_es',
+            'cs',
+            'cy_gb',
+            'da',
+            'da_dk',
+            'de',
+            'de_at',
+            'de_ch',
+            'de_de',
+            'el',
+            'el_gr',
+            'en',
+            'en_as',
+            'en_au',
+            'en_bb',
+            'en_be',
+            'en_bm',
+            'en_bw',
+            'en_bz',
+            'en_ca',
+            'en_dsrt',
+            'en_dsrt_us',
+            'en_gb',
+            'en_gu',
+            'en_gy',
+            'en_hk',
+            'en_ie',
+            'en_in',
+            'en_jm',
+            'en_mh',
+            'en_mp',
+            'en_mt',
+            'en_mu',
+            'en_na',
+            'en_nz',
+            'en_ph',
+            'en_pk',
+            'en_sg',
+            'en_shaw',
+            'en_tt',
+            'en_um',
+            'en_us',
+            'en_us_posix',
+            'en_vi',
+            'en_za',
+            'en_zw',
+            'en_zz',
+            'es',
+            'es_cl',
+            'es_es',
+            'es_mx',
+            'es_us',
+            'es_ve',
+            'et',
+            'fi',
+            'fi_fi',
+            'fil',
+            'fr',
+            'fr_be',
+            'fr_ca',
+            'fr_ch',
+            'fr_fr',
+            'fr_ma',
+            'he',
+            'hr',
+            'hr_hr',
+            'hu',
+            'hu_hu',
+            'id',
+            'id_id',
+            'it',
+            'it_ch',
+            'it_it',
+            'ja',
+            'ja_jp',
+            'ko',
+            'ko_kr',
+            'lt',
+            'lv',
+            'ms',
+            'ms_my',
+            'nb',
+            'nb_no',
+            'nl',
+            'nl_be',
+            'nl_nl',
+            'nn',
+            'nn_no',
+            'no',
+            'pl',
+            'pl_pl',
+            'pt',
+            'pt_br',
+            'pt_pt',
+            'ro',
+            'ro_ro',
+            'ru',
+            'ru_ru',
+            'sk',
+            'sl',
+            'sr',
+            'sv',
+            'sv_se',
+            'th',
+            'th_th',
+            'tr',
+            'tr_tr',
+            'uk',
+            'vi',
+            'zh',
+            'zh_cn',
+            'zh_tw',
+        ];
+        $parts = explode('/', $uri);
+
+        if (count($parts) > 1 && in_array($parts[1], $locales)) {
+            $indexPath = $sitePath.'/public/'. $parts[1] .'/index.php';
+            $scriptName = '/' . $parts[1] . '/index.php';
+        }
+
+        $_SERVER['SCRIPT_FILENAME'] = $indexPath;
+        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+        $_SERVER['SCRIPT_NAME'] = $scriptName;
+
+        return $indexPath;
     }
 }


### PR DESCRIPTION
Pull request adds basic (as per [the official guide](https://craftcms.com/docs/localization-guide#step-5-set-up-the-files)) localization (i.e. multi-locale) support for Craft CMS. Code contributions by @sjelfull and @danethomas, see #179 for discussion.