### PR TITLE
Clean up `valet links` output

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -101,7 +101,7 @@ $app->command('link [name]', function ($name) {
  * Display all of the registered symbolic links.
  */
 $app->command('links', function () {
-    passthru('ls -la '.VALET_HOME_PATH.'/Sites');
+    passthru('ls -lA '.VALET_HOME_PATH.'/Sites');
 })->descriptions('Display all of the registered Valet links');
 
 /**


### PR DESCRIPTION
This little tweak removes `.` (current directory) and `..` (parent directory) from `valet links` output.

e.g.

```
total 8
drwxr-xr-x   3 jerguslejko  staff  102  9 Dec 01:38 .
drwxr-xr-x  10 jerguslejko  staff  340  9 Dec 01:18 ..
lrwxr-xr-x   1 jerguslejko  staff   18  9 Dec 01:38 blog -> /Users/jerguslejko/code/blog
```

vs

```
total 8
lrwxr-xr-x  1 jerguslejko  staff  18  9 Dec 01:38 blog -> /Users/jerguslejko/code/blog
```

🌵 