### PR TITLE
add notes when upgrading from v1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ valet stop
 valet uninstall
 ```
 
-Next, you should upgrade to the latest version of Valet. Depending on how you installed Valet, this is typically done through Git or Composer. Once the fresh Valet source code has been downloaded, you should run the `install` command:
+Next, you should upgrade to the latest version of Valet. Depending on how you installed Valet, this is typically done through Git or Composer. Since it's Semantic Version, use `composer global require laravel/valet` instead of `composer global update`. Once the fresh Valet source code has been downloaded, you should run the `install` command:
 
 ```
 valet install


### PR DESCRIPTION
When upgrading from v1, since it's semantic version, `composer global update` will not update anything. You need to run `composer global require laravel/valet` again.