### PR TITLE
Fixes issue #244, where the Craft CMS admin panel is inaccessible

### DIFF
--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -175,6 +175,7 @@ class CraftValetDriver extends ValetDriver
         $_SERVER['SCRIPT_FILENAME'] = $indexPath;
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
         $_SERVER['SCRIPT_NAME'] = $scriptName;
+        $_SERVER['PHP_SELF'] = $scriptName;
 
         return $indexPath;
     }


### PR DESCRIPTION
Sets `$_SERVER['PHP_SELF']` to equal `$_SERVER['SCRIPT_NAME']`, which fixes the issue described in #244.