### PR TITLE
Fix `Request Entity Too Large` error by adding client_max_body_size to config

### DIFF
--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -2,6 +2,7 @@ server {
     listen 80 default_server;
     root /;
     charset utf-8;
+    client_max_body_size 128M;
 
     location /static/ {
         internal;


### PR DESCRIPTION
This will prevent `Request Entity Too Large` errors when uploading files.