### PR TITLE
Fix for query string in PHP

### DIFF
--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -10,7 +10,7 @@ server {
     }
 
     location / {
-        rewrite ^ VALET_SERVER_PATH?$query_string last;
+        rewrite ^ VALET_SERVER_PATH last;
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }


### PR DESCRIPTION
When retrieving the query string in your app, it's twice the value it should be.

For example I have a request like "/overview?page=1" when I use request()->server('QUERY_STRING') I get "page=1&page=1" instead of "page=1".

Removing the ?$querystring for the Nginx config in the rewrite directive fixes this.