### PR TITLE
Forbid access to most commands if not installed

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -47,8 +47,6 @@ $app->command('install', function () {
     output(PHP_EOL.'<info>Valet installed successfully!</info>');
 })->descriptions('Install the Valet services');
 
-var_dump(VALET_HOME_PATH);
-
 /**
  * Most commands are available only if valet is installed.
  */


### PR DESCRIPTION
If valet is not yet installed we get all sort of errors on commands, like

![image](https://cloud.githubusercontent.com/assets/3182864/21225503/5be2b3fa-c2b8-11e6-94c5-743e20c1215c.png)


So I thought we could just show this, while not installed:

![image](https://cloud.githubusercontent.com/assets/3182864/21225395/c8031300-c2b7-11e6-8166-334b480a3cd3.png)
