### PR TITLE
Show start & stop process info in terminal

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -91,6 +91,8 @@ class Brew
      */
     function installOrFail($formula, $options = [], $taps = [])
     {
+        info("Installing $formula...");
+
         if (count($taps) > 0) {
             $this->tap($taps);
         }
@@ -129,8 +131,12 @@ class Brew
         $services = is_array($services) ? $services : func_get_args();
 
         foreach ($services as $service) {
-            $this->cli->quietly('sudo brew services stop '.$service);
-            $this->cli->quietly('sudo brew services start '.$service);
+            if ($this->installed($service)) {
+                info("Restarting $service...");
+
+                $this->cli->quietly('sudo brew services stop '.$service);
+                $this->cli->quietly('sudo brew services start '.$service);
+            }
         }
     }
 
@@ -144,7 +150,11 @@ class Brew
         $services = is_array($services) ? $services : func_get_args();
 
         foreach ($services as $service) {
-            $this->cli->quietly('sudo brew services stop '.$service);
+            if ($this->installed($service)) {
+                info("Stopping $service...");
+
+                $this->cli->quietly('sudo brew services stop '.$service);
+            }
         }
     }
 

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -91,7 +91,7 @@ class Brew
      */
     function installOrFail($formula, $options = [], $taps = [])
     {
-        info("Installing $formula...");
+        info("Installing {$formula}...");
 
         if (count($taps) > 0) {
             $this->tap($taps);
@@ -132,7 +132,7 @@ class Brew
 
         foreach ($services as $service) {
             if ($this->installed($service)) {
-                info("Restarting $service...");
+                info("Restarting {$service}...");
 
                 $this->cli->quietly('sudo brew services stop '.$service);
                 $this->cli->quietly('sudo brew services start '.$service);
@@ -151,7 +151,7 @@ class Brew
 
         foreach ($services as $service) {
             if ($this->installed($service)) {
-                info("Stopping $service...");
+                info("Stopping {$service}...");
 
                 $this->cli->quietly('sudo brew services stop '.$service);
             }

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -53,6 +53,8 @@ class Nginx
      */
     function installConfiguration()
     {
+        info('Installing nginx configuration...');
+
         $contents = $this->files->get(__DIR__.'/../stubs/nginx.conf');
 
         $this->files->putAsUser(
@@ -94,6 +96,8 @@ class Nginx
      */
     function installNginxDirectory()
     {
+        info('Installing nginx directory...');
+
         if (! $this->files->isDir($nginxDirectory = VALET_HOME_PATH.'/Nginx')) {
             $this->files->mkdirAsUser($nginxDirectory);
         }
@@ -132,6 +136,8 @@ class Nginx
      */
     function stop()
     {
+        info('Stopping nginx....');
+
         $this->cli->quietly('sudo brew services stop '. $this->brew->nginxServiceName());
     }
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -54,6 +54,8 @@ class PhpFpm
      */
     function updateConfiguration()
     {
+        info('Updating php configuration...');
+
         $contents = $this->files->get($this->fpmConfigPath());
 
         $contents = preg_replace('/^user = .+$/m', 'user = '.user(), $contents);

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -54,7 +54,7 @@ class PhpFpm
      */
     function updateConfiguration()
     {
-        info('Updating php configuration...');
+        info('Updating PHP configuration...');
 
         $contents = $this->files->get($this->fpmConfigPath());
 

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -99,6 +99,7 @@ php7');
     public function test_restart_restarts_the_service_using_homebrew_services()
     {
         $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep dnsmasq')->andReturn('dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services start dnsmasq');
         swap(CommandLine::class, $cli);
@@ -109,6 +110,7 @@ php7');
     public function test_stop_stops_the_service_using_homebrew_services()
     {
         $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep dnsmasq')->andReturn('dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
         swap(CommandLine::class, $cli);
         resolve(Brew::class)->stopService('dnsmasq');


### PR DESCRIPTION
Give users some info while starting, stopping and restarting services:

![image](https://cloud.githubusercontent.com/assets/3182864/21226740/fb33e122-c2bd-11e6-8493-7b5660537263.png)
