### PR TITLE
Added new command for creating new databases

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -248,6 +248,21 @@ $app->command('on-latest-version', function () use ($version) {
 })->descriptions('Determine if this is the latest version of Valet');
 
 /**
+ * Create a new database on your local machine.
+ */
+$app->command('db [name]', function ($name) {
+    if(!$name) {
+        warning('Please specify a database name');
+        return;
+    }
+    if($error = CommandLine::run('mysql -uroot -e "create database '.$name.'"')) {
+        warning($error);
+    } else {
+        info('The database '.$name.' has been created');
+    }
+})->descriptions('Create a new database');
+
+/**
  * Load all of the Valet extensions.
  */
 foreach (Valet::extensions() as $extension) {


### PR DESCRIPTION
I find myself creating new databases in Sequel Pro each time I start a new project. Unfortunately, this is the only reason why I mostly open Sequel Pro and so I've added this as a valet command:

valet db new_db_name

I think it is a good fit for valet because the local mysql/mariadb user is root with no password and will be accessible via valet easily.