### PR TITLE
Add a 'host' command to behave like /etc/hosts

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -121,6 +121,26 @@ class Configuration
     }
 
     /**
+     * Add a host to the host list in the config file
+     * 
+     * @param string $host
+     * @param string $ip
+     * @param boolean $prepend
+     */
+    function addHost ($host, $ip, $prepend = false) {
+        $this->write(tap($this->read(), function (&$config) use ($host, $ip, $prepend) {
+            $method = $prepend ? 'prepend' : 'push';
+
+            $hosts = $config['hosts'] ?? [];
+
+            $config['hosts'] = collect($hosts)->{$method}([
+                'host' => $host,
+                'ip' => $ip
+            ])->all();
+        }));
+    }
+
+    /**
      * Prepend the given path to the configuration.
      *
      * @param  string  $path
@@ -142,6 +162,20 @@ class Configuration
         $this->write(tap($this->read(), function (&$config) use ($path) {
             $config['paths'] = collect($config['paths'])->reject(function ($value) use ($path) {
                 return $value === $path;
+            })->values()->all();
+        }));
+    }
+
+    /**
+     * Remove the host
+     * 
+     * @param  string $host
+     */
+    function removeHost ($host) {
+        $this->write(tap($this->read(), function (&$config) use ($host) {
+            $hosts = $config['hosts'] ?? [];
+            $config['hosts'] = collect($hosts)->reject(function ($value) use ($host) {
+                return $value['host'] === $host;
             })->values()->all();
         }));
     }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -97,6 +97,18 @@ $app->command('link [name]', function ($name) {
     info('A ['.$name.'] symbolic link has been created in ['.$linkPath.'].');
 })->descriptions('Link the current working directory to Valet');
 
+$app->command('host name ip', function ($name, $ip) {
+    DnsMasq::addHost ($name, $ip);
+
+    info('Added host ['.$name.'] with ip ['.$ip.'].');
+})->descriptions('Add a new host');
+
+$app->command('rmhost name', function ($name) {
+    DnsMasq::removeHost ($name);
+
+    info('Removed host ['.$name.'].');
+})->descriptions('Remove a host');
+
 /**
  * Display all of the registered symbolic links.
  */


### PR DESCRIPTION
Valet is really nice, and I miss this functionality while using vagrant, and any non-php framework. Editing /etc/hosts can be a little cumbersome, so I added a command to add similar functionality

```cmd
$ valet host homestead 192.168.10.10

Added host [homestead] with ip [192.168.10.10].
```

Now, visiting http://homestead.dev opens the correct IP and connects to the vagrant network. You can also run `valet rmhost homestead` to remove that host.

This feature is far from complete, and there's a good bit of validation and cleaning up and testing that needs to be done. If you're interested in having this feature, I'll be happy to make this fully functional. 