### PR TITLE
Fix large-upload problems by setting PHP limits and Nginx max size

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -67,6 +67,15 @@ class PhpFpm
         $contents = preg_replace('/^;?listen\.mode = .+$/m', 'listen.mode = 0777', $contents);
 
         $this->files->put($this->fpmConfigPath(), $contents);
+
+
+        $contents = $this->files->get(__DIR__.'/../stubs/php-memory-limits.ini');
+
+        $destFile = dirname($this->fpmConfigPath());
+        $destFile = str_replace('php-fpm.d', '', $destFile);
+        $destFile .= '/conf.d/php-memory-limits.ini';
+
+        $this->files->putAsUser($destFile, $contents);
     }
 
     /**

--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -11,6 +11,7 @@ http {
 
     sendfile on;
     keepalive_timeout  65;
+    client_max_body_size 128M;
 
     gzip  on;
     gzip_comp_level 5;

--- a/cli/stubs/php-memory-limits.ini
+++ b/cli/stubs/php-memory-limits.ini
@@ -1,0 +1,8 @@
+; Max memory per instance
+memory_limit = 128M
+
+;The maximum size of an uploaded file.
+upload_max_filesize = 128M
+
+;Sets max size of post data allowed. This setting also affects file upload. To upload large files, this value must be larger than upload_max_filesize
+post_max_size = 128M

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -2,7 +2,6 @@ server {
     listen 80 default_server;
     root /;
     charset utf-8;
-    client_max_body_size 128M;
 
     location /VALET_STATIC_PREFIX/ {
         internal;

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -25,6 +25,8 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
     public function test_fpm_is_configured_with_the_correct_user_group_and_port()
     {
         copy(__DIR__.'/files/fpm.conf', __DIR__.'/output/fpm.conf');
+        mkdir(__DIR__.'/output/conf.d');
+        copy(__DIR__.'/files/php-memory-limits.ini', __DIR__.'/output/conf.d/php-memory-limits.ini');
         resolve(StubForUpdatingFpmConfigFiles::class)->updateConfiguration();
         $contents = file_get_contents(__DIR__.'/output/fpm.conf');
         $this->assertContains(sprintf("\nuser = %s", user()), $contents);

--- a/tests/files/php-memory-limits.ini
+++ b/tests/files/php-memory-limits.ini
@@ -1,0 +1,8 @@
+; Max memory per instance
+memory_limit = 128M
+
+;The maximum size of an uploaded file.
+upload_max_filesize = 128M
+
+;Sets max size of post data allowed. This setting also affects file upload. To upload large files, this value must be larger than upload_max_filesize
+post_max_size = 128M


### PR DESCRIPTION
- Sets `client_max_body_size 128M` in `http` section of `nginx.conf`  so it covers all configs
- Adds `php-memory-limits.conf` to `php-fpm` conf folder, to set `memory_limit`, `upload_max_filesize`, `post_max_size` all to 128M

(Updates #253 by moving config location to cover all, since #253 didn't cover secure configs, etc)