### PR TITLE
Change visibilities to explicit public

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -7,7 +7,7 @@ use DomainException;
 
 class Brew
 {
-    var $cli, $files;
+    public $cli, $files;
 
     /**
      * Create a new Brew instance.

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -16,7 +16,7 @@ class Brew
      * @param  Filesystem  $files
      * @return void
      */
-    function __construct(CommandLine $cli, Filesystem $files)
+    public function __construct(CommandLine $cli, Filesystem $files)
     {
         $this->cli = $cli;
         $this->files = $files;
@@ -28,7 +28,7 @@ class Brew
      * @param  string  $formula
      * @return bool
      */
-    function installed($formula)
+    public function installed($formula)
     {
         return in_array($formula, explode(PHP_EOL, $this->cli->runAsUser('brew list | grep '.$formula)));
     }
@@ -38,7 +38,7 @@ class Brew
      *
      * @return bool
      */
-    function hasInstalledPhp()
+    public function hasInstalledPhp()
     {
         return $this->installed('php71')
             || $this->installed('php70')
@@ -53,7 +53,7 @@ class Brew
      * @param  array  $taps
      * @return void
      */
-    function ensureInstalled($formula, $options = [], $taps = [])
+    public function ensureInstalled($formula, $options = [], $taps = [])
     {
         if (! $this->installed($formula)) {
             $this->installOrFail($formula, $options, $taps);
@@ -68,7 +68,7 @@ class Brew
      * @param  array  $taps
      * @return void
      */
-    function installOrFail($formula, $options = [], $taps = [])
+    public function installOrFail($formula, $options = [], $taps = [])
     {
         if (count($taps) > 0) {
             $this->tap($taps);
@@ -89,7 +89,7 @@ class Brew
      * @param  dynamic[string]  $formula
      * @return void
      */
-    function tap($formulas)
+    public function tap($formulas)
     {
         $formulas = is_array($formulas) ? $formulas : func_get_args();
 
@@ -103,7 +103,7 @@ class Brew
      *
      * @param
      */
-    function restartService($services)
+    public function restartService($services)
     {
         $services = is_array($services) ? $services : func_get_args();
 
@@ -117,7 +117,7 @@ class Brew
      *
      * @param
      */
-    function stopService($services)
+    public function stopService($services)
     {
         $services = is_array($services) ? $services : func_get_args();
 
@@ -131,7 +131,7 @@ class Brew
      *
      * @return string
      */
-    function linkedPhp()
+    public function linkedPhp()
     {
         if (! $this->files->isLink('/usr/local/bin/php')) {
             throw new DomainException("Unable to determine linked PHP.");
@@ -155,7 +155,7 @@ class Brew
      *
      * @return void
      */
-    function restartLinkedPhp()
+    public function restartLinkedPhp()
     {
         $this->restartService($this->linkedPhp());
     }
@@ -165,7 +165,7 @@ class Brew
      *
      * @return void
      */
-    function createSudoersEntry()
+    public function createSudoersEntry()
     {
         $this->files->ensureDirExists('/etc/sudoers.d');
 

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -12,7 +12,7 @@ class CommandLine
      * @param  string  $command
      * @return void
      */
-    function quietly($command)
+    public function quietly($command)
     {
         $this->runCommand($command.' > /dev/null 2>&1');
     }
@@ -23,7 +23,7 @@ class CommandLine
      * @param  string  $command
      * @return void
      */
-    function quietlyAsUser($command)
+    public function quietlyAsUser($command)
     {
         $this->quietly('sudo -u '.user().' '.$command.' > /dev/null 2>&1');
     }
@@ -34,7 +34,7 @@ class CommandLine
      * @param  string  $command
      * @return void
      */
-    function passthru($command)
+    public function passthru($command)
     {
         passthru($command);
     }
@@ -46,7 +46,7 @@ class CommandLine
      * @param  callable $onError
      * @return string
      */
-    function run($command, callable $onError = null)
+    public function run($command, callable $onError = null)
     {
         return $this->runCommand($command, $onError);
     }
@@ -58,7 +58,7 @@ class CommandLine
      * @param  callable $onError
      * @return string
      */
-    function runAsUser($command, callable $onError = null)
+    public function runAsUser($command, callable $onError = null)
     {
         return $this->runCommand('sudo -u '.user().' '.$command, $onError);
     }
@@ -70,7 +70,7 @@ class CommandLine
      * @param  callable $onError
      * @return string
      */
-    function runCommand($command, callable $onError = null)
+    public function runCommand($command, callable $onError = null)
     {
         $onError = $onError ?: function () {};
 

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -4,7 +4,7 @@ namespace Valet;
 
 class Configuration
 {
-    var $files;
+    public $files;
 
     /**
      * Create a new Valet configuration class instance.

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -11,7 +11,7 @@ class Configuration
      *
      * @param Filesystem $filesystem
      */
-    function __construct(Filesystem $files)
+    public function __construct(Filesystem $files)
     {
         $this->files = $files;
     }
@@ -21,7 +21,7 @@ class Configuration
      *
      * @return void
      */
-    function install()
+    public function install()
     {
         $this->createConfigurationDirectory();
         $this->createDriversDirectory();
@@ -38,7 +38,7 @@ class Configuration
      *
      * @return void
      */
-    function createConfigurationDirectory()
+    public function createConfigurationDirectory()
     {
         $this->files->ensureDirExists(VALET_HOME_PATH, user());
     }
@@ -48,7 +48,7 @@ class Configuration
      *
      * @return void
      */
-    function createDriversDirectory()
+    public function createDriversDirectory()
     {
         if ($this->files->isDir($driversDirectory = VALET_HOME_PATH.'/Drivers')) {
             return;
@@ -67,7 +67,7 @@ class Configuration
      *
      * @return void
      */
-    function createSitesDirectory()
+    public function createSitesDirectory()
     {
         $this->files->ensureDirExists(VALET_HOME_PATH.'/Sites', user());
     }
@@ -77,7 +77,7 @@ class Configuration
      *
      * @return void
      */
-    function createExtensionsDirectory()
+    public function createExtensionsDirectory()
     {
         $this->files->ensureDirExists(VALET_HOME_PATH.'/Extensions', user());
     }
@@ -87,7 +87,7 @@ class Configuration
      *
      * @return void
      */
-    function createLogDirectory()
+    public function createLogDirectory()
     {
         $this->files->ensureDirExists(VALET_HOME_PATH.'/Log', user());
 
@@ -97,7 +97,7 @@ class Configuration
     /**
      * Write the base, initial configuration for Valet.
      */
-    function writeBaseConfiguration()
+    public function writeBaseConfiguration()
     {
         if (! $this->files->exists($this->path())) {
             $this->write(['domain' => 'dev', 'paths' => []]);
@@ -111,7 +111,7 @@ class Configuration
      * @param  bool  $prepend
      * @return void
      */
-    function addPath($path, $prepend = false)
+    public function addPath($path, $prepend = false)
     {
         $this->write(tap($this->read(), function (&$config) use ($path, $prepend) {
             $method = $prepend ? 'prepend' : 'push';
@@ -126,7 +126,7 @@ class Configuration
      * @param  string  $path
      * @return void
      */
-    function prependPath($path)
+    public function prependPath($path)
     {
         $this->addPath($path, true);
     }
@@ -137,7 +137,7 @@ class Configuration
      * @param  string  $path
      * @return void
      */
-    function removePath($path)
+    public function removePath($path)
     {
         $this->write(tap($this->read(), function (&$config) use ($path) {
             $config['paths'] = collect($config['paths'])->reject(function ($value) use ($path) {
@@ -151,7 +151,7 @@ class Configuration
      *
      * @return void
      */
-    function prune()
+    public function prune()
     {
         if (! $this->files->exists($this->path())) {
             return;
@@ -169,7 +169,7 @@ class Configuration
      *
      * @return array
      */
-    function read()
+    public function read()
     {
         return json_decode($this->files->get($this->path()), true);
     }
@@ -181,7 +181,7 @@ class Configuration
      * @param  mixed  $value
      * @return array
      */
-    function updateKey($key, $value)
+    public function updateKey($key, $value)
     {
         return tap($this->read(), function (&$config) use ($key, $value) {
             $config[$key] = $value;
@@ -196,7 +196,7 @@ class Configuration
      * @param  array  $config
      * @return void
      */
-    function write($config)
+    public function write($config)
     {
         $this->files->putAsUser($this->path(), json_encode(
             $config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
@@ -208,7 +208,7 @@ class Configuration
      *
      * @return string
      */
-    function path()
+    public function path()
     {
         return VALET_HOME_PATH.'/config.json';
     }

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -21,7 +21,7 @@ class DnsMasq
      * @param  Filesystem  $files
      * @return void
      */
-    function __construct(Brew $brew, CommandLine $cli, Filesystem $files)
+    public function __construct(Brew $brew, CommandLine $cli, Filesystem $files)
     {
         $this->cli = $cli;
         $this->brew = $brew;
@@ -33,7 +33,7 @@ class DnsMasq
      *
      * @return void
      */
-    function install($domain = 'dev')
+    public function install($domain = 'dev')
     {
         $this->brew->ensureInstalled('dnsmasq');
 
@@ -53,7 +53,7 @@ class DnsMasq
      * @param  string  $domain
      * @return void
      */
-    function createCustomConfigFile($domain)
+    public function createCustomConfigFile($domain)
     {
         $customConfigPath = $this->customConfigPath();
 
@@ -69,7 +69,7 @@ class DnsMasq
      *
      * @return void
      */
-    function copyExampleConfig()
+    public function copyExampleConfig()
     {
         if (! $this->files->exists($this->configPath)) {
             $this->files->copyAsUser(
@@ -85,7 +85,7 @@ class DnsMasq
      * @param  string  $customConfigPath
      * @return void
      */
-    function appendCustomConfigImport($customConfigPath)
+    public function appendCustomConfigImport($customConfigPath)
     {
         if (! $this->customConfigIsBeingImported($customConfigPath)) {
             $this->files->appendAsUser(
@@ -101,7 +101,7 @@ class DnsMasq
      * @param  string  $customConfigPath
      * @return bool
      */
-    function customConfigIsBeingImported($customConfigPath)
+    public function customConfigIsBeingImported($customConfigPath)
     {
         return strpos($this->files->get($this->configPath), $customConfigPath) !== false;
     }
@@ -112,7 +112,7 @@ class DnsMasq
      * @param  string  $domain
      * @return void
      */
-    function createDomainResolver($domain)
+    public function createDomainResolver($domain)
     {
         $this->files->ensureDirExists($this->resolverPath);
 
@@ -126,7 +126,7 @@ class DnsMasq
      * @param  string  $newDomain
      * @return void
      */
-    function updateDomain($oldDomain, $newDomain)
+    public function updateDomain($oldDomain, $newDomain)
     {
         $this->files->unlink($this->resolverPath.'/'.$oldDomain);
 
@@ -138,7 +138,7 @@ class DnsMasq
      *
      * @return string
      */
-    function customConfigPath()
+    public function customConfigPath()
     {
         return $_SERVER['HOME'].'/.valet/dnsmasq.conf';
     }

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -7,11 +7,11 @@ use Symfony\Component\Process\Process;
 
 class DnsMasq
 {
-    var $brew, $cli, $files;
+    public $brew, $cli, $files;
 
-    var $resolverPath = '/etc/resolver';
-    var $configPath = '/usr/local/etc/dnsmasq.conf';
-    var $exampleConfigPath = '/usr/local/opt/dnsmasq/dnsmasq.conf.example';
+    public $resolverPath = '/etc/resolver';
+    public $configPath = '/usr/local/etc/dnsmasq.conf';
+    public $exampleConfigPath = '/usr/local/opt/dnsmasq/dnsmasq.conf.example';
 
     /**
      * Create a new DnsMasq instance.

--- a/cli/Valet/Filesystem.php
+++ b/cli/Valet/Filesystem.php
@@ -12,7 +12,7 @@ class Filesystem
      * @param  string  $path
      * @return bool
      */
-    function isDir($path)
+    public function isDir($path)
     {
         return is_dir($path);
     }
@@ -25,7 +25,7 @@ class Filesystem
      * @param  int  $mode
      * @return void
      */
-    function mkdir($path, $owner = null, $mode = 0755)
+    public function mkdir($path, $owner = null, $mode = 0755)
     {
         mkdir($path, $mode, true);
 
@@ -42,7 +42,7 @@ class Filesystem
      * @param  int  $mode
      * @return void
      */
-    function ensureDirExists($path, $owner = null, $mode = 0755)
+    public function ensureDirExists($path, $owner = null, $mode = 0755)
     {
         if (! $this->isDir($path)) {
             $this->mkdir($path, $owner, $mode);
@@ -56,7 +56,7 @@ class Filesystem
      * @param  int  $mode
      * @return void
      */
-    function mkdirAsUser($path, $mode = 0755)
+    public function mkdirAsUser($path, $mode = 0755)
     {
         return $this->mkdir($path, user(), $mode);
     }
@@ -68,7 +68,7 @@ class Filesystem
      * @param  string|null  $owner
      * @return string
      */
-    function touch($path, $owner = null)
+    public function touch($path, $owner = null)
     {
         touch($path);
 
@@ -85,7 +85,7 @@ class Filesystem
      * @param  string  $path
      * @return void
      */
-    function touchAsUser($path)
+    public function touchAsUser($path)
     {
         return $this->touch($path, user());
     }
@@ -96,7 +96,7 @@ class Filesystem
      * @param  string  $path
      * @return bool
      */
-    function exists($path)
+    public function exists($path)
     {
         return file_exists($path);
     }
@@ -107,7 +107,7 @@ class Filesystem
      * @param  string  $path
      * @return string
      */
-    function get($path)
+    public function get($path)
     {
         return file_get_contents($path);
     }
@@ -120,7 +120,7 @@ class Filesystem
      * @param  string|null  $owner
      * @return string
      */
-    function put($path, $contents, $owner = null)
+    public function put($path, $contents, $owner = null)
     {
         file_put_contents($path, $contents);
 
@@ -136,7 +136,7 @@ class Filesystem
      * @param  string  $contents
      * @return string
      */
-    function putAsUser($path, $contents)
+    public function putAsUser($path, $contents)
     {
         return $this->put($path, $contents, user());
     }
@@ -149,7 +149,7 @@ class Filesystem
      * @param  string|null  $owner
      * @return void
      */
-    function append($path, $contents, $owner = null)
+    public function append($path, $contents, $owner = null)
     {
         file_put_contents($path, $contents, FILE_APPEND);
 
@@ -165,7 +165,7 @@ class Filesystem
      * @param  string  $contents
      * @return void
      */
-    function appendAsUser($path, $contents)
+    public function appendAsUser($path, $contents)
     {
         $this->append($path, $contents, user());
     }
@@ -177,7 +177,7 @@ class Filesystem
      * @param  string  $to
      * @return void
      */
-    function copy($from, $to)
+    public function copy($from, $to)
     {
         copy($from, $to);
     }
@@ -189,7 +189,7 @@ class Filesystem
      * @param  string  $to
      * @return void
      */
-    function copyAsUser($from, $to)
+    public function copyAsUser($from, $to)
     {
         copy($from, $to);
 
@@ -203,7 +203,7 @@ class Filesystem
      * @param  string  $link
      * @return void
      */
-    function symlink($target, $link)
+    public function symlink($target, $link)
     {
         if ($this->exists($link)) {
             $this->unlink($link);
@@ -221,7 +221,7 @@ class Filesystem
      * @param  string  $link
      * @return void
      */
-    function symlinkAsUser($target, $link)
+    public function symlinkAsUser($target, $link)
     {
         if ($this->exists($link)) {
             $this->unlink($link);
@@ -236,7 +236,7 @@ class Filesystem
      * @param  string  $path
      * @return void
      */
-    function unlink($path)
+    public function unlink($path)
     {
         if (file_exists($path) || is_link($path)) {
             @unlink($path);
@@ -249,7 +249,7 @@ class Filesystem
      * @param  string  $path
      * @param  string  $user
      */
-    function chown($path, $user)
+    public function chown($path, $user)
     {
         chown($path, $user);
     }
@@ -260,7 +260,7 @@ class Filesystem
      * @param  string  $path
      * @param  string  $group
      */
-    function chgrp($path, $group)
+    public function chgrp($path, $group)
     {
         chgrp($path, $group);
     }
@@ -271,7 +271,7 @@ class Filesystem
      * @param  string  $path
      * @return string
      */
-    function realpath($path)
+    public function realpath($path)
     {
         return realpath($path);
     }
@@ -282,7 +282,7 @@ class Filesystem
      * @param  string  $path
      * @return bool
      */
-    function isLink($path)
+    public function isLink($path)
     {
         return is_link($path);
     }
@@ -293,7 +293,7 @@ class Filesystem
      * @param  string  $path
      * @return string
      */
-    function readLink($path)
+    public function readLink($path)
     {
         return readlink($path);
     }
@@ -304,7 +304,7 @@ class Filesystem
      * @param  string  $path
      * @return void
      */
-    function removeBrokenLinksAt($path)
+    public function removeBrokenLinksAt($path)
     {
         collect($this->scandir($path))
                 ->filter(function ($file) use ($path) {
@@ -321,7 +321,7 @@ class Filesystem
      * @param  string  $path
      * @return bool
      */
-    function isBrokenLink($path)
+    public function isBrokenLink($path)
     {
         return is_link($path) && ! file_exists($path);
     }
@@ -332,7 +332,7 @@ class Filesystem
      * @param  string  $path
      * @return array
      */
-    function scandir($path)
+    public function scandir($path)
     {
         return collect(scandir($path))
                     ->reject(function ($file) {

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -4,11 +4,11 @@ namespace Valet;
 
 class Nginx
 {
-    var $brew;
-    var $cli;
-    var $files;
-    var $configuration;
-    var $site;
+    public $brew;
+    public $cli;
+    public $files;
+    public $configuration;
+    public $site;
 
     /**
      * Create a new Nginx instance.

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -20,7 +20,7 @@ class Nginx
      * @param  Site  $site
      * @return void
      */
-    function __construct(Brew $brew, CommandLine $cli, Filesystem $files,
+    public function __construct(Brew $brew, CommandLine $cli, Filesystem $files,
                          Configuration $configuration, Site $site)
     {
         $this->cli = $cli;
@@ -35,7 +35,7 @@ class Nginx
      *
      * @return void
      */
-    function install()
+    public function install()
     {
         $this->brew->ensureInstalled('nginx', ['--with-http2']);
 
@@ -49,7 +49,7 @@ class Nginx
      *
      * @return void
      */
-    function installConfiguration()
+    public function installConfiguration()
     {
         $contents = $this->files->get(__DIR__.'/../stubs/nginx.conf');
 
@@ -64,7 +64,7 @@ class Nginx
      *
      * @return void
      */
-    function installServer()
+    public function installServer()
     {
         $this->files->ensureDirExists('/usr/local/etc/nginx/valet');
 
@@ -90,7 +90,7 @@ class Nginx
      *
      * @return void
      */
-    function installNginxDirectory()
+    public function installNginxDirectory()
     {
         if (! $this->files->isDir($nginxDirectory = VALET_HOME_PATH.'/Nginx')) {
             $this->files->mkdirAsUser($nginxDirectory);
@@ -106,7 +106,7 @@ class Nginx
      *
      * @return void
      */
-    function rewriteSecureNginxFiles()
+    public function rewriteSecureNginxFiles()
     {
         $domain = $this->configuration->read()['domain'];
 
@@ -118,7 +118,7 @@ class Nginx
      *
      * @return void
      */
-    function restart()
+    public function restart()
     {
         $this->cli->quietly('sudo brew services restart nginx');
     }
@@ -128,7 +128,7 @@ class Nginx
      *
      * @return void
      */
-    function stop()
+    public function stop()
     {
         $this->cli->quietly('sudo brew services stop nginx');
     }
@@ -138,7 +138,7 @@ class Nginx
      *
      * @return void
      */
-    function uninstall()
+    public function uninstall()
     {
         $this->stop();
     }

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -14,7 +14,7 @@ class Ngrok
      *
      * @return string
      */
-    function currentTunnelUrl()
+    public function currentTunnelUrl()
     {
         return retry(20, function () {
             $body = Request::get($this->tunnelsEndpoint)->send()->body;
@@ -36,7 +36,7 @@ class Ngrok
      * @param  array  $tunnels
      * @return string|null
      */
-    function findHttpTunnelUrl($tunnels)
+    public function findHttpTunnelUrl($tunnels)
     {
         foreach ($tunnels as $tunnel) {
             if ($tunnel->proto === 'http') {

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -7,7 +7,7 @@ use DomainException;
 
 class Ngrok
 {
-    var $tunnelsEndpoint = 'http://127.0.0.1:4040/api/tunnels';
+    public $tunnelsEndpoint = 'http://127.0.0.1:4040/api/tunnels';
 
     /**
      * Get the current tunnel URL from the Ngrok API.

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -22,7 +22,7 @@ class PhpFpm
      * @param  Filesystem  $files
      * @return void
      */
-    function __construct(Brew $brew, CommandLine $cli, Filesystem $files)
+    public function __construct(Brew $brew, CommandLine $cli, Filesystem $files)
     {
         $this->cli = $cli;
         $this->brew = $brew;
@@ -34,7 +34,7 @@ class PhpFpm
      *
      * @return void
      */
-    function install()
+    public function install()
     {
         if (! $this->brew->installed('php71') &&
             ! $this->brew->installed('php70') &&
@@ -54,7 +54,7 @@ class PhpFpm
      *
      * @return void
      */
-    function updateConfiguration()
+    public function updateConfiguration()
     {
         $contents = $this->files->get($this->fpmConfigPath());
 
@@ -73,7 +73,7 @@ class PhpFpm
      *
      * @return void
      */
-    function restart()
+    public function restart()
     {
         $this->stop();
 
@@ -85,7 +85,7 @@ class PhpFpm
      *
      * @return void
      */
-    function stop()
+    public function stop()
     {
         $this->brew->stopService('php56', 'php70', 'php71');
     }
@@ -95,7 +95,7 @@ class PhpFpm
      *
      * @return string
      */
-    function fpmConfigPath()
+    public function fpmConfigPath()
     {
         $confLookup = [
             'php71' => '/usr/local/etc/php/7.1/php-fpm.d/www.conf',

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -8,9 +8,9 @@ use Symfony\Component\Process\Process;
 
 class PhpFpm
 {
-    var $brew, $cli, $files;
+    public $brew, $cli, $files;
 
-    var $taps = [
+    public $taps = [
         'homebrew/dupes', 'homebrew/versions', 'homebrew/homebrew-php'
     ];
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -2,11 +2,9 @@
 
 namespace Valet;
 
-use DomainException;
-
 class Site
 {
-    var $config, $cli, $files;
+    public $config, $cli, $files;
 
     /**
      * Create a new Site instance.

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -13,7 +13,7 @@ class Site
      * @param  CommandLine  $cli
      * @param  Filesystem  $files
      */
-    function __construct(Configuration $config, CommandLine $cli, Filesystem $files)
+    public function __construct(Configuration $config, CommandLine $cli, Filesystem $files)
     {
         $this->cli = $cli;
         $this->files = $files;
@@ -26,7 +26,7 @@ class Site
      * @param  string  $path
      * @return string|null
      */
-    function host($path)
+    public function host($path)
     {
         foreach ($this->files->scandir($this->sitesPath()) as $link) {
             if ($resolved = realpath($this->sitesPath().'/'.$link) === $path) {
@@ -44,7 +44,7 @@ class Site
      * @param  string  $link
      * @return string
      */
-    function link($target, $link)
+    public function link($target, $link)
     {
         $this->files->ensureDirExists(
             $linkPath = $this->sitesPath(), user()
@@ -63,7 +63,7 @@ class Site
      * @param  string  $name
      * @return void
      */
-    function unlink($name)
+    public function unlink($name)
     {
         if ($this->files->exists($path = $this->sitesPath().'/'.$name)) {
             $this->files->unlink($path);
@@ -75,7 +75,7 @@ class Site
      *
      * @return void
      */
-    function pruneLinks()
+    public function pruneLinks()
     {
         $this->files->ensureDirExists($this->sitesPath(), user());
 
@@ -89,7 +89,7 @@ class Site
      * @param  string  $domain
      * @return void
      */
-    function resecureForNewDomain($oldDomain, $domain)
+    public function resecureForNewDomain($oldDomain, $domain)
     {
         if (! $this->files->exists($this->certificatesPath())) {
             return;
@@ -111,7 +111,7 @@ class Site
      *
      * @return array
      */
-    function secured()
+    public function secured()
     {
         return collect($this->files->scandir($this->certificatesPath()))
                     ->map(function ($file) {
@@ -125,7 +125,7 @@ class Site
      * @param  string  $url
      * @return void
      */
-    function secure($url)
+    public function secure($url)
     {
         $this->unsecure($url);
 
@@ -144,7 +144,7 @@ class Site
      * @param  string  $url
      * @return void
      */
-    function createCertificate($url)
+    public function createCertificate($url)
     {
         $keyPath = $this->certificatesPath().'/'.$url.'.key';
         $csrPath = $this->certificatesPath().'/'.$url.'.csr';
@@ -166,7 +166,7 @@ class Site
      * @param  string  $keyPath
      * @return void
      */
-    function createPrivateKey($keyPath)
+    public function createPrivateKey($keyPath)
     {
         $this->cli->runAsUser(sprintf('openssl genrsa -out %s 2048', $keyPath));
     }
@@ -177,7 +177,7 @@ class Site
      * @param  string  $keyPath
      * @return void
      */
-    function createSigningRequest($url, $keyPath, $csrPath)
+    public function createSigningRequest($url, $keyPath, $csrPath)
     {
         $this->cli->runAsUser(sprintf(
             'openssl req -new -subj "/C=/ST=/O=/localityName=/commonName=%s/organizationalUnitName=/emailAddress=/" -key %s -out %s -passin pass:',
@@ -191,7 +191,7 @@ class Site
      * @param  string  $crtPath
      * @return void
      */
-    function trustCertificate($crtPath)
+    public function trustCertificate($crtPath)
     {
         $this->cli->run(sprintf(
             'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain %s', $crtPath
@@ -204,7 +204,7 @@ class Site
      * @param  string  $url
      * @return string
      */
-    function buildSecureNginxServer($url)
+    public function buildSecureNginxServer($url)
     {
         $path = $this->certificatesPath();
 
@@ -221,7 +221,7 @@ class Site
      * @param  string  $url
      * @return void
      */
-    function unsecure($url)
+    public function unsecure($url)
     {
         if ($this->files->exists($this->certificatesPath().'/'.$url.'.crt')) {
             $this->files->unlink(VALET_HOME_PATH.'/Nginx/'.$url);
@@ -239,7 +239,7 @@ class Site
      *
      * @return string
      */
-    function sitesPath()
+    public function sitesPath()
     {
         return VALET_HOME_PATH.'/Sites';
     }
@@ -249,7 +249,7 @@ class Site
      *
      * @return string
      */
-    function certificatesPath()
+    public function certificatesPath()
     {
         return VALET_HOME_PATH.'/Certificates';
     }

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -16,7 +16,7 @@ class Valet
      * @param  CommandLine  $cli
      * @param  Filesystem  $files
      */
-    function __construct(CommandLine $cli, Filesystem $files)
+    public function __construct(CommandLine $cli, Filesystem $files)
     {
         $this->cli = $cli;
         $this->files = $files;
@@ -27,7 +27,7 @@ class Valet
      *
      * @return void
      */
-    function symlinkToUsersBin()
+    public function symlinkToUsersBin()
     {
         $this->cli->quietlyAsUser('rm '.$this->valetBin);
 
@@ -39,7 +39,7 @@ class Valet
      *
      * @return void
      */
-    function createSudoersEntry()
+    public function createSudoersEntry()
     {
         $this->files->ensureDirExists('/etc/sudoers.d');
 
@@ -52,7 +52,7 @@ class Valet
      *
      * @return array
      */
-    function extensions()
+    public function extensions()
     {
         if (! $this->files->isDir(VALET_HOME_PATH.'/Extensions')) {
             return [];
@@ -74,7 +74,7 @@ class Valet
      * @param  string  $currentVersion
      * @return bool
      */
-    function onLatestVersion($currentVersion)
+    public function onLatestVersion($currentVersion)
     {
         $response = Request::get('https://api.github.com/repos/laravel/valet/releases/latest')->send();
 

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -2,11 +2,13 @@
 
 namespace Valet;
 
+use Httpful\Request;
+
 class Valet
 {
-    var $cli, $files;
+    public $cli, $files;
 
-    var $valetBin = '/usr/local/bin/valet';
+    public $valetBin = '/usr/local/bin/valet';
 
     /**
      * Create a new Valet instance.
@@ -74,7 +76,7 @@ class Valet
      */
     function onLatestVersion($currentVersion)
     {
-        $response = \Httpful\Request::get('https://api.github.com/repos/laravel/valet/releases/latest')->send();
+        $response = Request::get('https://api.github.com/repos/laravel/valet/releases/latest')->send();
 
         return version_compare($currentVersion, trim($response->body->tag_name, 'v'), '>=');
     }


### PR DESCRIPTION
Just explicitly saying that methods (whiteout any visibility) and properties (declared with var) are public.
I think its more clearly to read and OOP friendly.