### PR TITLE
Add support for Craft 3 Beta

### DIFF
--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -12,7 +12,18 @@ class CraftValetDriver extends ValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
-        return is_dir($sitePath.'/craft');
+        return file_exists($sitePath.'/craft');
+    }
+
+    /**
+     * Determine the name of the directory where the front controller lives.
+     *
+     * @param  string  $sitePath
+     * @return string
+     */
+    public function frontControllerDirectory($sitePath)
+    {
+        return is_file($sitePath.'/craft') ? 'web' : 'public';
     }
 
     /**
@@ -25,7 +36,9 @@ class CraftValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        if ($this->isActualFile($staticFilePath = $sitePath.'/public'.$uri)) {
+        $frontControllerDir = $this->frontControllerDirectory($sitePath);
+
+        if ($this->isActualFile($staticFilePath = $sitePath.'/'.$frontControllerDir.$uri)) {
             return $staticFilePath;
         }
 
@@ -42,8 +55,10 @@ class CraftValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        $frontControllerDirectory = $this->frontControllerDirectory($sitePath);
+
         // Default index path
-        $indexPath = $sitePath.'/public/index.php';
+        $indexPath = $sitePath.'/'.$frontControllerDirectory.'/index.php';
         $scriptName = '/index.php';
 
         // Check if the first URL segment matches any of the defined locales

--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -36,9 +36,9 @@ class CraftValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        $frontControllerDir = $this->frontControllerDirectory($sitePath);
+        $frontControllerDirectory = $this->frontControllerDirectory($sitePath);
 
-        if ($this->isActualFile($staticFilePath = $sitePath.'/'.$frontControllerDir.$uri)) {
+        if ($this->isActualFile($staticFilePath = $sitePath.'/'.$frontControllerDirectory.$uri)) {
             return $staticFilePath;
         }
 


### PR DESCRIPTION
Currently the Craft 3 Beta has the front controller stored in a `/web` directory; Craft 2 stored it in the `/public` directory.

As Craft 3 Beta has a `craft` cli bootstrap file, we can use this as our check in the `serves()` method. We can also use this to determine whether to load the front controller from the `/web` or `/public` directory.