### PR TITLE
Adds the ability to pass a directory to `valet open`

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -172,13 +172,13 @@ $app->command('paths', function () {
 })->descriptions('Get all of the paths registered with Valet');
 
 /**
- * Open the current directory in the browser.
+ * Open the current or given directory in the browser.
  */
- $app->command('open', function () {
-     $url = "http://".Site::host(getcwd()).'.'.Configuration::read()['domain'].'/';
+ $app->command('open [domain]', function ($domain = null) {
+     $url = "http://".($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
 
      passthru("open ".escapeshellarg($url));
- })->descriptions('Open the site for the current directory in your browser');
+ })->descriptions('Open the site for the current (or specified) directory in your browser');
 
 /**
  * Generate a publicly accessible URL for your project.


### PR DESCRIPTION
Occasionally I find myself in my projects directory and my reflex has been to type `valet open $dirname` to open a site in the browser.

This PR adds that ability. Saves a few keystrokes when you would have to cd into a directory to `valet open` it.