### PR TITLE
Lock PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": ">=4.8.24"
+        "phpunit/phpunit": "~5.7"
     },
     "bin": [
         "valet"


### PR DESCRIPTION
Before it would install PHPUnit 6 which only has namespaced classes and doesn't support PHP 5.6. 