### PR TITLE
Filter out .conf files when switching domains

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -168,7 +168,7 @@ class Site
     {
         return collect($this->files->scandir($this->certificatesPath()))
                     ->map(function ($file) {
-                        return str_replace(['.key', '.csr', '.crt'], '', $file);
+                        return str_replace(['.key', '.csr', '.crt', '.conf'], '', $file);
                     })->unique()->values()->all();
     }
 


### PR DESCRIPTION
When wildcard SAN certs were introduced https://github.com/laravel/valet/commit/f51959f7ec59f84e38c9031d121e63a3df2d2c15, a new `.conf` file was added to the Certificates directory. This file is not currently being filtered out during the `Sites#secured` method, and it's leading to some interesting behavior when running `valet domain <domain>` after you have secured at least one site:

<img width="439" alt="screen shot 2017-03-23 at 3 51 16 pm" src="https://cloud.githubusercontent.com/assets/848147/24272295/9cbe47a2-0fea-11e7-8a5f-c739503dddf9.png">
<img width="451" alt="screen shot 2017-03-23 at 3 55 08 pm" src="https://cloud.githubusercontent.com/assets/848147/24272296/9cbf0ee4-0fea-11e7-9970-9790a6945113.png">

😬 After switching domains about 8 times, this breaks Nginx's configuration, and you cannot access any sites through Valet until you delete all the configs. I don't know why, but I assume it's because there are too many/weird configs.

This PR filters out the extra file when building the URL list so this doesn't happen.