### PR TITLE
Adding directory listing option

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -250,6 +250,26 @@ if (is_dir(VALET_HOME_PATH)) {
             output('NO');
         }
     })->descriptions('Determine if this is the latest version of Valet');
+
+    /**
+     * Determine directory listing option
+     */
+    $app->command('directory-listing [option]', function ($option = null) {
+        $key = 'directory-listing';
+        $config = Configuration::read();
+
+        if (is_null($option)) {
+            if (!isset($config[$key])) {
+                output('Directory listing is not enabled. Set to on or off. Default is off');
+            } else {
+                output('Directory listing is ' . $config[$key]);
+            }
+        } else {
+            $config[$key] = $option;
+            Configuration::write($config);
+            output('Directory listing configuration is saved');
+        }
+    })->descriptions('Determine directory listing behavior. Default is off');
 }
 
 /**

--- a/server.php
+++ b/server.php
@@ -18,6 +18,47 @@ function show_valet_404()
 }
 
 /**
+ * Show directory listing
+ */
+function show_directory_listing($valetSitePath, $siteName, $uri)
+{
+    echo "<h1>Index of " . $uri . "</h1>";
+    echo "<hr>";
+
+    if ($uri == '/') {
+        $directory = $valetSitePath."/*";
+    } else {
+        $directory = $valetSitePath.$uri."/*";
+    }
+
+    $paths = glob($directory);
+
+    // sort and group directories at the top then files
+    usort($paths, function ($a, $b) {
+        if (is_dir($a) == is_dir($b)) {
+            return strnatcasecmp($a, $b);
+        } else {
+            return is_dir($a) ? -1 : 1;
+        }
+    });
+
+    function display_path($path, $uri)
+    {
+        $file = basename($path);
+        if ($uri == '/') {
+            return sprintf('<a href="/%s">/%s</a>', $file, $file);
+        } else {
+            return sprintf('<a href="%s">%s</a>', $uri.'/'.$file, $uri.'/'.$file);
+        }
+    }
+
+    echo implode(array_map(function ($path) use ($uri) {
+        return display_path($path, $uri);
+    }, $paths), "<br/>");
+    exit;
+}
+
+/**
  * @param $domain string Domain to filter
  *
  * @return string Filtered domain (without xip.io feature)
@@ -125,7 +166,11 @@ $frontControllerPath = $valetDriver->frontControllerPath(
 );
 
 if (! $frontControllerPath) {
-    show_valet_404();
+    if (isset($valetConfig['directory-listing']) && $valetConfig['directory-listing'] == 'on') {
+        show_directory_listing($valetSitePath, $siteName, $uri);
+    } else {
+        show_valet_404();
+    }
 }
 
 chdir(dirname($frontControllerPath));


### PR DESCRIPTION
I have created directory listing option in this Laravel Valet. This will simulate "autoindex on" option that is usually found in nginx configuration. Instead of showing 404 (file not found) error message, it can display all files & directories in site folder.

How to use:

`valet directory-listing` is to show current configuration
`valet directory-listing on` is to enable directory listing
`valet directory-listing off` is to disable directory listing
