### PR TITLE
Secure option for link command

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -93,10 +93,14 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Register a symbolic link with Valet.
      */
-    $app->command('link [name]', function ($name) {
+    $app->command('link [name] [--secure]', function ($name, $secure) {
         $linkPath = Site::link(getcwd(), $name = $name ?: basename(getcwd()));
 
         info('A ['.$name.'] symbolic link has been created in ['.$linkPath.'].');
+
+        if ($secure) {
+            $this->runCommand('secure '.$name);
+        }
     })->descriptions('Link the current working directory to Valet');
 
     /**


### PR DESCRIPTION
Added `--secure` option for `valet link` command. This can save some time when people want to link specific folder to domain and then generate certificate.