### PR TITLE
Fix contao driver never gets loaded

### DIFF
--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -54,6 +54,7 @@ abstract class ValetDriver
 
         $drivers[] = 'WordPressValetDriver';
         $drivers[] = 'BedrockValetDriver';
+        $drivers[] = 'ContaoValetDriver';
         $drivers[] = 'SymfonyValetDriver';
         $drivers[] = 'CraftValetDriver';
         $drivers[] = 'StatamicValetDriver';
@@ -62,7 +63,6 @@ abstract class ValetDriver
         $drivers[] = 'SculpinValetDriver';
         $drivers[] = 'JigsawValetDriver';
         $drivers[] = 'KirbyValetDriver';
-        $drivers[] = 'ContaoValetDriver';
         $drivers[] = 'KatanaValetDriver';
         $drivers[] = 'JoomlaValetDriver';
         $drivers[] = 'DrupalValetDriver';


### PR DESCRIPTION
Contao 4.x is a symfony bundle/application. The symfony driver is currently loaded/checked before the concrete contao driver. In result, the contao driver never gets loaded, because the local contao installation gets handled by valets symfony driver, not the contao driver.

To fix this, the contao driver should always been loaded/checked before the symfony driver (more _specialized_ driver above the _general_ symfony driver).