### PR TITLE
Improved HTTP_HOST rewriting

### DIFF
--- a/cli/drivers/LaravelValetDriver.php
+++ b/cli/drivers/LaravelValetDriver.php
@@ -54,7 +54,7 @@ class LaravelValetDriver extends ValetDriver
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
         // Shortcut for getting the "local" hostname as the HTTP_HOST
-        if (isset($_SERVER['HTTP_X_ORIGINAL_HOST']) && isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+        if (isset($_SERVER['HTTP_X_ORIGINAL_HOST'], $_SERVER['HTTP_X_FORWARDED_HOST'])) {
             $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
         }
         

--- a/cli/drivers/LaravelValetDriver.php
+++ b/cli/drivers/LaravelValetDriver.php
@@ -53,6 +53,11 @@ class LaravelValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        // Shortcut for getting the "local" hostname as the HTTP_HOST
+        if (isset($_SERVER['HTTP_X_ORIGINAL_HOST']) && isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+            $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+        }
+        
         return $sitePath.'/public/index.php';
     }
 }

--- a/cli/drivers/SymfonyValetDriver.php
+++ b/cli/drivers/SymfonyValetDriver.php
@@ -45,10 +45,6 @@ class SymfonyValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        if (isset($_SERVER['HTTP_X_ORIGINAL_HOST']) && isset($_SERVER['HTTP_X_INBOUND_HOST']) && $_SERVER['HTTP_X_ORIGINAL_HOST'] === $_SERVER['HTTP_HOST']) {
-            $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_INBOUND_HOST'];
-        }
-
         if (file_exists($frontControllerPath = $sitePath.'/web/app_dev.php')) {
             return $frontControllerPath;
         } elseif (file_exists($frontControllerPath = $sitePath.'/web/app.php')) {

--- a/cli/drivers/SymfonyValetDriver.php
+++ b/cli/drivers/SymfonyValetDriver.php
@@ -45,6 +45,10 @@ class SymfonyValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        if (isset($_SERVER['HTTP_X_ORIGINAL_HOST']) && isset($_SERVER['HTTP_X_INBOUND_HOST']) && $_SERVER['HTTP_X_ORIGINAL_HOST'] === $_SERVER['HTTP_HOST']) {
+            $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_INBOUND_HOST'];
+        }
+
         if (file_exists($frontControllerPath = $sitePath.'/web/app_dev.php')) {
             return $frontControllerPath;
         } elseif (file_exists($frontControllerPath = $sitePath.'/web/app.php')) {

--- a/server.php
+++ b/server.php
@@ -100,6 +100,14 @@ if (! $valetDriver) {
  * Overwrite the HTTP host for Ngrok.
  */
 if (isset($_SERVER['HTTP_X_ORIGINAL_HOST'])) {
+    if (!isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
+    }
+
+    // Store original HTTP_HOST so it can optionally be restored in a driver
+    $_SERVER['HTTP_X_INBOUND_HOST'] = $_SERVER['HTTP_HOST'];
+
+    // Rewrite HTTP_HOST so it contains the hostname as entered by the visitor
     $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
 }
 

--- a/server.php
+++ b/server.php
@@ -97,18 +97,10 @@ if (! $valetDriver) {
 }
 
 /**
- * Overwrite the HTTP host for Ngrok.
+ * ngrok uses the X-Original-Host to store the forwarded hostname.
  */
-if (isset($_SERVER['HTTP_X_ORIGINAL_HOST'])) {
-    if (!isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-        $_SERVER['HTTP_X_FORWARDED_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
-    }
-
-    // Store original HTTP_HOST so it can optionally be restored in a driver
-    $_SERVER['HTTP_X_INBOUND_HOST'] = $_SERVER['HTTP_HOST'];
-
-    // Rewrite HTTP_HOST so it contains the hostname as entered by the visitor
-    $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
+if (isset($_SERVER['HTTP_X_ORIGINAL_HOST']) && !isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+    $_SERVER['HTTP_X_FORWARDED_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
 }
 
 /**


### PR DESCRIPTION
See #342 - this PR changes the rewriting of the `$_SERVER['HTTP_HOST']` variable in case of an Ngrok proxy.

The default behavior for the `LaravelValetDriver` remains unchanged (restoring the original `Host` value), but other drivers will now revert to standards-compliant behavior which leaves the `Host` header as-is. The `X-Forwarded-Host` can then be used to retrieve the hostname that was entered by the visitor, i.e. the `*.ngrok.io` hostname.