### PR TITLE
Fix TinyMCE not loaded correctly using contao driver

### DIFF
--- a/cli/drivers/ContaoValetDriver.php
+++ b/cli/drivers/ContaoValetDriver.php
@@ -42,6 +42,10 @@ class ContaoValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        if ($uri === '/assets/tinymce4/js/tinymce.gzip.php') {
+            return $sitePath.'/assets/tinymce4/js/tinymce.gzip.php';
+        }
+
         if ($uri === '/install.php') {
             return $sitePath.'/web/install.php';
         }


### PR DESCRIPTION
The TinyMCE javascript is embedded using the php file [`tinymce.gzip.php`](https://github.com/contao-components/tinymce4/blob/master/js/tinymce.gzip.php). Without this fix, valet sends the request to this file through the contao/symfony routing. So, it is not the TinyMCE javascript that is returned but the html source of the index page.