### PR TITLE
Fix 128mb max client body size for secured sites.

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -9,6 +9,7 @@ server {
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
+    client_max_body_size 128M;
 
     location /VALET_STATIC_PREFIX/ {
         internal;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -2,6 +2,7 @@ server {
     listen 80 default_server;
     root /;
     charset utf-8;
+    client_max_body_size 128M;
 
     location /VALET_STATIC_PREFIX/ {
         internal;


### PR DESCRIPTION
client_max_body_size does not propagate down from the http context into
the server context.

See this stack overflow for further details on the issue:
https://stackoverflow.com/questions/2056124/nginx-client-max-body-size-has-no-effect

This fix ensures that the max client body size is always the default
128mb as specified in nginx.conf.