### PR TITLE
Fix bug where the "valet open" command ignores your default browser choice

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -185,7 +185,7 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('open [domain]', function ($domain = null) {
         $url = "http://".($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
         // Run the 'open' command as the currently logged in user instead of root
-        passthru('sudo --user=`stat -f%Su /dev/console` open ' . escapeshellarg($url));
+        CommandLine::runAsUser("open ".escapeshellarg($url));
     })->descriptions('Open the site for the current (or specified) directory in your browser');
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -184,8 +184,8 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('open [domain]', function ($domain = null) {
         $url = "http://".($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
-
-        passthru("open ".escapeshellarg($url));
+        // Run the 'open' command as the currently logged in user instead of root
+        passthru('sudo --user=`stat -f%Su /dev/console` open ' . escapeshellarg($url));
     })->descriptions('Open the site for the current (or specified) directory in your browser');
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -184,7 +184,6 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('open [domain]', function ($domain = null) {
         $url = "http://".($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
-        // Run the 'open' command as the currently logged in user instead of root
         CommandLine::runAsUser("open ".escapeshellarg($url));
     })->descriptions('Open the site for the current (or specified) directory in your browser');
 


### PR DESCRIPTION
Here we take the currently logged in user, and run the open command as that user instead of root. This ensures that your default browser choice works.

Steps to reproduce:

* cd into a directory that has a site
* Type "valet open"

Before patch:
Valet always opens Safari. The open command runs as root, so it doesn't read the local user's default browser preferences.

After patch:
Valet opens in your default browser. If that happens to be Safari still, that also works.