### PR TITLE
Statamic caching and localization support

### DIFF
--- a/cli/drivers/StatamicValetDriver.php
+++ b/cli/drivers/StatamicValetDriver.php
@@ -69,13 +69,16 @@ class StatamicValetDriver extends ValetDriver
         $sitePathPrefix = ($isAboveWebroot) ? $sitePath.'/public' : $sitePath;
 
         if ($locale = $this->getUriLocale($uri)) {
-            // Force trailing slashes on locale roots.
-            if ($uri === '/' . $locale) {
-                header('Location: ' . $uri . '/'); die;
-            }
+            if ($this->isActualFile($localeIndexPath = $sitePathPrefix . '/' . $locale . '/index.php')) {
+                // Force trailing slashes on locale roots.
+                if ($uri === '/' . $locale) {
+                    header('Location: ' . $uri . '/');
+                    die;
+                }
 
-            $indexPath = $sitePathPrefix . '/' . $locale . '/index.php';
-            $scriptName = '/' . $locale . '/index.php';
+                $indexPath = $localeIndexPath;
+                $scriptName = '/' . $locale . '/index.php';
+            }
         }
 
         $_SERVER['SCRIPT_NAME'] = $scriptName;

--- a/cli/drivers/StatamicValetDriver.php
+++ b/cli/drivers/StatamicValetDriver.php
@@ -62,9 +62,11 @@ class StatamicValetDriver extends ValetDriver
             $indexPath = $sitePath.'/index.php';
         }
 
-        if ($this->isActualFile($sitePath.'/public/index.php')) {
+        if ($isAboveWebroot = $this->isActualFile($sitePath.'/public/index.php')) {
             $indexPath = $sitePath.'/public/index.php';
         }
+
+        $sitePathPrefix = ($isAboveWebroot) ? $sitePath.'/public' : $sitePath;
 
         if ($locale = $this->getUriLocale($uri)) {
             // Force trailing slashes on locale roots.
@@ -72,12 +74,12 @@ class StatamicValetDriver extends ValetDriver
                 header('Location: ' . $uri . '/'); die;
             }
 
-            $indexPath = $sitePath . '/' . $locale . '/index.php';
+            $indexPath = $sitePathPrefix . '/' . $locale . '/index.php';
             $scriptName = '/' . $locale . '/index.php';
         }
 
         $_SERVER['SCRIPT_NAME'] = $scriptName;
-        $_SERVER['SCRIPT_FILENAME'] = $sitePath . $scriptName;
+        $_SERVER['SCRIPT_FILENAME'] = $sitePathPrefix . $scriptName;
 
         return $indexPath;
     }

--- a/cli/drivers/StatamicValetDriver.php
+++ b/cli/drivers/StatamicValetDriver.php
@@ -48,30 +48,94 @@ class StatamicValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        if (file_exists($staticPath = $sitePath.'/static'.$uri.'/index.html')) {
+        if ($this->isActualFile($staticPath = $this->getStaticPath($sitePath))) {
             return $staticPath;
-        }
-
-        $_SERVER['SCRIPT_NAME'] = '/index.php';
-
-        if (strpos($_SERVER['REQUEST_URI'], '/index.php') === 0) {
-            $_SERVER['REQUEST_URI'] = substr($_SERVER['REQUEST_URI'], 10);
-        }
-
-        if ($uri === '') {
-            $uri = '/';
         }
 
         if ($uri === '/installer.php') {
             return $sitePath.'/installer.php';
         }
 
-        if (file_exists($indexPath = $sitePath.'/index.php')) {
-            return $indexPath;
+        $scriptName = '/index.php';
+
+        if (file_exists($sitePath.'/index.php')) {
+            $indexPath = $sitePath.'/index.php';
         }
 
-        if (file_exists($indexPath = $sitePath.'/public/index.php')) {
-            return $indexPath;
+        if (file_exists($sitePath.'/public/index.php')) {
+            $indexPath = $sitePath.'/public/index.php';
         }
+
+        if ($locale = $this->getUriLocale($uri)) {
+            // Force trailing slashes on locale roots.
+            if ($uri === '/' . $locale) {
+                header('Location: ' . $uri . '/'); die;
+            }
+
+            $indexPath = $sitePath . '/' . $locale . '/index.php';
+            $scriptName = '/' . $locale . '/index.php';
+        }
+
+        $_SERVER['SCRIPT_NAME'] = $scriptName;
+        $_SERVER['SCRIPT_FILENAME'] = $sitePath . $scriptName;
+
+        return $indexPath;
+    }
+
+    /**
+     * Get the locale from this URI
+     *
+     * @param  string  $uri
+     * @return string|null
+     */
+    public function getUriLocale($uri)
+    {
+        $parts = explode('/', $uri);
+        $locale = $parts[1];
+
+        if (count($parts) < 2 || ! in_array($locale, $this->getLocales())) {
+            return;
+        }
+
+        return $locale;
+    }
+
+    /**
+     * Get the list of possible locales used in the first segment of a URI
+     *
+     * @return array
+     */
+    public function getLocales()
+    {
+        return [
+            'af', 'ax', 'al', 'dz', 'as', 'ad', 'ao', 'ai', 'aq', 'ag', 'ar', 'am', 'aw', 'au', 'at', 'az', 'bs', 'bh',
+            'bd', 'bb', 'by', 'be', 'bz', 'bj', 'bm', 'bt', 'bo', 'bq', 'ba', 'bw', 'bv', 'br', 'io', 'bn', 'bg', 'bf',
+            'bi', 'cv', 'kh', 'cm', 'ca', 'ky', 'cf', 'td', 'cl', 'cn', 'cx', 'cc', 'co', 'km', 'cg', 'cd', 'ck', 'cr',
+            'ci', 'hr', 'cu', 'cw', 'cy', 'cz', 'dk', 'dj', 'dm', 'do', 'ec', 'eg', 'sv', 'gq', 'er', 'ee', 'et', 'fk',
+            'fo', 'fj', 'fi', 'fr', 'gf', 'pf', 'tf', 'ga', 'gm', 'ge', 'de', 'gh', 'gi', 'gr', 'gl', 'gd', 'gp', 'gu',
+            'gt', 'gg', 'gn', 'gw', 'gy', 'ht', 'hm', 'va', 'hn', 'hk', 'hu', 'is', 'in', 'id', 'ir', 'iq', 'ie', 'im',
+            'il', 'it', 'jm', 'jp', 'je', 'jo', 'kz', 'ke', 'ki', 'kp', 'kr', 'kw', 'kg', 'la', 'lv', 'lb', 'ls', 'lr',
+            'ly', 'li', 'lt', 'lu', 'mo', 'mk', 'mg', 'mw', 'my', 'mv', 'ml', 'mt', 'mh', 'mq', 'mr', 'mu', 'yt', 'mx',
+            'fm', 'md', 'mc', 'mn', 'me', 'ms', 'ma', 'mz', 'mm', 'na', 'nr', 'np', 'nl', 'nc', 'nz', 'ni', 'ne', 'ng',
+            'nu', 'nf', 'mp', 'no', 'om', 'pk', 'pw', 'ps', 'pa', 'pg', 'py', 'pe', 'ph', 'pn', 'pl', 'pt', 'pr', 'qa',
+            're', 'ro', 'ru', 'rw', 'bl', 'sh', 'kn', 'lc', 'mf', 'pm', 'vc', 'ws', 'sm', 'st', 'sa', 'sn', 'rs', 'sc',
+            'sl', 'sg', 'sx', 'sk', 'si', 'sb', 'so', 'za', 'gs', 'ss', 'es', 'lk', 'sd', 'sr', 'sj', 'sz', 'se', 'ch',
+            'sy', 'tw', 'tj', 'tz', 'th', 'tl', 'tg', 'tk', 'to', 'tt', 'tn', 'tr', 'tm', 'tc', 'tv', 'ug', 'ua', 'ae',
+            'gb', 'us', 'um', 'uy', 'uz', 'vu', 've', 'vn', 'vg', 'vi', 'wf', 'eh', 'ye', 'zm', 'zw',
+        ];
+    }
+
+    /**
+     * Get the path to a statically cached page
+     *
+     * @param  string $sitePath
+     * @return string
+     */
+    protected function getStaticPath($sitePath)
+    {
+        $parts = parse_url($_SERVER['REQUEST_URI']);
+        $query = isset($parts['query']) ? $parts['query'] : '';
+
+        return $sitePath . '/static' . $parts['path'] . '_' . $query . '.html';
     }
 }

--- a/cli/drivers/StatamicValetDriver.php
+++ b/cli/drivers/StatamicValetDriver.php
@@ -58,11 +58,11 @@ class StatamicValetDriver extends ValetDriver
 
         $scriptName = '/index.php';
 
-        if (file_exists($sitePath.'/index.php')) {
+        if ($this->isActualFile($sitePath.'/index.php')) {
             $indexPath = $sitePath.'/index.php';
         }
 
-        if (file_exists($sitePath.'/public/index.php')) {
+        if ($this->isActualFile($sitePath.'/public/index.php')) {
             $indexPath = $sitePath.'/public/index.php';
         }
 


### PR DESCRIPTION
This PR provides support for the new way that statically cached files are handled in Statamic 2.6.

This also provides support for users to serve localized versions of their site in subdirectories. It uses a list of ISO3166 alpha-2 codes which covers most use cases.
eg. `mysite.dev/fr/`

For edge cases, developers can extend this driver in their `LocalValetDriver` and override `getLocales()` with the subdirectories/locales they need. They can also override `getStaticPath()` if they need static caching support for versions below 2.6.