### PR TITLE
Checks to see if file_exists *and* it's an actual file.

### DIFF
--- a/cli/drivers/LaravelValetDriver.php
+++ b/cli/drivers/LaravelValetDriver.php
@@ -26,7 +26,8 @@ class LaravelValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        if (file_exists($staticFilePath = $sitePath.'/public'.$uri)) {
+        if (file_exists($staticFilePath = $sitePath.'/public'.$uri)
+           && is_file($staticFilePath)) {
             return $staticFilePath;
         }
 


### PR DESCRIPTION
The current check short-circuits too early, allowing the existence of a folder at $uri
to trigger a false positive. This verifies that the file at $uri is actually a file before
returning.