### PR TITLE
Check if info method already exists

### DIFF
--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -12,15 +12,17 @@ define('VALET_HOME_PATH', $_SERVER['HOME'].'/.valet');
 define('VALET_SERVER_PATH', realpath(__DIR__ . '/../../server.php'));
 define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
 
-/**
- * Output the given text to the console.
- *
- * @param  string  $output
- * @return void
- */
-function info($output)
-{
-    output('<info>'.$output.'</info>');
+if (! function_exists('info')) {
+    /**
+     * Output the given text to the console.
+     *
+     * @param  string  $output
+     * @return void
+     */
+    function info($output)
+    {
+        output('<info>'.$output.'</info>');
+    }
 }
 
 /**


### PR DESCRIPTION
Clashes with https://github.com/mpociot/documentarian/blob/master/includes/helpers.php#L9-L14 when documentarian is installed via `composer global` when trying to run any global command.

Running `php-cs-fixer fix app` results in this error caused by valet.

```
→ php-cs-fixer fix app
PHP Fatal error:  Cannot redeclare info() (previously declared in /Users/Brian/.composer/vendor/mpociot/documentarian/includes/helpers.php:10) in /Users/Brian/.composer/vendor/laravel/valet/cli/includes/helpers.php on line 24

Fatal error: Cannot redeclare info() (previously declared in /Users/Brian/.composer/vendor/mpociot/documentarian/includes/helpers.php:10) in /Users/Brian/.composer/vendor/laravel/valet/cli/includes/helpers.php on line 24
```