### PR TITLE
Fixed typo: two much dots in ellipsis

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -154,7 +154,7 @@ class Nginx
      */
     function stop()
     {
-        info('Stopping nginx....');
+        info('Stopping nginx...');
 
         $this->cli->quietly('sudo brew services stop '. $this->brew->nginxServiceName());
     }


### PR DESCRIPTION
Just a little typo fix I saw : There's 4 ellipsis dots at the end of the "Stopping ngnix" string.