### PR TITLE
Add $_SERVER['DOCUMENT_ROOT'] to CraftValetDriver

### DIFF
--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -191,6 +191,7 @@ class CraftValetDriver extends ValetDriver
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
         $_SERVER['SCRIPT_NAME'] = $scriptName;
         $_SERVER['PHP_SELF'] = $scriptName;
+        $_SERVER['DOCUMENT_ROOT'] = $sitePath.'/'.$frontControllerDirectory;
 
         return $indexPath;
     }


### PR DESCRIPTION
Certain CraftCMS plugins (might) depend on the $_SERVER['DOCUMENT_ROOT'] variable being set.