### PR TITLE
Generate SHA-256 certificates

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -209,7 +209,7 @@ class Site
         $this->createSigningRequest($url, $keyPath, $csrPath, $confPath);
 
         $this->cli->runAsUser(sprintf(
-            'openssl x509 -req -days 365 -in %s -signkey %s -out %s -extensions v3_req -extfile %s',
+            'openssl x509 -req -sha256 -days 365 -in %s -signkey %s -out %s -extensions v3_req -extfile %s',
             $csrPath, $keyPath, $crtPath, $confPath
         ));
 


### PR DESCRIPTION
Generate SHA-256 certificates as SHA-1 certificates, the current default, are deprecated and support for them will quickly be dropped by major browsers as documented here: https://blog.qualys.com/ssllabs/2014/09/09/sha1-deprecation-what-you-need-to-know