### PR TITLE
Set SERVER_NAME variable for WordPress (Bedrock) driver

### DIFF
--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -48,6 +48,7 @@ class BedrockValetDriver extends BasicValetDriver
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
         $_SERVER['PHP_SELF'] = $uri;
+        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
         if (strpos($uri, '/wp/') === 0) {
             return is_dir($sitePath.'/web'.$uri)


### PR DESCRIPTION
Fix for Wordpress (Bedrock) as in #138