### PR TITLE
Fallback Site Path

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -253,36 +253,6 @@ if (is_dir(VALET_HOME_PATH)) {
             output('NO');
         }
     })->descriptions('Determine if this is the latest version of Valet');
-
-    /**
-     * Get or set the fallback site path used by Valet for uncaught urls.
-     */
-    $app->command('fallback [path]', function ($path = null) {
-        if ($path === '?') {
-            if (($config = Configuration::read()) && isset($config['fallback'])) {
-                return info($config['fallback']);
-            } else {
-                return warning('Fallback path not set.');
-            }
-        }
-
-        if ($path && !is_dir($path)) {
-            return warning('The fallback path ['.$path.'] is not a valid directory.');
-        }
-
-        Configuration::updateKey('fallback', $path ?: getcwd());
-
-        info('Your Valet fallback path has been updated to '.($path === null ? 'the current directory' : "[{$path}]").'.');
-    })->descriptions('Set the current working (or specified) directory as the fallback site path for uncaught urls');
-
-    /**
-     * Removes the fallback site path used by Valet.
-     */
-    $app->command('unfallback', function () {
-        Configuration::updateKey('fallback', null);
-
-        info('Your Valet fallback path has been removed.');
-    })->descriptions('Remove the fallback site path for uncaught urls');
 }
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -273,7 +273,7 @@ if (is_dir(VALET_HOME_PATH)) {
         Configuration::updateKey('fallback', $path ?: getcwd());
 
         info('Your Valet fallback path has been updated to '.($path === null ? 'the current directory' : "[{$path}]").'.');
-    })->descriptions('Set the current working (or specified) directory as the fallback path for uncaught urls');
+    })->descriptions('Set the current working (or specified) directory as the fallback site path for uncaught urls');
 
     /**
      * Removes the fallback site path used by Valet.
@@ -282,7 +282,7 @@ if (is_dir(VALET_HOME_PATH)) {
         Configuration::updateKey('fallback', null);
 
         info('Your Valet fallback path has been removed.');
-    })->descriptions('Remove the fallback site path used for uncaught urls');
+    })->descriptions('Remove the fallback site path for uncaught urls');
 }
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -253,6 +253,36 @@ if (is_dir(VALET_HOME_PATH)) {
             output('NO');
         }
     })->descriptions('Determine if this is the latest version of Valet');
+
+    /**
+     * Get or set the fallback site path used by Valet for uncaught urls.
+     */
+    $app->command('fallback [path]', function ($path = null) {
+        if ($path === '?') {
+            if (($config = Configuration::read()) && isset($config['fallback'])) {
+                return info($config['fallback']);
+            } else {
+                return warning('Fallback path not set.');
+            }
+        }
+
+        if ($path && !is_dir($path)) {
+            return warning('The fallback path ['.$path.'] is not a valid directory.');
+        }
+
+        Configuration::updateKey('fallback', $path ?: getcwd());
+
+        info('Your Valet fallback path has been updated to '.($path === null ? 'the current directory' : "[{$path}]").'.');
+    })->descriptions('Set the current working (or specified) directory as the fallback path for uncaught urls');
+
+    /**
+     * Removes the fallback site path used by Valet.
+     */
+    $app->command('unfallback', function () {
+        Configuration::updateKey('fallback', null);
+
+        info('Your Valet fallback path has been removed.');
+    })->descriptions('Remove the fallback site path used for uncaught urls');
 }
 
 /**

--- a/server.php
+++ b/server.php
@@ -36,6 +36,20 @@ function valet_support_xip_io($domain)
 }
 
 /**
+ * @param array $config Valet configuration array
+ *
+ * @return string|null If set, fallback site path for uncaught urls
+ * */
+function valet_fallback_site_path($config)
+{
+    if (isset($config['fallback']) && is_string($config['fallback']) && is_dir($config['fallback'])) {
+        return $config['fallback'];
+    }
+
+    return null;
+}
+
+/**
  * Load the Valet configuration.
  */
 $valetConfig = json_decode(
@@ -77,7 +91,7 @@ foreach ($valetConfig['paths'] as $path) {
     }
 }
 
-if (is_null($valetSitePath)) {
+if (is_null($valetSitePath) && is_null($valetSitePath = valet_fallback_site_path($valetConfig))) {
     show_valet_404();
 }
 

--- a/server.php
+++ b/server.php
@@ -38,12 +38,12 @@ function valet_support_xip_io($domain)
 /**
  * @param array $config Valet configuration array
  *
- * @return string|null If set, fallback site path for uncaught urls
+ * @return string|null If set, default site path for uncaught urls
  * */
-function valet_fallback_site_path($config)
+function valet_default_site_path($config)
 {
-    if (isset($config['fallback']) && is_string($config['fallback']) && is_dir($config['fallback'])) {
-        return $config['fallback'];
+    if (isset($config['default']) && is_string($config['default']) && is_dir($config['default'])) {
+        return $config['default'];
     }
 
     return null;
@@ -91,7 +91,7 @@ foreach ($valetConfig['paths'] as $path) {
     }
 }
 
-if (is_null($valetSitePath) && is_null($valetSitePath = valet_fallback_site_path($valetConfig))) {
+if (is_null($valetSitePath) && is_null($valetSitePath = valet_default_site_path($valetConfig))) {
     show_valet_404();
 }
 


### PR DESCRIPTION
This PR optionally enables a fallback site path for uncaught urls.

It adds a "fallback" command to the CLI:

![fallback](https://user-images.githubusercontent.com/1914481/30695241-d7a7626c-9f1a-11e7-8980-ba28b5766e09.png)

It also adds the inverse command, "unfallback":

![unfallback](https://user-images.githubusercontent.com/1914481/30695252-ddd07444-9f1a-11e7-9d2e-8068737ab73e.png)

Example use case…

I'm developing a site locally on my Mac and I want to view it on my mobile device which is connected to the same LAN. I could run `valet share` from my site's local directory, but because ngrok is painfully slow where I live & work, I run `valet fallback` instead:

![updated](https://user-images.githubusercontent.com/1914481/30695273-f2633842-9f1a-11e7-99f6-0f13714f6a11.png)

On my mobile device, I enter my Mac's LAN IP address and I am now viewing the site I was developing on my Mac. Yay! When I'm done, I run `valet unfallback` (or `valet unfall` because it sounds cooler) and the site I'm developing is no longer viewable by my mobile device:

![removed](https://user-images.githubusercontent.com/1914481/30695276-f6a22abc-9f1a-11e7-9e7f-4ed51abddf18.png)
  
Closes #440