### PR TITLE
Add en to locales

### DIFF
--- a/cli/drivers/StatamicValetDriver.php
+++ b/cli/drivers/StatamicValetDriver.php
@@ -126,7 +126,7 @@ class StatamicValetDriver extends ValetDriver
             're', 'ro', 'ru', 'rw', 'bl', 'sh', 'kn', 'lc', 'mf', 'pm', 'vc', 'ws', 'sm', 'st', 'sa', 'sn', 'rs', 'sc',
             'sl', 'sg', 'sx', 'sk', 'si', 'sb', 'so', 'za', 'gs', 'ss', 'es', 'lk', 'sd', 'sr', 'sj', 'sz', 'se', 'ch',
             'sy', 'tw', 'tj', 'tz', 'th', 'tl', 'tg', 'tk', 'to', 'tt', 'tn', 'tr', 'tm', 'tc', 'tv', 'ug', 'ua', 'ae',
-            'gb', 'us', 'um', 'uy', 'uz', 'vu', 've', 'vn', 'vg', 'vi', 'wf', 'eh', 'ye', 'zm', 'zw',
+            'gb', 'us', 'um', 'uy', 'uz', 'vu', 've', 'vn', 'vg', 'vi', 'wf', 'eh', 'ye', 'zm', 'zw', 'en',
         ];
     }
 


### PR DESCRIPTION
In my [previous PR](https://github.com/laravel/valet/pull/401), I added all the ISO3166 alpha-2 codes, which doesn't include `en`. You can also override the `getLocales` method in a LocalValetDriver if you need to add exceptions.

But, there a ton of people that like to use `en` if they don't use English by default. This PR just adds it to the list because its super common.