### PR TITLE
Drupal 8 autocomplete

### DIFF
--- a/cli/drivers/DrupalValetDriver.php
+++ b/cli/drivers/DrupalValetDriver.php
@@ -51,7 +51,7 @@ class DrupalValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        if (!empty($uri) && $uri !== '/') {
+        if (!isset($_GET['q']) && !empty($uri) && $uri !== '/') {
           $_GET['q'] = $uri;
         }
 


### PR DESCRIPTION
Drupal 8 uses q in $_GET for autocomplete args, it shouldn't always be overwritten with uri if q is already set.

Issue #455

Fixes #455
  