### PR TITLE
Silver Stripe valet driver

### DIFF
--- a/cli/drivers/SilverStripeValetDriver.php
+++ b/cli/drivers/SilverStripeValetDriver.php
@@ -1,0 +1,65 @@
+<?php
+
+class SilverStripeValetDriver extends ValetDriver
+{
+    /**
+     * Determine if the driver serves the request.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return bool
+     */
+    public function serves($sitePath, $siteName, $uri)
+    {
+        if (file_exists($sitePath.'/cms') && file_exists($sitePath.'/framework')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the incoming request is for a static file.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string|false
+     */
+    public function isStaticFile($sitePath, $siteName, $uri)
+    {
+        if (file_exists($sitePath.$uri) &&
+            ! is_dir($sitePath.$uri) &&
+            pathinfo($sitePath.$uri)['extension'] != 'php') {
+            return $sitePath.$uri;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        if (file_exists($sitePath.$uri) && ! is_dir($sitePath.$uri)) {
+            return $sitePath.$uri;
+        }
+
+        $_SERVER['PHP_SELF'] = '/framework/main.php';
+        $_SERVER['SCRIPT_NAME'] = '/framework/main.php';
+        $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/framework/main.php';
+        $_SERVER['QUERY_STRING'] = 'url='.$uri;
+        $_SERVER['DOCUMENT_URI'] = $uri;
+        $_SERVER['DOCUMENT_ROOT'] = $sitePath;
+        $_GET['url'] = $uri;
+
+        return $sitePath.'/framework/main.php';
+    }
+}

--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -70,6 +70,7 @@ abstract class ValetDriver
         $drivers[] = 'Typo3ValetDriver';
         $drivers[] = 'NeosValetDriver';
         $drivers[] = 'Magento2ValetDriver';
+        $drivers[] = 'SilverStripeValetDriver';
 
         $drivers[] = 'BasicValetDriver';
 

--- a/cli/drivers/require.php
+++ b/cli/drivers/require.php
@@ -28,3 +28,4 @@ require_once __DIR__.'/Concrete5ValetDriver.php';
 require_once __DIR__.'/Typo3ValetDriver.php';
 require_once __DIR__.'/NeosValetDriver.php';
 require_once __DIR__.'/Magento2ValetDriver.php';
+require_once __DIR__.'/SilverStripeValetDriver.php';

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -20,6 +20,8 @@ server {
     error_page 404 VALET_SERVER_PATH;
 
     location ~ \.php$ {
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:VALET_HOME_PATH/valet.sock;
         fastcgi_index VALET_SERVER_PATH;


### PR DESCRIPTION
This is for the SilverStripe CMS, the biggest change in this that is off putting would be the buffer size modification to the nginx config in valet.conf which increases the buffer size above the default values, from my understanding this shouldn't effect any existing applications but is required for the silver stripe admin to work. 

An alternative if we don't want to modify the valet.conf would be to add a "Drivers" resource doc and link to various drivers for valet so that people can easily find and install them