### PR TITLE
Enable support for modern Sculpin projects.

### DIFF
--- a/cli/drivers/SculpinValetDriver.php
+++ b/cli/drivers/SculpinValetDriver.php
@@ -18,12 +18,30 @@ class SculpinValetDriver extends BasicValetDriver
 
     private function isModernSculpinProject($sitePath)
     {
-        return is_dir($sitePath.'/source') && is_dir($sitePath.'/output_dev');
+        return is_dir($sitePath.'/source') &&
+            is_dir($sitePath.'/output_dev') &&
+            $this->composerRequiresSculpin($sitePath);
     }
 
     private function isLegacySculpinProject($sitePath)
     {
         return is_dir($sitePath.'/.sculpin');
+    }
+
+    private function composerRequiresSculpin($sitePath)
+    {
+        if (! file_exists($sitePath.'/composer.json')) {
+            return false;
+        }
+
+        $composer_json_source = file_get_contents($sitePath.'/composer.json');
+        $composer_json = json_decode($composer_json_source, true);
+
+        if (json_last_error() != JSON_ERROR_NONE) {
+            return false;
+        }
+
+        return isset($composer_json['require']['sculpin/sculpin']);
     }
 
     /**

--- a/cli/drivers/SculpinValetDriver.php
+++ b/cli/drivers/SculpinValetDriver.php
@@ -12,6 +12,17 @@ class SculpinValetDriver extends BasicValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
+        return $this->isModernSculpinProject($sitePath) ||
+            $this->isLegacySculpinProject($sitePath);
+    }
+
+    private function isModernSculpinProject($sitePath)
+    {
+        return is_dir($sitePath.'/source') && is_dir($sitePath.'/output_dev');
+    }
+
+    private function isLegacySculpinProject($sitePath)
+    {
         return is_dir($sitePath.'/.sculpin');
     }
 

--- a/cli/drivers/SculpinValetDriver.php
+++ b/cli/drivers/SculpinValetDriver.php
@@ -37,7 +37,7 @@ class SculpinValetDriver extends BasicValetDriver
         $composer_json_source = file_get_contents($sitePath.'/composer.json');
         $composer_json = json_decode($composer_json_source, true);
 
-        if (json_last_error() != JSON_ERROR_NONE) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             return false;
         }
 


### PR DESCRIPTION
Modern Sculpin sites are closer to regular PHP projects. They use Sculpin as a dependency. They usually have a `source` directory so if `source` and `output_dev` both exist, there is a good chance it is a Sculpin project.

If you'd prefer changing how this is handled, let me know! I'm happy to change it. :)