### PR TITLE
Support for Magento Commerce (Cloud) applications that rely on DOCUMENT_ROOT

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -144,8 +144,10 @@ class Magento2ValetDriver extends ValetDriver
         $this->checkMageMode($sitePath);
 
         if ('developer' === $this->mageMode) {
+            $_SERVER['DOCUMENT_ROOT'] = $sitePath;
             return $sitePath . '/index.php';
         }
+        $_SERVER['DOCUMENT_ROOT'] = $sitePath . '/pub';
         return $sitePath . '/pub/index.php';
     }
 }


### PR DESCRIPTION
Was getting the following:

```
a:4:{i:0;s:38:"DOCUMENT_ROOT variable is unavailable.";i:1;s:1058:"#0 /Users/simensen/Code/magento-cloud-blackfire-example/vendor/magento/framework/App/Http.php(181): Magento\Framework\App\SetupInfo->__construct(Array)
#1 /Users/simensen/Code/magento-cloud-blackfire-example/vendor/magento/framework/App/Http.php(213): Magento\Framework\App\Http->redirectToSetup(Object(Magento\Framework\App\Bootstrap), Object(Exception))
#2 /Users/simensen/Code/magento-cloud-blackfire-example/vendor/magento/framework/App/Http.php(137): Magento\Framework\App\Http->handleBootstrapErrors(Object(Magento\Framework\App\Bootstrap), Object(InvalidArgumentException))
#3 /Users/simensen/Code/magento-cloud-blackfire-example/vendor/magento/framework/App/Bootstrap.php(263): Magento\Framework\App\Http->catchException(Object(Magento\Framework\App\Bootstrap), Object(InvalidArgumentException))
#4 /Users/simensen/Code/magento-cloud-blackfire-example/pub/index.php(37): Magento\Framework\App\Bootstrap->run(Object(Magento\Framework\App\Http))
#5 /Users/simensen/.composer/vendor/laravel/valet/server.php(133): require('/Users/simensen...')
#6 {main}";s:3:"url";s:1:"/";s:11:"script_name";s:57:"/Users/simensen/.composer/vendor/laravel/valet/server.php";}
```