### PR TITLE
Stop taking over whole TLDs and allow subdomains

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -110,9 +110,13 @@ class Configuration
      */
     function writeBaseConfiguration()
     {
-        if (! $this->files->exists($this->path())) {
-            $this->write(['domain' => 'test', 'paths' => []]);
-        }
+        $this->updateKey('tld', $this->get('tld', 'test'));
+
+        $this->updateKey('subdomain', $this->get('subdomain', null));
+
+        $this->updateKey('park_tld', $this->get('park_tld', null));
+
+        $this->updateKey('paths', $this->get('paths', [VALET_HOME_PATH.'/Sites']));
     }
 
     /**
@@ -222,5 +226,21 @@ class Configuration
     function path()
     {
         return VALET_HOME_PATH.'/config.json';
+    }
+
+    /**
+     * Get a configuration item.
+     *
+     * @param string $key
+     * @param mixed|null $default
+     * @return string
+     */
+    function get($key, $default = null)
+    {
+        $configuration = $this->read();
+
+        return isset($configuration[$key]) && !empty($configuration[$key])
+            ? $configuration[$key]
+            : $default;
     }
 }

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -130,9 +130,11 @@ class Nginx
      */
     function rewriteSecureNginxFiles()
     {
-        $domain = $this->configuration->read()['domain'];
+        $tld = $this->configuration->get('tld');
 
-        $this->site->resecureForNewDomain($domain, $domain);
+        $subdomain = $this->configuration->get('subdomain');
+
+        $this->site->resecureForNewDomain($tld, $subdomain, $tld, $subdomain);
     }
 
     /**

--- a/server.php
+++ b/server.php
@@ -49,10 +49,11 @@ $uri = urldecode(
     explode("?", $_SERVER['REQUEST_URI'])[0]
 );
 
-$siteName = basename(
+$siteName = preg_replace(
+    "/^({$valetConfig['subdomain']}\.)?(.+)(\.({$valetConfig['tld']}|{$valetConfig['park_tld']}))$/",
+    "$2",
     // Filter host to support wildcard dns feature
-    valet_support_wildcard_dns($_SERVER['HTTP_HOST']),
-    '.'.$valetConfig['domain']
+    valet_support_wildcard_dns($_SERVER['HTTP_HOST'])
 );
 
 if (strpos($siteName, 'www.') === 0) {

--- a/tests/NginxTest.php
+++ b/tests/NginxTest.php
@@ -76,15 +76,19 @@ class NginxTest extends PHPUnit_Framework_TestCase
         $files->shouldReceive('isDir')->with(VALET_HOME_PATH.'/Nginx')->andReturn(false);
         $files->shouldReceive('mkdirAsUser')->with(VALET_HOME_PATH.'/Nginx')->once();
         $files->shouldReceive('putAsUser')->with(VALET_HOME_PATH.'/Nginx/.keep', "\n")->once();
+        $config = Mockery::mock(Configuration::class.'[get]', [$files]);
+
+        $config->shouldReceive('get')->with('tld')->andReturn('test');
+        $config->shouldReceive('get')->with('subdomain')->andReturn('dev');
 
         swap(Filesystem::class, $files);
-        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['domain' => 'test']]));
+        swap(Configuration::class, $config);
         swap(Site::class, $site = Mockery::spy(Site::class));
 
         $nginx = resolve(Nginx::class);
         $nginx->installNginxDirectory();
 
-        $site->shouldHaveReceived('resecureForNewDomain', ['test', 'test']);
+        $site->shouldHaveReceived('resecureForNewDomain', ['test', 'dev', 'test', 'dev']);
     }
 
 }


### PR DESCRIPTION
This PR will provide some benefits:

#### Stop taking over whole TLDs

Currently if you do `valet domain com`, you won't be able to access any `.com` domains anymore. I prefer (for a number of reasons) using "real" domain names on my local development environment. This PR makes Valet create one resolver for each site domain in /etc/resolver:

![image](https://user-images.githubusercontent.com/3182864/33995619-a2d9a3b4-e0c5-11e7-9871-6efb202a217c.png)

#### Allow developers to use domains browsers actually understand as Internet domains: `.com`, `.io`, `.org`

If you type `anything.test` on Chrome you will probably be redirected to the search page, to go to the address you have to add the scheme (http://) or a slash (/) at the end of the domain name, but you don't need to do that if you type `anything.com` or `anything.io`, either you're going to hit a page or receive a 'domain not resolved' error message.

#### Add an optional subdomain to domains

When developing a site (**`www.parlamento-juvenil.rj.gov.br`**), people may like to look at something different (`parlamentojuvenil.test`), but I prefer to use the exact domain name I will use in production, within the subdomain `dev.` (**`dev.parlamento-juvenil.rj.gov.br`**). This PR allows users to configure a subdomain:

```
valet domain com dev
```
#### Change/Add configuration items

`domain` is now `tld` (defaulting to `test`) and `subdomain`, of course, was added, but defaults to `null`

``` json
{
    "paths": [
        "/Users/antoniocarlosribeiro/.valet/Sites",
        "/Users/antoniocarlosribeiro/code"
    ],
    "park_tld": "test",
    "tld": "com",
    "subdomain": "dev"
}
```

#### Valet Park

Will keep working the exact same way, taking over a whole top level domain, but it should be informed when parking:

```
valet park test ~/code
```
