### PR TITLE
Add multi domain support

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -160,7 +160,7 @@ class Configuration
     {
         $this->write(tap($this->read(), function (&$config) use ($path) {
             $config['paths'] = collect($config['paths'])->reject(function ($value) use ($path) {
-                return $value === $path;
+                return is_array($value) ? ($value['path'] === $path) : ($value === $path);
             })->values()->all();
         }));
     }

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -122,12 +122,20 @@ class Configuration
      * @param  bool  $prepend
      * @return void
      */
-    function addPath($path, $prepend = false)
+    function addPath($path, $prepend = false, $domain = null)
     {
+        if (! is_null($domain)) {
+            $path = [
+                'domain' => $domain,
+                'path' => $path
+            ];
+        }
         $this->write(tap($this->read(), function (&$config) use ($path, $prepend) {
             $method = $prepend ? 'prepend' : 'push';
 
-            $config['paths'] = collect($config['paths'])->{$method}($path)->unique()->all();
+            $config['paths'] = collect($config['paths'])->{$method}($path)->reverse()->unique(function ($item) {
+                return is_array($item) ? $item['path'] : $item;
+            })->reverse()->values()->all();
         }));
     }
 

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -178,6 +178,7 @@ class Configuration
 
         $this->write(tap($this->read(), function (&$config) {
             $config['paths'] = collect($config['paths'])->filter(function ($path) {
+                $path = is_array($path) ? $path['path'] : $path;
                 return $this->files->isDir($path);
             })->values()->all();
         }));

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -78,7 +78,7 @@ class DnsMasq
         $listen = 'listen-address=127.0.0.1';
         $lines = collect(explode(PHP_EOL, $this->files->get($this->customConfigPath())))->filter()->reject(function ($line) use ($listen) {
             return $line === $listen;
-        })->all();
+        })->unique()->all();
         $lines[] = $listen;
 
         $this->files->putAsUser($this->customConfigPath(), implode(PHP_EOL, $lines) . PHP_EOL);

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -168,6 +168,7 @@ class DnsMasq
         if ($paths->isNotEmpty()) {
             $this->appendListenAddressToConfigFile();
         }
+        $this->brew->restartService('dnsmasq');
     }
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -99,6 +99,7 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('forget [path]', function ($path = null) {
         Configuration::removePath($path ?: getcwd());
+        DnsMasq::updateCustomPathDomains();
 
         info(($path === null ? "This" : "The [{$path}]") . " directory has been removed from Valet's paths.");
     })->descriptions('Remove the current working (or specified) directory from Valet\'s list of paths');

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -74,11 +74,12 @@ if (is_dir(VALET_HOME_PATH)) {
 
     /**
      * Add the current working directory to the paths configuration.
+     * If a custom domain is specified, use this for this path.
      */
-    $app->command('park [path]', function ($path = null) {
-        Configuration::addPath($path ?: getcwd());
+    $app->command('park [path] [domain]', function ($path = null, $domain = null) {
+        Configuration::addPath($path ?: getcwd(), false, $domain);
 
-        info(($path === null ? "This" : "The [{$path}]") . " directory has been added to Valet's paths.");
+        info(($path === null ? "This" : "The [{$path}]") . " directory has been added to Valet's paths" . ($domain === null ? "." : " using domain [{$domain}]"));
     })->descriptions('Register the current working (or specified) directory with Valet');
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -187,10 +187,16 @@ if (is_dir(VALET_HOME_PATH)) {
      * Display all of the registered paths.
      */
     $app->command('paths', function () {
-        $paths = Configuration::read()['paths'];
+        $paths = collect(Configuration::read()['paths']);
+        $domain = Configuration::read()['domain'];
 
         if (count($paths) > 0) {
-            output(json_encode($paths, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            table(['Path', 'Domain'], $paths->map(function ($path) use ($domain) {
+                return [
+                    is_array($path) ? $path['path'] : $path,
+                    '.' . (is_array($path) ? $path['domain'] : $domain)
+                ];
+            })->all());
         } else {
             info('No paths have been registered.');
         }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -78,6 +78,7 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('park [path] [domain]', function ($path = null, $domain = null) {
         Configuration::addPath($path ?: getcwd(), false, $domain);
+        DnsMasq::updateCustomPathDomains();
 
         info(($path === null ? "This" : "The [{$path}]") . " directory has been added to Valet's paths" . ($domain === null ? "." : " using domain [{$domain}]"));
     })->descriptions('Register the current working (or specified) directory with Valet');

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -87,7 +87,7 @@ if (is_dir(VALET_HOME_PATH)) {
      * Add the current working directory to the paths configuration.
      * If a custom domain is specified, use this for this path.
      */
-    $app->command('park [path] [domain]', function ($path = null, $domain = null) {
+    $app->command('park [path] [--domain=]', function ($path = null, $domain = null) {
         Configuration::addPath($path ?: getcwd(), false, $domain);
         DnsMasq::updateCustomPathDomains();
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -185,7 +185,13 @@ if (is_dir(VALET_HOME_PATH)) {
      * Open the current or given directory in the browser.
      */
     $app->command('open [domain]', function ($domain = null) {
-        $url = "http://".($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
+        $domain = ($domain ?: Site::host(getcwd()));
+
+        $tld = data_get(collect(Configuration::read()['paths'])->filter(function ($path) use ($domain) {
+            return is_array($path) && $path['path'].'/'.$domain === getcwd();
+        })->first(), 'domain', Configuration::read()['domain']);
+
+        $url = "http://".$domain.'.'.$tld;
         CommandLine::runAsUser("open ".escapeshellarg($url));
     })->descriptions('Open the site for the current (or specified) directory in your browser');
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -52,19 +52,112 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
+            'domain' => 'test',
             'paths' => ['path-1', 'path-2'],
         ]);
         $config->shouldReceive('write')->with([
+            'domain' => 'test',
             'paths' => ['path-1', 'path-2', 'path-3'],
         ]);
         $config->addPath('path-3');
 
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
+            'domain' => 'test',
             'paths' => ['path-1', 'path-2', 'path-3'],
         ]);
         $config->shouldReceive('write')->with([
+            'domain' => 'test',
             'paths' => ['path-1', 'path-2', 'path-3'],
+        ]);
+        $config->addPath('path-3');
+    }
+
+    public function test_add_path_accepts_a_custom_domain_name()
+    {
+        $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
+        $config->shouldReceive('read')->andReturn([
+            'domain' => 'test',
+            'paths' => ['path-1', 'path-2'],
+        ]);
+        $config->shouldReceive('write')->with([
+            'domain' => 'test',
+            'paths' => [
+                'path-1',
+                'path-2',
+                [
+                    'domain' => 'custom',
+                    'path' => 'path-3'
+                ]
+            ],
+        ]);
+        $config->addPath('path-3', false, 'custom');
+
+        $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
+        $config->shouldReceive('read')->andReturn([
+            'domain' => 'test',
+            'paths' => [
+                'path-1',
+                'path-2',
+                [
+                    'domain' => 'custom',
+                    'path' => 'path-3'
+                ]
+            ],
+        ]);
+        $config->shouldReceive('write')->with([
+            'domain' => 'test',
+            'paths' => [
+                'path-1',
+                'path-2',
+                [
+                    'domain' => 'valet',
+                    'path' => 'path-3'
+                ]
+            ],
+        ]);
+        $config->addPath('path-3', false, 'valet');
+    }
+
+    public function test_add_path_with_custom_domain_converts_existing_paths()
+    {
+        $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
+        $config->shouldReceive('read')->andReturn([
+            'domain' => 'test',
+            'paths' => ['path-1', 'path-2', 'path-3'],
+        ]);
+        $config->shouldReceive('write')->with([
+            'domain' => 'test',
+            'paths' => [
+                'path-1',
+                'path-2',
+                [
+                    'domain' => 'custom',
+                    'path' => 'path-3'
+                ]
+            ],
+        ]);
+        $config->addPath('path-3', false, 'custom');
+
+        $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
+        $config->shouldReceive('read')->andReturn([
+            'domain' => 'test',
+            'paths' => [
+                'path-1',
+                'path-2',
+                [
+                    'domain' => 'custom',
+                    'path' => 'path-3'
+                ]
+            ],
+        ]);
+        $config->shouldReceive('write')->with([
+            'domain' => 'test',
+            'paths' => [
+                'path-1',
+                'path-2',
+                'path-3'
+            ],
         ]);
         $config->addPath('path-3');
     }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -189,9 +189,17 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $files->shouldReceive('exists')->with(VALET_HOME_PATH.'/config.json')->andReturn(true);
         $files->shouldReceive('isDir')->with('path-1')->andReturn(true);
         $files->shouldReceive('isDir')->with('path-2')->andReturn(false);
+        $files->shouldReceive('isDir')->with('path-3')->andReturn(false);
         $config = Mockery::mock(Configuration::class.'[read,write]', [$files]);
         $config->shouldReceive('read')->andReturn([
-            'paths' => ['path-1', 'path-2'],
+            'paths' => [
+                'path-1', 
+                'path-2',
+                [
+                    'domain' => 'custom',
+                    'path' => 'path-3'
+                ]
+            ],
         ]);
         $config->shouldReceive('write')->with([
             'paths' => ['path-1'],

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -52,22 +52,18 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
-            'domain' => 'test',
             'paths' => ['path-1', 'path-2'],
         ]);
         $config->shouldReceive('write')->with([
-            'domain' => 'test',
             'paths' => ['path-1', 'path-2', 'path-3'],
         ]);
         $config->addPath('path-3');
 
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
-            'domain' => 'test',
             'paths' => ['path-1', 'path-2', 'path-3'],
         ]);
         $config->shouldReceive('write')->with([
-            'domain' => 'test',
             'paths' => ['path-1', 'path-2', 'path-3'],
         ]);
         $config->addPath('path-3');
@@ -77,11 +73,9 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
-            'domain' => 'test',
             'paths' => ['path-1', 'path-2'],
         ]);
         $config->shouldReceive('write')->with([
-            'domain' => 'test',
             'paths' => [
                 'path-1',
                 'path-2',
@@ -95,7 +89,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
-            'domain' => 'test',
             'paths' => [
                 'path-1',
                 'path-2',
@@ -106,7 +99,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
             ],
         ]);
         $config->shouldReceive('write')->with([
-            'domain' => 'test',
             'paths' => [
                 'path-1',
                 'path-2',
@@ -123,11 +115,9 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
-            'domain' => 'test',
             'paths' => ['path-1', 'path-2', 'path-3'],
         ]);
         $config->shouldReceive('write')->with([
-            'domain' => 'test',
             'paths' => [
                 'path-1',
                 'path-2',
@@ -141,7 +131,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
-            'domain' => 'test',
             'paths' => [
                 'path-1',
                 'path-2',
@@ -152,7 +141,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
             ],
         ]);
         $config->shouldReceive('write')->with([
-            'domain' => 'test',
             'paths' => [
                 'path-1',
                 'path-2',
@@ -168,6 +156,24 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
         $config->shouldReceive('read')->andReturn([
             'paths' => ['path-1', 'path-2'],
+        ]);
+        $config->shouldReceive('write')->with([
+            'paths' => ['path-1'],
+        ]);
+        $config->removePath('path-2');
+    }
+
+    public function test_paths_with_custom_domain_may_be_removed_from_the_configuration()
+    {
+        $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
+        $config->shouldReceive('read')->andReturn([
+            'paths' => [
+                'path-1',
+                [
+                    'domain' => 'custom',
+                    'path' => 'path-2'
+                ]
+            ],
         ]);
         $config->shouldReceive('write')->with([
             'paths' => ['path-1'],

--- a/tests/DnsMasqTest.php
+++ b/tests/DnsMasqTest.php
@@ -124,6 +124,7 @@ conf-file='.__DIR__.'/output/custom-dnsmasq.conf
 
         $dnsMasq->updateCustomPathDomains();
 
+        $this->assertSame('nameserver 127.0.0.1'.PHP_EOL, file_get_contents(__DIR__.'/output/resolver/test'));
         $this->assertSame('nameserver 127.0.0.1'.PHP_EOL, file_get_contents(__DIR__.'/output/resolver/example'));
         $this->assertSame('nameserver 127.0.0.1'.PHP_EOL, file_get_contents(__DIR__.'/output/resolver/custom'));
         $this->assertSame('address=/.test/127.0.0.1'.PHP_EOL.'address=/.example/127.0.0.1'.PHP_EOL.'address=/.custom/127.0.0.1'.PHP_EOL.'listen-address=127.0.0.1'.PHP_EOL, file_get_contents(__DIR__.'/output/custom-dnsmasq.conf'));

--- a/tests/DnsMasqTest.php
+++ b/tests/DnsMasqTest.php
@@ -56,7 +56,8 @@ conf-file='.__DIR__.'/output/custom-dnsmasq.conf
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('quietly')->with('rm /etc/resolver/old');
         swap(Configuration::class, Mockery::spy(Configuration::class));
-        $dnsMasq = Mockery::mock(DnsMasq::class.'[install]', [resolve(Brew::class), $cli, new Filesystem, resolve(Configuration::class)]);
+        $dnsMasq = Mockery::mock(DnsMasq::class.'[install, updateCustomPathDomains]', [resolve(Brew::class), $cli, new Filesystem, resolve(Configuration::class)]);
+        $dnsMasq->shouldReceive('updateCustomPathDomains');
         $dnsMasq->shouldReceive('install')->with('new');
         $dnsMasq->updateDomain('old', 'new');
     }
@@ -64,6 +65,9 @@ conf-file='.__DIR__.'/output/custom-dnsmasq.conf
 
     public function test_update_custom_path_domains_creates_config_files()
     {
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('restartService')->once()->with('dnsmasq');
+        swap(Brew::class, $brew);
         swap(Configuration::class, $config = Mockery::spy(Configuration::class, [
             'read' => [
                 'paths' => [
@@ -97,7 +101,7 @@ conf-file='.__DIR__.'/output/custom-dnsmasq.conf
     {
         $brew = Mockery::mock(Brew::class);
         $brew->shouldReceive('ensureInstalled')->once()->with('dnsmasq');
-        $brew->shouldReceive('restartService')->once()->with('dnsmasq');
+        $brew->shouldReceive('restartService')->twice()->with('dnsmasq');
         swap(Brew::class, $brew);
         swap(Configuration::class, $config = Mockery::spy(Configuration::class, [
             'read' => [


### PR DESCRIPTION
### Multi Domain Support

This PR adds the ability to use different TLDs for individual paths.

Imagine you have the following folder structure:

```
~/Code
~/Projects
~/SecretStuff
```

With the current Valet functionality, when parking these paths, they will all be available at the `.test` domain.

When this PR gets merged, you can specify custom domains for these paths using the `park` command as you're used to:

```bash
$ ~/Project> valet park --domain=projects
```

This will add the appropriate DnsMasq entry to the configuration file and allows you to access all projects inside of your `~/Project` directory at the `.projects` domain.
When trying to access the project using the default `.test` domain, Valet will show a 404 error.

This PR adds this multi domain support to these commands:

```bash
valet park
valet forget
valet secure
valet unsecure
valet open
```

In addition, I extended the `valet paths` command to display a table with the path and the domain that will be used for it.

This PR is fully backward compatible, as this change only affects paths that make use of this new feature.