### PR TITLE
Remove duplicated forceTrailingSlash

### DIFF
--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -1,6 +1,6 @@
 <?php
 
-class BedrockValetDriver extends BasicValetDriver
+class BedrockValetDriver extends WordPressValetDriver
 {
     /**
      * Determine if the driver serves the request.
@@ -57,20 +57,5 @@ class BedrockValetDriver extends BasicValetDriver
         }
 
         return $sitePath.'/web/index.php';
-    }
-
-    /**
-     * Redirect to uri with trailing slash.
-     *
-     * @param  string $uri
-     * @return string
-     */
-    private function forceTrailingSlash($uri)
-    {
-        if (substr($uri, -1 * strlen('/wp/wp-admin')) == '/wp/wp-admin') {
-            header('Location: '.$uri.'/'); die;
-        }
-
-        return $uri;
     }
 }

--- a/cli/drivers/WordPressValetDriver.php
+++ b/cli/drivers/WordPressValetDriver.php
@@ -40,7 +40,7 @@ class WordPressValetDriver extends BasicValetDriver
      * @param  string $uri
      * @return string
      */
-    private function forceTrailingSlash($uri)
+    protected function forceTrailingSlash($uri)
     {
         if (substr($uri, -1 * strlen('/wp-admin')) == '/wp-admin') {
             header('Location: '.$uri.'/'); die;


### PR DESCRIPTION
This pull request makes the Bedrock driver extend the WordPress driver. This way we don't have to redefine the `forceTrailingSlash` method.