### PR TITLE
Fix valet doesn't recognize PHP version correctly

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -40,7 +40,7 @@ class Brew
      */
     function hasInstalledPhp()
     {
-        return $this->supportedPhpVersions()->contains(function ($version) {
+        return $this->supportedPhpVersions()->contains(function ($index, $version) {
             return $this->installed($version);
         });
     }


### PR DESCRIPTION
Valet loops over supported PHP versions, but passes index of the array instead of version which makes it think PHP is installed although it is a fresh installation.