### PR TITLE
Update valet links command to parse out https for non-.dev domains

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -85,7 +85,7 @@ class Site
         return collect($this->files->scanDir($path))->filter(function ($value, $key) {
             return ends_with($value, '.crt');
         })->map(function ($cert) {
-            return substr($cert, 0, -8);
+            return substr($cert, 0, strripos($cert, '.', -4));
         })->flip();
     }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -85,7 +85,7 @@ class Site
         return collect($this->files->scanDir($path))->filter(function ($value, $key) {
             return ends_with($value, '.crt');
         })->map(function ($cert) {
-            return substr($cert, 0, strripos($cert, '.', -4));
+            return substr($cert, 0, strripos($cert, '.', -5));
         })->flip();
     }
 


### PR DESCRIPTION
Can't `valet links` other domain show https except `.dev`
  
Fixes #445