### PR TITLE
Add 'trust' command

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -197,4 +197,17 @@ class Brew
     {
         $this->restartService($this->linkedPhp());
     }
+
+    /**
+     * Create the "sudoers.d" entry for running Brew.
+     *
+     * @return void
+     */
+    function createSudoersEntry()
+    {
+        $this->files->ensureDirExists('/etc/sudoers.d');
+
+        $this->files->put('/etc/sudoers.d/brew', 'Cmnd_Alias BREW = /usr/local/bin/brew *
+%admin ALL=(root) NOPASSWD: BREW'.PHP_EOL);
+    }
 }

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -65,4 +65,17 @@ class Valet
 
         return version_compare($currentVersion, trim($response->body->tag_name, 'v'), '>=');
     }
+
+    /**
+     * Create the "sudoers.d" entry for running Valet.
+     *
+     * @return void
+     */
+    function createSudoersEntry()
+    {
+        $this->files->ensureDirExists('/etc/sudoers.d');
+
+        $this->files->put('/etc/sudoers.d/valet', 'Cmnd_Alias VALET = /usr/local/bin/valet *
+%admin ALL=(root) NOPASSWD: VALET'.PHP_EOL);
+    }
 }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -253,6 +253,16 @@ if (is_dir(VALET_HOME_PATH)) {
             output('NO');
         }
     })->descriptions('Determine if this is the latest version of Valet');
+
+    /**
+     * Install the sudoers.d entries so password is no longer required.
+     */
+    $app->command('trust', function () {
+        Brew::createSudoersEntry();
+        Valet::createSudoersEntry();
+
+        info('Sudoers entries have been added for Brew and Valet.');
+    })->descriptions('Add sudoers files for Brew and Valet to make Valet commands run without passwords');
 }
 
 /**

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Valet\Brew;
+use Valet\Valet;
 use Valet\Filesystem;
 use Valet\Configuration;
 use Illuminate\Container\Container;
@@ -119,5 +121,16 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $config->shouldReceive('read')->once()->andReturn(['foo' => 'bar']);
         $config->shouldReceive('write')->once()->with(['foo' => 'bar', 'bar' => 'baz']);
         $config->updateKey('bar', 'baz');
+    }
+
+
+    public function test_trust_adds_the_sudoer_files()
+    {
+        $files = Mockery::mock(Filesystem::class.'[ensureDirExists,put]');
+        $files->shouldReceive('ensureDirExists')->with('/etc/sudoers.d')->twice();
+        $files->shouldReceive('put')->twice();
+        swap(Filesystem::class, $files);
+        resolve(Brew::class)->createSudoersEntry();
+        resolve(Valet::class)->createSudoersEntry();
     }
 }


### PR DESCRIPTION
Brings back the sudoer files, but now optional.

When they were removed: 
https://github.com/laravel/valet/pull/334/files

Addresses issues like https://github.com/laravel/valet/issues/446

One big question is whether this test actually does any good, since it just tests that the commands do what they do. `¯\(°_o)/¯`

Closes #446
Closes #198
Impacts #206