### PR TITLE
adding CA to the created certificates

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -256,6 +256,7 @@ class Site
     {
         $caPemPath = $this->certificatesPath().'/LaravelValetCASelfSigned.pem';
         $caKeyPath = $this->certificatesPath().'/LaravelValetCASelfSigned.key';
+        $caSrlPath = $this->certificatesPath().'/LaravelValetCASelfSigned.srl';
         $keyPath = $this->certificatesPath().'/'.$url.'.key';
         $csrPath = $this->certificatesPath().'/'.$url.'.csr';
         $crtPath = $this->certificatesPath().'/'.$url.'.crt';
@@ -265,9 +266,14 @@ class Site
         $this->createPrivateKey($keyPath);
         $this->createSigningRequest($url, $keyPath, $csrPath, $confPath);
 
+        $caSrlParam = '-CAcreateserial ';
+        if ($this->files->exists($caSrlPath)) {
+            $caSrlParam = '-CAserial ' . $caSrlPath;
+        }
+
         $this->cli->runAsUser(sprintf(
-            'openssl x509 -req -sha256 -days 730 -CA %s -CAkey %s -in %s -out %s -extensions v3_req -extfile %s',
-            $caPemPath, $caKeyPath, $csrPath, $crtPath, $confPath
+            'openssl x509 -req -sha256 -days 730 -CA %s -CAkey %s %s -in %s -out %s -extensions v3_req -extfile %s',
+            $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath
         ));
 
         $this->trustCertificate($crtPath);

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -224,13 +224,13 @@ class Site
         if ($this->files->exists($caAffixPath)) {
             $affix = $this->files->get($caAffixPath);
             $this->cli->run(sprintf(
-                'sudo security delete-certificate -c "%s%s" /Library/Keychains/System.keychain -t',
+                'sudo security delete-certificate -c "%s%s" -t /Library/Keychains/System.keychain',
                 $cName, $affix
             ));
             $this->files->unlink($caAffixPath);
         }
         $this->cli->run(sprintf(
-            'sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain -t',
+            'sudo security delete-certificate -c "%s" -t /Library/Keychains/System.keychain',
             $cName
         ));
 
@@ -369,8 +369,8 @@ class Site
             $this->files->unlink($this->certificatesPath().'/'.$url.'.csr');
             $this->files->unlink($this->certificatesPath().'/'.$url.'.crt');
 
-            $this->cli->run(sprintf('sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain -t', $url));
-            $this->cli->run(sprintf('sudo security delete-certificate -c "*.%s" /Library/Keychains/System.keychain -t', $url));
+            $this->cli->run(sprintf('sudo security delete-certificate -c "%s" -t /Library/Keychains/System.keychain', $url));
+            $this->cli->run(sprintf('sudo security delete-certificate -c "*.%s" -t /Library/Keychains/System.keychain', $url));
         }
     }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -226,8 +226,8 @@ class Site
         ));
 
         $this->cli->runAsUser(sprintf(
-            'openssl req -new -newkey rsa:2048 -days 730 -nodes -x509 -subj "/C=/ST=/O=%s/localityName=/commonName=%s/organizationalUnitName=Developers/emailAddress=noreply@valet.test/" -keyout %s -out %s',
-            $oName, $cName, $caKeyPath, $caPemPath
+            'openssl req -new -newkey rsa:2048 -days 730 -nodes -x509 -subj "/C=/ST=/O=%s/localityName=/commonName=%s/organizationalUnitName=Developers/emailAddress=%s/" -keyout %s -out %s',
+            $oName, $cName, 'rootcertificate@laravel.valet', $caKeyPath, $caPemPath
         ));
         $this->trustCa($caPemPath);
     }
@@ -285,8 +285,8 @@ class Site
     function createSigningRequest($url, $keyPath, $csrPath, $confPath)
     {
         $this->cli->runAsUser(sprintf(
-            'openssl req -new -key %s -out %s -subj "/C=/ST=/O=/localityName=/commonName=%s/organizationalUnitName=/emailAddress=/" -config %s',
-            $keyPath, $csrPath, $url, $confPath
+            'openssl req -new -key %s -out %s -subj "/C=/ST=/O=/localityName=/commonName=%s/organizationalUnitName=/emailAddress=%s%s/" -config %s',
+            $keyPath, $csrPath, $url, $url, '@laravel.valet', $confPath
         ));
     }
 
@@ -363,6 +363,10 @@ class Site
 
             $this->cli->run(sprintf('sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain', $url));
             $this->cli->run(sprintf('sudo security delete-certificate -c "*.%s" /Library/Keychains/System.keychain', $url));
+            $this->cli->run(sprintf(
+                'sudo security find-certificate -e "%s%s" -a -Z | grep SHA-1 | sudo awk \'{system("security delete-certificate -Z "$NF" /Library/Keychains/System.keychain")}\'',
+                $url, '@laravel.valet'
+            ));
         }
     }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -241,7 +241,7 @@ class Site
         $cName .= $affix;
 
         $this->cli->runAsUser(sprintf(
-            'openssl req -new -newkey rsa:2048 -days 730 -nodes -x509 -subj "/C=LV/ST=Latvia/O=%s/localityName=Riga/commonName=%s/organizationalUnitName=Developers/emailAddress=noreply@valet.test/" -keyout %s -out %s',
+            'openssl req -new -newkey rsa:2048 -days 730 -nodes -x509 -subj "/C=/ST=/O=%s/localityName=/commonName=%s/organizationalUnitName=Developers/emailAddress=noreply@valet.test/" -keyout %s -out %s',
             $oName, $cName, $caKeyPath, $caPemPath
         ));
         $this->trustCa($caPemPath);

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -371,6 +371,7 @@ class Site
             $this->files->unlink($this->certificatesPath().'/'.$url.'.crt');
 
             $this->cli->run(sprintf('sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain -t', $url));
+            $this->cli->run(sprintf('sudo security delete-certificate -c "*.%s" /Library/Keychains/System.keychain -t', $url));
         }
     }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -226,13 +226,13 @@ class Site
         if ($this->files->exists($caAffixPath)) {
             $affix = $this->files->get($caAffixPath);
             $this->cli->run(sprintf(
-                'sudo security delete-certificate -c "%s%s" -t /Library/Keychains/System.keychain',
+                'sudo security delete-certificate -c "%s%s" /Library/Keychains/System.keychain',
                 $cName, $affix
             ));
             $this->files->unlink($caAffixPath);
         }
         $this->cli->run(sprintf(
-            'sudo security delete-certificate -c "%s" -t /Library/Keychains/System.keychain',
+            'sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain',
             $cName
         ));
 
@@ -377,8 +377,8 @@ class Site
             $this->files->unlink($this->certificatesPath().'/'.$url.'.csr');
             $this->files->unlink($this->certificatesPath().'/'.$url.'.crt');
 
-            $this->cli->run(sprintf('sudo security delete-certificate -c "%s" -t /Library/Keychains/System.keychain', $url));
-            $this->cli->run(sprintf('sudo security delete-certificate -c "*.%s" -t /Library/Keychains/System.keychain', $url));
+            $this->cli->run(sprintf('sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain', $url));
+            $this->cli->run(sprintf('sudo security delete-certificate -c "*.%s" /Library/Keychains/System.keychain', $url));
         }
     }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -183,6 +183,8 @@ class Site
     {
         $this->unsecure($url);
 
+        $this->files->ensureDirExists($this->caPath(), user());
+
         $this->files->ensureDirExists($this->certificatesPath(), user());
 
         $this->createCa();
@@ -203,9 +205,9 @@ class Site
      */
     function createCa()
     {
-        $caPemPath = $this->certificatesPath().'/LaravelValetCASelfSigned.pem';
-        $caKeyPath = $this->certificatesPath().'/LaravelValetCASelfSigned.key';
-        $caAffixPath = $this->certificatesPath().'/LaravelValetCASelfSigned.affix';
+        $caPemPath = $this->caPath().'/LaravelValetCASelfSigned.pem';
+        $caKeyPath = $this->caPath().'/LaravelValetCASelfSigned.key';
+        $caAffixPath = $this->caPath().'/LaravelValetCASelfSigned.affix';
 
         if ($this->files->exists($caKeyPath) && $this->files->exists($caPemPath) && $this->files->exists($caAffixPath)) {
             return;
@@ -254,9 +256,9 @@ class Site
      */
     function createCertificate($url)
     {
-        $caPemPath = $this->certificatesPath().'/LaravelValetCASelfSigned.pem';
-        $caKeyPath = $this->certificatesPath().'/LaravelValetCASelfSigned.key';
-        $caSrlPath = $this->certificatesPath().'/LaravelValetCASelfSigned.srl';
+        $caPemPath = $this->caPath().'/LaravelValetCASelfSigned.pem';
+        $caKeyPath = $this->caPath().'/LaravelValetCASelfSigned.key';
+        $caSrlPath = $this->caPath().'/LaravelValetCASelfSigned.srl';
         $keyPath = $this->certificatesPath().'/'.$url.'.key';
         $csrPath = $this->certificatesPath().'/'.$url.'.csr';
         $crtPath = $this->certificatesPath().'/'.$url.'.crt';
@@ -388,6 +390,16 @@ class Site
     function sitesPath()
     {
         return VALET_HOME_PATH.'/Sites';
+    }
+
+    /**
+     * Get the path to the Valet CA certificates.
+     *
+     * @return string
+     */
+    function caPath()
+    {
+        return VALET_HOME_PATH.'/CA';
     }
 
     /**

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -266,13 +266,13 @@ class Site
         $this->createPrivateKey($keyPath);
         $this->createSigningRequest($url, $keyPath, $csrPath, $confPath);
 
-        $caSrlParam = '-CAcreateserial ';
+        $caSrlParam = ' -CAcreateserial';
         if ($this->files->exists($caSrlPath)) {
-            $caSrlParam = '-CAserial ' . $caSrlPath;
+            $caSrlParam = ' -CAserial ' . $caSrlPath;
         }
 
         $this->cli->runAsUser(sprintf(
-            'openssl x509 -req -sha256 -days 730 -CA %s -CAkey %s %s -in %s -out %s -extensions v3_req -extfile %s',
+            'openssl x509 -req -sha256 -days 730 -CA %s -CAkey %s%s -in %s -out %s -extensions v3_req -extfile %s',
             $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath
         ));
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -211,8 +211,8 @@ class Site
             return;
         }
 
-        $oName = 'Laravel Valet CA Self Signed O';
-        $cName = 'Laravel Valet CA Self Signed C';
+        $oName = 'Laravel Valet CA Self Signed Organization';
+        $cName = 'Laravel Valet CA Self Signed CN ';
         $affix = '';
 
         if ($this->files->exists($caKeyPath)) {
@@ -237,7 +237,6 @@ class Site
         $affix = bin2hex(openssl_random_pseudo_bytes(15));
         $this->files->putAsUser($caAffixPath, $affix);
 
-        $oName .= $affix;
         $cName .= $affix;
 
         $this->cli->runAsUser(sprintf(

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -360,14 +360,14 @@ class Site
             $this->files->unlink($this->certificatesPath().'/'.$url.'.key');
             $this->files->unlink($this->certificatesPath().'/'.$url.'.csr');
             $this->files->unlink($this->certificatesPath().'/'.$url.'.crt');
-
-            $this->cli->run(sprintf('sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain', $url));
-            $this->cli->run(sprintf('sudo security delete-certificate -c "*.%s" /Library/Keychains/System.keychain', $url));
-            $this->cli->run(sprintf(
-                'sudo security find-certificate -e "%s%s" -a -Z | grep SHA-1 | sudo awk \'{system("security delete-certificate -Z "$NF" /Library/Keychains/System.keychain")}\'',
-                $url, '@laravel.valet'
-            ));
         }
+
+        $this->cli->run(sprintf('sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain', $url));
+        $this->cli->run(sprintf('sudo security delete-certificate -c "*.%s" /Library/Keychains/System.keychain', $url));
+        $this->cli->run(sprintf(
+            'sudo security find-certificate -e "%s%s" -a -Z | grep SHA-1 | sudo awk \'{system("security delete-certificate -Z "$NF" /Library/Keychains/System.keychain")}\'',
+            $url, '@laravel.valet'
+        ));
     }
 
     /**


### PR DESCRIPTION
This PR addresses these issues

https://github.com/laravel/valet/issues/390  

https://github.com/laravel/valet/issues/296  (import `~/.valet/CA/LaravelValetCASelfSigned.pem` to FF trusted authorities and all valet sites will be trusted)

![screen shot 2018-01-31 at 09 28 41](https://user-images.githubusercontent.com/720976/35610239-2d60e4fc-0669-11e8-8b31-779bd793b3a0.png)

https://github.com/laravel/valet/issues/460 (works when `curl https://mypage.test/ --cacert ~/.valet/CA/LaravelValetCASelfSigned.pem`)

as well as issue I found out while playing with it, namely that `unsecure` previously did not remove old certs from keychain (had tons of them) due to `security delete-certificate` not passing keychain parameter.

As the changes are only in one file it is easy to test them for those who use valet with master branch (`composer global require laravel/valet dev-master`) and are affected by this issue and cannot wait till this gets merged (if it even will). Simply grab `Site.php` head and replace it with file at `~/.composer/vendor/laravel/valet/cli/Valet/Site.php` (backup existing `Site.php` just in case).

---

1)

The logic where the first step is to `untrust` is kept as is, only now it really removes previous cert from Keychain. However manual cleanup needed, read https://github.com/laravel/valet/pull/515#issuecomment-363936795

2)

It checks if _CA_ directory (a new directory, it is created if it does not exist) contains *LaravelValetCASelfSigned.key* && *LaravelValetCASelfSigned.pem*

If yes, then CA has been already created.

3)

If any of those files are not present it creates private key for CA (*LaravelValetCASelfSigned.key*) and generates root certificate (*LaravelValetCASelfSigned.pem*) in _CA_ directory.  

4)

CA is added as trusted to Keychain.

5)

Private key is created for website certificate that will be issued by our new CA.

6)

Create Certificate Signing Request (CSR).  
Certificate will have common name `sitename.tld` and email address `sitename.tld@laravel.valet`  

7)

Issue the certificate for website.

8)

Add issued website certificate and trust it in Keychain.

---

`unsecure()` tries to delete certificate by searching by common name `sitename.tld`.
In addition `unsecure()` also tries to delete certificate by searching by email `sitename.tld@laravel.valet`.