### PR TITLE
Craft driver web or public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 vendor/
 composer.lock
 error.log
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 composer.lock
 error.log
+.idea

--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -23,6 +23,14 @@ class CraftValetDriver extends ValetDriver
      */
     public function frontControllerDirectory($sitePath)
     {
+        $dirs = ['web', 'public'];
+
+        foreach ($dirs as $dir) {
+            if (is_dir($sitePath.'/'.$dir)) {
+                return $dir;
+            }
+        }
+        // Give up, and just return the default
         return is_file($sitePath.'/craft') ? 'web' : 'public';
     }
 


### PR DESCRIPTION
The previous method simply returned `web` if there was a file named `craft` in the $sitePath (which means we’re running Craft 3).

The problem is that many sites, especially upgraded ones, will be serving out of `public`. This is also in line with the default Forge/ServerPilot default dirs.

So we test to see if either `/web` or `/public` exist, and return them if so. Otherwise default to the current method.