### PR TITLE
Add `ssi on;` to the default config

### DIFF
--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -18,6 +18,7 @@ http {
     gzip_min_length 256;
     gzip_proxied any;
     gzip_vary on;
+    ssi on;
 
     gzip_types
     application/atom+xml


### PR DESCRIPTION
Defaulting to having `ssi on;` in the `http` block will allow those of us doing Nginx Server Side Includes to use Valet in local development.

A longer explanation of SSI, why we want it, and the impact is here: https://github.com/laravel/valet/issues/513