### PR TITLE
Switch homebrew 'php72' references to 'php'

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -52,7 +52,7 @@ class Brew
      */
     function supportedPhpVersions()
     {
-        return collect(['php72', 'php71', 'php70', 'php56']);
+        return collect(['php', 'php71', 'php70', 'php56']);
     }
 
     /**
@@ -182,7 +182,7 @@ class Brew
         $resolvedPath = $this->files->readLink('/usr/local/bin/php');
 
         return $this->supportedPhpVersions()->first(function ($version) use ($resolvedPath) {
-            return strpos($resolvedPath, $version) !== false;
+            return strpos($resolvedPath, "/$version/") !== false;
         }, function () {
             throw new DomainException("Unable to determine linked PHP.");
         });

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -95,7 +95,7 @@ class PhpFpm
      */
     function stop()
     {
-        $this->brew->stopService('php56', 'php70', 'php71', 'php72');
+        $this->brew->stopService('php56', 'php70', 'php71', 'php');
     }
 
     /**
@@ -106,7 +106,7 @@ class PhpFpm
     function fpmConfigPath()
     {
         $confLookup = [
-            'php72' => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
+            'php' => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
             'php71' => '/usr/local/etc/php/7.1/php-fpm.d/www.conf',
             'php70' => '/usr/local/etc/php/7.0/php-fpm.d/www.conf',
             'php56' => '/usr/local/etc/php/5.6/php-fpm.conf',

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -66,35 +66,35 @@ php7');
     public function test_has_installed_php_indicates_if_php_is_installed_via_brew()
     {
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php')->andReturn(true);
         $brew->shouldReceive('installed')->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->with('php70')->andReturn(false);
         $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
         $brew->shouldReceive('installed')->with('php71')->andReturn(true);
         $brew->shouldReceive('installed')->with('php70')->andReturn(false);
         $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
         $brew->shouldReceive('installed')->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->with('php70')->andReturn(true);
         $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
         $brew->shouldReceive('installed')->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->with('php70')->andReturn(false);
         $brew->shouldReceive('installed')->with('php56')->andReturn(true);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
         $brew->shouldReceive('installed')->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->with('php70')->andReturn(false);
         $brew->shouldReceive('installed')->with('php56')->andReturn(false);


### PR DESCRIPTION
Homebrew just renamed `php72` to `php`. This is a quick patch to get things back up and going, though new checks will need to be put in place once php73 is a thing.

Edit: Looks like this would close #528