### PR TITLE
Preserve compatibility with PHP 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     },
     "require": {
         "php": ">=5.6",
-        "illuminate/container": "~5.1",
+        "illuminate/container": ">=5.1 <5.5",
         "mnapoli/silly": "~1.0",
         "symfony/process": "~2.7|~3.0|~4.0",
         "nategood/httpful": "~0.2",
-        "tightenco/collect": "^5.3"
+        "tightenco/collect": ">=5.3 <5.5"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",


### PR DESCRIPTION
Valet is already compatible with PHP 5.6, but if it is installed/updated using PHP 7 or higher, Composer will install a few dependencies at newer versions that don't support 5.6. This causes Valet to break if the linked version of PHP is then switched to 5.6. The current work around is to do something like deleting Composer's global vendor directory and then run `composer update` with PHP 5.6.

This PR solves this problem by simply limiting the upper bounds of a few dependencies so that PHP 5.6 compatible versions are always installed, regardless of the version of PHP it is installed with.

Resolves #530 