### PR TITLE
Craft driver optional separate index.php

### DIFF
--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -191,8 +191,13 @@ class CraftValetDriver extends ValetDriver
         $parts = explode('/', $uri);
 
         if (count($parts) > 1 && in_array($parts[1], $locales)) {
-            $indexPath = $sitePath.'/'.$frontControllerDirectory.'/'.$parts[1].'/index.php';
-            $scriptName = '/'.$parts[1].'/index.php';
+            $indexLocalizedPath = $sitePath.'/'.$frontControllerDirectory.'/'.$parts[1].'/index.php';
+
+            // Check if index.php exists in the localized folder, this is optional in Craft 3
+            if (file_exists($indexLocalizedPath)) {
+                $indexPath = $indexLocalizedPath;
+                $scriptName = '/'.$parts[1].'/index.php';
+            }
         }
 
         $_SERVER['SCRIPT_FILENAME'] = $indexPath;


### PR DESCRIPTION
As Craft 3 RC11, it is no longer necessary to route sites with base URI paths to separate index.php files. Craft will automatically detect URI segments that were meant to be part of the site base URI, and ignore them when routing the request.

https://github.com/craftcms/cms/blob/develop/CHANGELOG-v3.md#300-rc11---2018-02-20