### PR TITLE
fix for new php versions/paths from php installed via brew

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -182,7 +182,7 @@ class Brew
         $resolvedPath = $this->files->readLink('/usr/local/bin/php');
 
         return $this->supportedPhpVersions()->first(function ($version) use ($resolvedPath) {
-            return strpos($resolvedPath, "/$version/") !== false;
+            return strpos(preg_replace('/([@|\.])/', '', $resolvedPath, "/$version/")) !== false;
         }, function () {
             throw new DomainException("Unable to determine linked PHP.");
         });

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -113,6 +113,8 @@ class PhpFpm
             'php56' => '/usr/local/etc/php/5.6/php-fpm.conf',
         ];
 
-        return $confLookup[$this->brew->linkedPhp()];
+        $key = preg_replace('/([@|\.])/', '', $this->brew->linkedPhp());
+
+        return $confLookup[$key];
     }
 }


### PR DESCRIPTION
Previous versions of brew installed PHP like so:

```
/usr/local/opt/php71/bin/
```

Now they look like this:

```
/usr/local/opt/php@7.1/bin/
```

These changes just tweak the version check to remove `@` and `.` from the paths. So this should be backwards compatible with older installations as well.

*I was unable to get the tests running, but I applied these patches locally and went from not being able to install to a valid installation.*