### PR TITLE
Fixes #521

### DIFF
--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -25,7 +25,7 @@ class CommandLine
      */
     function quietlyAsUser($command)
     {
-        $this->quietly('sudo -u '.user().' '.$command.' > /dev/null 2>&1');
+        $this->quietly('sudo '.$command.' > /dev/null 2>&1');
     }
 
     /**

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -25,7 +25,7 @@ server {
     }
 
     access_log off;
-    error_log VALET_HOME_PATH/Log/nginx-error.log;
+    error_log /usr/local/var/log/nginx/error.log;
 
     error_page 404 VALET_SERVER_PATH;
 


### PR DESCRIPTION
This PR fixes inability to run `valet secure` (see #521) and nginx work. 
The problem was because valet config is stored under `/var/root/.valet` folder while valet tries to create certificates under `/Users/johndoe/.valet/Certificates` which obviously doesn't work.
Also, it fixes `error_log` path which was located under `/var/root/.valet` folder which is not accessible because `nginx` runs under `johndoe` user.