### PR TITLE
Update Brew.php - Homebrew\Core Package Names

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -52,7 +52,7 @@ class Brew
      */
     function supportedPhpVersions()
     {
-        return collect(['php', 'php72', 'php71', 'php70', 'php56']);
+        return collect(['php', 'php@7.2', 'php@7.1', 'php@7.0', 'php@5.6', 'php72', 'php71', 'php70', 'php56' ]);
     }
 
     /**


### PR DESCRIPTION
Update supportedPhpVersions to include the new names used by homebrew now that the php packages have migrated to 'core'.   `php71` has become `php@7.1` etc

The new names are put at the front of the list to optimise the loops that use these collections.

Anyone who installs or updates 'homebrew php' from will start using the new packages names which breaks parts of valet.