### PR TITLE
Revert "Fix (really) changes where brew php paths now include @ and semver-st…"

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -52,7 +52,7 @@ class Brew
      */
     function supportedPhpVersions()
     {
-        return collect(['php', 'php72', 'php71', 'php70', 'php56']);
+        return collect(['php', 'php@7.2', 'php@7.1', 'php@7.0', 'php@5.6', 'php72', 'php71', 'php70', 'php56' ]);
     }
 
     /**
@@ -182,7 +182,7 @@ class Brew
         $resolvedPath = $this->files->readLink('/usr/local/bin/php');
 
         return $this->supportedPhpVersions()->first(function ($version) use ($resolvedPath) {
-            return strpos(preg_replace('/([@|\.])/', '', $resolvedPath), "/$version/") !== false;
+            return strpos($resolvedPath, "/$version/") !== false;
         }, function () {
             throw new DomainException("Unable to determine linked PHP.");
         });


### PR DESCRIPTION
Reverts laravel/valet#553

We should be updating the supported versions array.  This change reverted the fix in place already.

Doing a regex here does not address the other place where the array is used (hasInstalledPhp) causing valet not to restart php.  It may leave people who haven't or can't update the brew package source in a bad place.  Also, we want the display string to represent the php "flavour" installed and detected for that user path (ie. php71 or php@71) so it is cleared what is linked in the context of the web server.