### PR TITLE
Unify php versions list. Fix deprecated homebrew/php

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -54,7 +54,7 @@ class Brew
      */
     function supportedPhpVersions()
     {
-        return collect(['php', 'php72', 'php71', 'php70', 'php56']);
+        return collect(static::SUPPORTED_PHP_VERSIONS);
     }
 
     /**

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -7,6 +7,8 @@ use DomainException;
 
 class Brew
 {
+    const SUPPORTED_PHP_VERSIONS = ['php', 'php@7.2', 'php@7.1', 'php@7.0', 'php@5.6'];
+
     var $cli, $files;
 
     /**
@@ -182,7 +184,9 @@ class Brew
         $resolvedPath = $this->files->readLink('/usr/local/bin/php');
 
         return $this->supportedPhpVersions()->first(function ($version) use ($resolvedPath) {
-            return strpos(preg_replace('/([@|\.])/', '', $resolvedPath), "/$version/") !== false;
+            $resolvedPathNormalized= preg_replace('/([@|\.])/', '', $resolvedPath);
+            $versionNormalized = preg_replace('/([@|\.])/', '', $version);
+            return strpos($resolvedPathNormalized, "/$versionNormalized/") !== false;
         }, function () {
             throw new DomainException("Unable to determine linked PHP.");
         });

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -7,7 +7,8 @@ use DomainException;
 
 class Brew
 {
-    const SUPPORTED_PHP_VERSIONS = ['php', 'php@7.2', 'php@7.1', 'php@7.0', 'php@5.6'];
+    const SUPPORTED_PHP_VERSIONS = ['php', 'php@7.2', 'php@7.1', 'php@7.0', 'php@5.6', 'php72', 'php71', 'php70', 'php56'];
+    const LATEST_PHP_VERSION = 'php@7.2';
 
     var $cli, $files;
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -111,10 +111,11 @@ class PhpFpm
         $confLookup = [];
 
         foreach (Brew::SUPPORTED_PHP_VERSIONS as $version) {
-            $versionNormalized = preg_replace('/([^\d\.])/', '', $version);
-            $versionNormalized = $versionNormalized === ''
-                ? '7.2'
-                : $versionNormalized;
+            $versionNormalized = preg_replace(
+                '/php@?(\d)\.?(\d)/',
+                '$1.$2',
+                $version === 'php' ? Brew::LATEST_PHP_VERSION : $version
+            );
 
             $confLookup[$version] = $versionNormalized === '5.6'
                 ? '/usr/local/etc/php/5.6/php-fpm.conf'

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -95,7 +95,10 @@ class PhpFpm
      */
     function stop()
     {
-        $this->brew->stopService('php56', 'php70', 'php71', 'php72', 'php');
+        call_user_func_array(
+            [$this->brew, 'stopService'],
+            Brew::SUPPORTED_PHP_VERSIONS
+        );
     }
 
     /**
@@ -105,13 +108,18 @@ class PhpFpm
      */
     function fpmConfigPath()
     {
-        $confLookup = [
-            'php' => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
-            'php72' => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
-            'php71' => '/usr/local/etc/php/7.1/php-fpm.d/www.conf',
-            'php70' => '/usr/local/etc/php/7.0/php-fpm.d/www.conf',
-            'php56' => '/usr/local/etc/php/5.6/php-fpm.conf',
-        ];
+        $confLookup = [];
+
+        foreach (Brew::SUPPORTED_PHP_VERSIONS as $version) {
+            $versionNormalized = preg_replace('/([^\d\.])/', '', $version);
+            $versionNormalized = $versionNormalized === ''
+                ? '7.2'
+                : $versionNormalized;
+
+            $confLookup[$version] = $versionNormalized === '5.6'
+                ? '/usr/local/etc/php/5.6/php-fpm.conf'
+                : "/usr/local/etc/php/${versionNormalized}/php-fpm.d/www.conf";
+        }
 
         return $confLookup[$this->brew->linkedPhp()];
     }

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -67,6 +67,10 @@ php7');
     {
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php72')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(true);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
@@ -75,6 +79,10 @@ php7');
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(true);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
@@ -83,6 +91,10 @@ php7');
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(true);
@@ -91,6 +103,10 @@ php7');
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(true);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
@@ -99,6 +115,10 @@ php7');
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -67,42 +67,42 @@ php7');
     {
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(true);
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
         $this->assertFalse($brew->hasInstalledPhp());
     }
 
@@ -145,13 +145,13 @@ php7');
         $files->shouldReceive('isLink')->once()->with('/usr/local/bin/php')->andReturn(true);
         $files->shouldReceive('readLink')->once()->with('/usr/local/bin/php')->andReturn('/test/path/php71/test');
         swap(Filesystem::class, $files);
-        $this->assertSame('php71', resolve(Brew::class)->linkedPhp());
+        $this->assertSame('php@7.1', resolve(Brew::class)->linkedPhp());
 
         $files = Mockery::mock(Filesystem::class);
         $files->shouldReceive('isLink')->once()->with('/usr/local/bin/php')->andReturn(true);
         $files->shouldReceive('readLink')->once()->with('/usr/local/bin/php')->andReturn('/test/path/php56/test');
         swap(Filesystem::class, $files);
-        $this->assertSame('php56', resolve(Brew::class)->linkedPhp());
+        $this->assertSame('php@5.6', resolve(Brew::class)->linkedPhp());
     }
 
 


### PR DESCRIPTION
Hello,

With previous code valet not found the new versions with `@` in name. Therefore valet not restarting these php versions.

Also unify the list of php versions.