### PR TITLE
Fix Regression from 2.0.9 and Modernise Unit Tests

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -52,7 +52,7 @@ class Brew
      */
     function supportedPhpVersions()
     {
-        return collect(['php', 'php72', 'php71', 'php70', 'php56']);
+        return collect(['php', 'php@7.2', 'php@7.1', 'php@7.0', 'php@5.6', 'php72', 'php71', 'php70', 'php56' ]);
     }
 
     /**
@@ -182,7 +182,7 @@ class Brew
         $resolvedPath = $this->files->readLink('/usr/local/bin/php');
 
         return $this->supportedPhpVersions()->first(function ($version) use ($resolvedPath) {
-            return strpos(preg_replace('/([@|\.])/', '', $resolvedPath), "/$version/") !== false;
+            return strpos($resolvedPath, "/$version/") !== false;
         }, function () {
             throw new DomainException("Unable to determine linked PHP.");
         });

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -11,7 +11,7 @@ class PhpFpm
     var $brew, $cli, $files;
 
     var $taps = [
-        'homebrew/dupes', 'homebrew/versions', 'homebrew/homebrew-php'
+        'homebrew/core', 'homebrew/services'
     ];
 
     /**
@@ -37,7 +37,7 @@ class PhpFpm
     function install()
     {
         if (! $this->brew->hasInstalledPhp()) {
-            $this->brew->ensureInstalled('php71', [], $this->taps);
+            $this->brew->ensureInstalled('php', [], $this->taps);
         }
 
         $this->files->ensureDirExists('/usr/local/var/log', user());
@@ -95,7 +95,7 @@ class PhpFpm
      */
     function stop()
     {
-        $this->brew->stopService('php56', 'php70', 'php71', 'php72', 'php');
+        $this->brew->stopService('php', 'php@5.6', 'php@7.0', 'php@7.1', 'php@7.2', 'php56', 'php70', 'php71', 'php72');
     }
 
     /**
@@ -106,7 +106,14 @@ class PhpFpm
     function fpmConfigPath()
     {
         $confLookup = [
+            // homebrew/core
             'php' => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
+            'php@7.2' => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
+            'php@7.1' => '/usr/local/etc/php/7.1/php-fpm.d/www.conf',
+            'php@7.0' => '/usr/local/etc/php/7.0/php-fpm.d/www.conf',
+            'php@5.6' => '/usr/local/etc/php/5.6/php-fpm.d/www.conf',
+
+            // homebrew/homebrew-php
             'php72' => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
             'php71' => '/usr/local/etc/php/7.1/php-fpm.d/www.conf',
             'php70' => '/usr/local/etc/php/7.0/php-fpm.d/www.conf',

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -30,36 +30,36 @@ class BrewTest extends PHPUnit_Framework_TestCase
     public function test_installed_returns_true_when_given_formula_is_installed()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php71')->andReturn('php71');
+        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php@7.1')->andReturn('php@7.1');
         swap(CommandLine::class, $cli);
-        $this->assertTrue(resolve(Brew::class)->installed('php71'));
+        $this->assertTrue(resolve(Brew::class)->installed('php@7.1'));
 
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php71')->andReturn('php71-mcrypt
-php71');
+        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php')->andReturn('php
+php@7.2');
         swap(CommandLine::class, $cli);
-        $this->assertTrue(resolve(Brew::class)->installed('php71'));
+        $this->assertTrue(resolve(Brew::class)->installed('php'));
     }
 
 
     public function test_installed_returns_false_when_given_formula_is_not_installed()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php71')->andReturn('');
+        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php@7.1')->andReturn('');
         swap(CommandLine::class, $cli);
-        $this->assertFalse(resolve(Brew::class)->installed('php71'));
+        $this->assertFalse(resolve(Brew::class)->installed('php@7.1'));
 
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php71')->andReturn('php71-mcrypt');
+        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php@7.1')->andReturn('php');
         swap(CommandLine::class, $cli);
-        $this->assertFalse(resolve(Brew::class)->installed('php71'));
+        $this->assertFalse(resolve(Brew::class)->installed('php@7.1'));
 
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php71')->andReturn('php71-mcrypt
-php71-something-else
+        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php@7.1')->andReturn('php
+something-else-php@7.1
 php7');
         swap(CommandLine::class, $cli);
-        $this->assertFalse(resolve(Brew::class)->installed('php71'));
+        $this->assertFalse(resolve(Brew::class)->installed('php@7.1'));
     }
 
 
@@ -220,11 +220,11 @@ php7');
     public function test_tap_taps_the_given_homebrew_repository()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('passthru')->once()->with('sudo -u '.user().' brew tap php71');
-        $cli->shouldReceive('passthru')->once()->with('sudo -u '.user().' brew tap php70');
-        $cli->shouldReceive('passthru')->once()->with('sudo -u '.user().' brew tap php56');
+        $cli->shouldReceive('passthru')->once()->with('sudo -u '.user().' brew tap php@7.1');
+        $cli->shouldReceive('passthru')->once()->with('sudo -u '.user().' brew tap php@7.0');
+        $cli->shouldReceive('passthru')->once()->with('sudo -u '.user().' brew tap php@5.6');
         swap(CommandLine::class, $cli);
-        resolve(Brew::class)->tap('php71', 'php70', 'php56');
+        resolve(Brew::class)->tap('php@7.1', 'php@7.0', 'php@5.6');
     }
 
 
@@ -251,6 +251,14 @@ php7');
 
     public function test_linked_php_returns_linked_php_formula_name()
     {
+        // homebrew\core php @7.2
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('isLink')->once()->with('/usr/local/bin/php')->andReturn(true);
+        $files->shouldReceive('readLink')->once()->with('/usr/local/bin/php')->andReturn('/test/path/php@7.2/test');
+        swap(Filesystem::class, $files);
+        $this->assertSame('php@7.2', resolve(Brew::class)->linkedPhp());
+
+        // hombrew\homebrew-php php @7.1
         $files = Mockery::mock(Filesystem::class);
         $files->shouldReceive('isLink')->once()->with('/usr/local/bin/php')->andReturn(true);
         $files->shouldReceive('readLink')->once()->with('/usr/local/bin/php')->andReturn('/test/path/php71/test');

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -65,40 +65,150 @@ php7');
 
     public function test_has_installed_php_indicates_if_php_is_installed_via_brew()
     {
+        // default homebrew\core php @ latest
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(true);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        // homebrew\core php @7.2
+        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        // hombrew\core php @7.1
+        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        // hombrew\core php @7.0
+        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        // hombrew\core php @5.6
+        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(true);
+
+        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        // hombrew\homebrew-php php @7.2
+        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+
         $brew->shouldReceive('installed')->with('php72')->andReturn(true);
         $brew->shouldReceive('installed')->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->with('php70')->andReturn(false);
         $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
+        // hombrew\homebrew-php php @7.1
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+
         $brew->shouldReceive('installed')->with('php72')->andReturn(false);
         $brew->shouldReceive('installed')->with('php71')->andReturn(true);
         $brew->shouldReceive('installed')->with('php70')->andReturn(false);
         $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
+        // hombrew\homebrew-php php @7.0
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+
         $brew->shouldReceive('installed')->with('php72')->andReturn(false);
         $brew->shouldReceive('installed')->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->with('php70')->andReturn(true);
         $brew->shouldReceive('installed')->with('php56')->andReturn(false);
         $this->assertTrue($brew->hasInstalledPhp());
 
+        // hombrew\homebrew-php php @5.6
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+
         $brew->shouldReceive('installed')->with('php72')->andReturn(false);
         $brew->shouldReceive('installed')->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->with('php70')->andReturn(false);
         $brew->shouldReceive('installed')->with('php56')->andReturn(true);
         $this->assertTrue($brew->hasInstalledPhp());
 
+        // neither homebrew\core or homebrew\homebrew-php
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installed')->with('php')->andReturn(false);
+
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+
         $brew->shouldReceive('installed')->with('php72')->andReturn(false);
         $brew->shouldReceive('installed')->with('php71')->andReturn(false);
         $brew->shouldReceive('installed')->with('php70')->andReturn(false);


### PR DESCRIPTION
Remove the commit made to satisfy the unit tests.

Ensure support for environments using the `homebrew\core` tap and those still on packages from the deprecated and mostly deleted `homebrew\homebrew-php` tap.

Ensure support for pinned and unpinned versions of php at 7.2.

Modernise unit tests to mock commands that could be run today in the command line as confirmation.  The exception to this are the "tap" commands that have always been illustrative.