### PR TITLE
Allow http2 server push for secured domains [BREAKING]

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -10,6 +10,7 @@ server {
     root /;
     charset utf-8;
     client_max_body_size 128M;
+    http2_push_preload on;
 
     location /VALET_STATIC_PREFIX/ {
         internal;


### PR DESCRIPTION
This is a very small addition that allows sites running on valet to test out preloading static assets.

However, `http2_push_preload` was not added into NGINX until 1.13.9 (released February 20th, 2018) which would mean this directive breaks secured sites on any older version of NGINX.

Figured this could be merged into the next major release?