### PR TITLE
Hard-code Nginx to return robots.txt with disallow all

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -11,6 +11,11 @@ server {
     charset utf-8;
     client_max_body_size 128M;
 
+    location /robots.txt {
+        default_type text/plain;
+        return 200 'User-agent: *\nDisallow: /';
+    }
+
     location /VALET_STATIC_PREFIX/ {
         internal;
         alias /;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -4,6 +4,11 @@ server {
     charset utf-8;
     client_max_body_size 128M;
 
+    location /robots.txt {
+        default_type text/plain;
+        return 200 'User-agent: *\nDisallow: /';
+    }
+
     location /VALET_STATIC_PREFIX/ {
         internal;
         alias /;


### PR DESCRIPTION
Not sure if others will find this useful or not but it helps me out as I tend to leave ngrok running for long periods of time and sometimes get hit by a webcrawler (or 2).

This will add location entries for `/robots.txt` to have it always return:
```
User-Agent: *
Disallow: /
```
without needing to remember to add a default robots.txt