### PR TITLE
Update the tap list, current taps deprecated.

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -11,7 +11,7 @@ class PhpFpm
     var $brew, $cli, $files;
 
     var $taps = [
-        'homebrew/dupes', 'homebrew/versions', 'homebrew/homebrew-php'
+        'homebrew/homebrew-core'
     ];
 
     /**


### PR DESCRIPTION
On performing `valet install` the current version of valet will error due to deprecated taps, previous taps moved to `homebrew/homebrew-core`.
```
> valet install
Stopping nginx...
Installing nginx configuration...
Installing nginx directory...
Installing php71...
Error: homebrew/dupes was deprecated. This tap is now empty as all its formulae were migrated.
Error: homebrew/versions was deprecated. This tap is now empty as all its formulae were migrated.
Error: homebrew/php was deprecated. This tap is now empty as all its formulae were migrated.```