### PR TITLE
Remove port from url

### DIFF
--- a/server.php
+++ b/server.php
@@ -65,7 +65,7 @@ $uri = urldecode(
 
 $siteName = basename(
     // Filter host to support wildcard dns feature
-    valet_support_wildcard_dns($_SERVER['HTTP_HOST']),
+    valet_support_wildcard_dns(explode(':',$_SERVER['HTTP_HOST'])[0]),
     '.'.$valetConfig['domain']
 );
 

--- a/server.php
+++ b/server.php
@@ -65,7 +65,7 @@ $uri = urldecode(
 
 $siteName = basename(
     // Filter host to support wildcard dns feature
-    valet_support_wildcard_dns(explode(':',$_SERVER['HTTP_HOST'])[0]),
+    valet_support_wildcard_dns(explode(':', $_SERVER['HTTP_HOST'])[0]),
     '.'.$valetConfig['domain']
 );
 

--- a/server.php
+++ b/server.php
@@ -66,7 +66,7 @@ $uri = urldecode(
 $siteName = basename(
     // Filter host to support wildcard dns feature
     valet_support_wildcard_dns(explode(':', $_SERVER['HTTP_HOST'])[0]),
-    '.'.$valetConfig['domain']
+    '.'.$valetConfig['tld']
 );
 
 if (strpos($siteName, 'www.') === 0) {


### PR DESCRIPTION
Hi,

I've found an issue when trying to access my application through valet specifying the port in the address, valet is not able to find the right folder in this case.

My motivation for specifying the port is that I'm accessing my application through a reverse proxy in a remote server listening on a port different from 443 or 80.

 I've fixed it by removing port from $_SERVER['HTTP_HOST'].