### PR TITLE
Move the helper functions into the Valet namespace

### DIFF
--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Valet;
+
 use Illuminate\Container\Container;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Console\Output\ConsoleOutput;

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -3,6 +3,9 @@
 use Valet\Brew;
 use Valet\Filesystem;
 use Valet\CommandLine;
+use function Valet\user;
+use function Valet\resolve;
+use function Valet\swap;
 use Illuminate\Container\Container;
 
 class BrewTest extends PHPUnit_Framework_TestCase

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -4,6 +4,9 @@ use Valet\Brew;
 use Valet\Valet;
 use Valet\Filesystem;
 use Valet\Configuration;
+use function Valet\user;
+use function Valet\resolve;
+use function Valet\swap;
 use Illuminate\Container\Container;
 
 class ConfigurationTest extends PHPUnit_Framework_TestCase

--- a/tests/DnsMasqTest.php
+++ b/tests/DnsMasqTest.php
@@ -4,6 +4,9 @@ use Valet\Brew;
 use Valet\DnsMasq;
 use Valet\Filesystem;
 use Valet\CommandLine;
+use function Valet\user;
+use function Valet\resolve;
+use function Valet\swap;
 use Illuminate\Container\Container;
 
 class DnsMasqTest extends PHPUnit_Framework_TestCase

--- a/tests/NginxTest.php
+++ b/tests/NginxTest.php
@@ -4,6 +4,9 @@ use Valet\Site;
 use Valet\Nginx;
 use Valet\Filesystem;
 use Valet\Configuration;
+use function Valet\user;
+use function Valet\resolve;
+use function Valet\swap;
 use Illuminate\Container\Container;
 
 class NginxTest extends PHPUnit_Framework_TestCase

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Valet\PhpFpm;
+use function Valet\user;
+use function Valet\resolve;
 use Illuminate\Container\Container;
 
 class PhpFpmTest extends PHPUnit_Framework_TestCase

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -3,6 +3,9 @@
 use Valet\Site;
 use Valet\Filesystem;
 use Valet\Configuration;
+use function Valet\user;
+use function Valet\resolve;
+use function Valet\swap;
 use Illuminate\Container\Container;
 
 class SiteTest extends PHPUnit_Framework_TestCase


### PR DESCRIPTION
Valet doesn't play well with others.

In its `helpers.php` file it registers a number of global functions without considering the landscape of the current environment. This leads to fatal errors being raised when Valet redeclares methods that already exist.

To remedy this issue, I've placed the helpers used by Valet in the `Valet` namespace.