### PR TITLE
Support Kirby v3 as well

### DIFF
--- a/cli/drivers/KirbyValetDriver.php
+++ b/cli/drivers/KirbyValetDriver.php
@@ -45,7 +45,7 @@ class KirbyValetDriver extends ValetDriver
         // Needed to force Kirby to use *.dev to generate its URLs...
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
-        if (preg_match('/^\/panel/', $uri)) {
+        if (preg_match('/^\/panel/', $uri) && file_exists($sitePath . '/panel/index.php')) {
             $_SERVER['SCRIPT_NAME'] = '/panel/index.php';
 
             return $sitePath.'/panel/index.php';


### PR DESCRIPTION
In version 3, there is no panel directory any longer, it's integrated in kirby proper.

This small changes prevents us from trying to load the /panel/index.php that doesn't exist.