### PR TITLE
Add missing imports for helpers

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -12,6 +12,10 @@ if (file_exists(__DIR__.'/../vendor/autoload.php')) {
 
 use Silly\Application;
 use Illuminate\Container\Container;
+use function Valet\info;
+use function Valet\output;
+use function Valet\table;
+use function Valet\warning;
 
 /**
  * Create the application.


### PR DESCRIPTION
This PR fixes a bug introduced in #602 which namespaced all helper functions, but didn't import them in `valet.php`.

E.g.
```
PHP Fatal error:  Uncaught Error: Call to undefined function info() in /Users/aaemnnosttv/.composer/vendor/laravel/valet/cli/valet.php:234
```