### PR TITLE
Fix php errors from #241 (valet tld command)

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -115,12 +115,15 @@ class Configuration
         }
 
         /**
-         *  For upgrades, change config key 'domain' to 'tld'
+         * Migrate old configurations from 'domain' to 'tld'
          */
         $config = $this->read();
-        if (isset($config['domain']) && !isset($config['tld'])) {
-            $this->updateKey('tld', $config['domain']);
+
+        if (isset($config['tld'])) {
+            return;
         }
+
+        $this->updateKey('tld', !empty($config['domain']) ? $config['domain'] : 'test');
     }
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -59,6 +59,10 @@ if (is_dir(VALET_HOME_PATH)) {
      * Get or set the TLD currently being used by Valet.
      */
     $app->command('tld [tld]', function ($tld = null) {
+        if (empty(Configuration::read()['tld'])) {
+            Configuration::writeBaseConfiguration();
+        }
+
         if ($tld === null) {
             return info('Valet is configured to serve for TLD: .'.Configuration::read()['tld']);
         }
@@ -74,7 +78,7 @@ if (is_dir(VALET_HOME_PATH)) {
         Nginx::restart();
 
         info('Your Valet TLD has been updated to ['.$tld.'].');
-    }, ['domain'])->descriptions('Get or set the TLD used for Valet sites. (Currently: .'.Configuration::read()['tld'].')');
+    }, ['domain'])->descriptions('Get or set the TLD used for Valet sites.');
 
     /**
      * Add the current working directory to the paths configuration.


### PR DESCRIPTION
Fixes #618

This now forces a migration of the 'domain' key to 'tld' in the config, to make it easier for upgraders from v2.0.0-2.0.12 to newer.