### PR TITLE
Remove extra message text from TLD output, for valet share cmd

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -64,7 +64,7 @@ if (is_dir(VALET_HOME_PATH)) {
         }
 
         if ($tld === null) {
-            return info('Valet is configured to serve for TLD: .'.Configuration::read()['tld']);
+            return info(Configuration::read()['tld']);
         }
 
         DnsMasq::updateTld(

--- a/valet
+++ b/valet
@@ -32,7 +32,7 @@ fi
 if [[ "$1" = "share" ]]
 then
     HOST="${PWD##*/}"
-    DOMAIN=$(php "$DIR/cli/valet.php" domain)
+    TLD=$(php "$DIR/cli/valet.php" tld)
 
     for linkname in ~/.config/valet/Sites/*; do
         if [[ "$(readlink $linkname)" = "$PWD" ]]
@@ -43,7 +43,7 @@ then
 
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
-    sudo -u $(logname) "$DIR/bin/ngrok" http "$HOST.$DOMAIN:80" -host-header=rewrite ${*:2}
+    sudo -u $(logname) "$DIR/bin/ngrok" http "$HOST.$TLD:80" -host-header=rewrite ${*:2}
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
The `valet share` command relies on the `tld` command outputting only the TLD and not a status message ... much like was discussed in #620.
This removes the status message that was added with the recent tld update in #241. 

(Other alternatives were considered including special treatment if the "domain" alias was detected etc, but in the end I know that the preference is to keep the code simpler, and removing the status message felt like the best approach after all.)