### PR TITLE
Fix errors from relocation of config dir

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -41,14 +41,14 @@ class Configuration
      */
     function createConfigurationDirectory()
     {
-        $this->files->ensureDirExists(VALET_HOME_PATH, user());
-
         $oldPath = posix_getpwuid(fileowner(__FILE__))['dir'].'/.valet';
 
         if ($this->files->isDir($oldPath)) {
-            $this->prependPath(VALET_HOME_PATH.'/Sites');
             rename($oldPath, VALET_HOME_PATH);
+            $this->prependPath(VALET_HOME_PATH.'/Sites');
         }
+
+        $this->files->ensureDirExists(VALET_HOME_PATH, user());
     }
 
     /**


### PR DESCRIPTION
This PR fixes the PHP errors reported in https://github.com/laravel/valet/issues/620#issuecomment-417365462 which were a result of merging #449 

From the tests I've been doing with both "old" and "new" locations of the config files, this PR seems to resolve those.