### PR TITLE
Automatically move config after upgrade to v2.1

### DIFF
--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -14,6 +14,8 @@ define('VALET_HOME_PATH', $_SERVER['HOME'].'/.config/valet');
 define('VALET_SERVER_PATH', realpath(__DIR__ . '/../../server.php'));
 define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
 
+define('VALET_LEGACY_HOME_PATH', $_SERVER['HOME'].'/.valet');
+
 /**
  * Output the given text to the console.
  *

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -18,6 +18,13 @@ use function Valet\table;
 use function Valet\warning;
 
 /**
+ * Relocate config dir to ~/.config/valet/ if found in old location.
+ */
+if (is_dir(VALET_LEGACY_HOME_PATH) && !is_dir(VALET_HOME_PATH)) {
+    Configuration::createConfigurationDirectory();
+}
+
+/**
  * Create the application.
  */
 Container::setInstance(new Container);


### PR DESCRIPTION
Fixes #635 by detecting if the config directory is in the old location and moving it immediately when running any Valet command.