### PR TITLE
Failing functional tests with Drupal in a sub-directory

### DIFF
--- a/cli/drivers/DrupalValetDriver.php
+++ b/cli/drivers/DrupalValetDriver.php
@@ -12,6 +12,8 @@ class DrupalValetDriver extends ValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
+        $sitePath = $this->addSubdirectory($sitePath);
+
       /**
        * /misc/drupal.js = Drupal 7
        * /core/lib/Drupal.php = Drupal 8
@@ -32,6 +34,8 @@ class DrupalValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
+        $sitePath = $this->addSubdirectory($sitePath);
+
         if (file_exists($sitePath.$uri) &&
             ! is_dir($sitePath.$uri) &&
             pathinfo($sitePath.$uri)['extension'] != 'php') {
@@ -51,6 +55,8 @@ class DrupalValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        $sitePath = $this->addSubdirectory($sitePath);
+
         if (!isset($_GET['q']) && !empty($uri) && $uri !== '/') {
           $_GET['q'] = $uri;
         }
@@ -69,5 +75,37 @@ class DrupalValetDriver extends ValetDriver
         $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/index.php';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         return $sitePath.'/index.php';
+    }
+
+    /**
+     * Add any matching subdirectory to the site path.
+     */
+    public function addSubdirectory($sitePath)
+    {
+        $paths = array_map(function ($subDir) use ($sitePath) {
+            return "$sitePath/$subDir";
+        }, $this->possibleSubdirectories());
+
+        $foundPaths = array_filter($paths, function ($path) {
+            return file_exists($path);
+        });
+
+        // If paths are found, return the first one.
+        if (!empty($foundPaths)) {
+            return array_shift($foundPaths);
+        }
+
+        // If there are no matches, return the original path.
+        return $sitePath;
+    }
+
+    /**
+     * Return an array of possible subdirectories.
+     *
+     * @return array
+     */
+    private function possibleSubdirectories()
+    {
+        return ['docroot', 'public', 'web'];
     }
 }

--- a/cli/drivers/DrupalValetDriver.php
+++ b/cli/drivers/DrupalValetDriver.php
@@ -82,12 +82,21 @@ class DrupalValetDriver extends ValetDriver
      */
     public function addSubdirectory($sitePath)
     {
-        return collect($this->possibleSubdirectories())
-            ->map(function ($subDir) use ($sitePath) {
-                return "$sitePath/$subDir";
-            })->filter(function ($path) {
-                return file_exists($path);
-            })->first() ?: $sitePath;
+        $paths = array_map(function ($subDir) use ($sitePath) {
+            return "$sitePath/$subDir";
+        }, $this->possibleSubdirectories());
+
+        $foundPaths = array_filter($paths, function ($path) {
+            return file_exists($path);
+        });
+
+        // If paths are found, return the first one.
+        if (!empty($foundPaths)) {
+            return array_shift($foundPaths);
+        }
+
+        // If there are no matches, return the original path.
+        return $sitePath;
     }
 
     /**

--- a/cli/drivers/DrupalValetDriver.php
+++ b/cli/drivers/DrupalValetDriver.php
@@ -82,21 +82,12 @@ class DrupalValetDriver extends ValetDriver
      */
     public function addSubdirectory($sitePath)
     {
-        $paths = array_map(function ($subDir) use ($sitePath) {
-            return "$sitePath/$subDir";
-        }, $this->possibleSubdirectories());
-
-        $foundPaths = array_filter($paths, function ($path) {
-            return file_exists($path);
-        });
-
-        // If paths are found, return the first one.
-        if (!empty($foundPaths)) {
-            return array_shift($foundPaths);
-        }
-
-        // If there are no matches, return the original path.
-        return $sitePath;
+        return collect($this->possibleSubdirectories())
+            ->map(function ($subDir) use ($sitePath) {
+                return "$sitePath/$subDir";
+            })->filter(function ($path) {
+                return file_exists($path);
+            })->first() ?: $sitePath;
     }
 
     /**


### PR DESCRIPTION
I've spotted an issue when using Valet with Drupal, that running functional tests are failing when Drupal is installed within a sub-directory like `web` or `docroot`. This situation is becoming more common the more that using Composer to manage Drupal projects. I've been testing this with a newly cloned version of https://github.com/drupal-composer/drupal-project with the Examples module (which contains some PHPUnit tests).

Default output:

```
There was 1 error:

1) Drupal\Tests\phpunit_example\Functional\PHPUnitExampleMenuTest::testLinksAndPages
Behat\Mink\Exception\ElementNotFoundException: Button with id|name|label|value "Log in" not found.
```

Within phpunit.xml, I've set `SIMPLETEST_BASE_URL` to be `https://drupal8-subdir.test` to match the domain name provided with Valet.

Using `valet which`, I can see that the BasicValetDriver is used when in the root of the project directory (outside of the `web` sub-directory).

I've tested locally by adding a new `DrupalTestValetDriver` which includes an additional method - `addSubdirectory` - which checks for and adds the additional sub-directory to `$sitePath` if one exists. `web` and `docroot` are probably the most common sub-directory names currently, so those are checked for as well as `public`.

Output using DrupalTestValetDriver:

```
OK (33 tests, 43 assertions)
```

This PR adds the updates from DrupalTestValetDriver to the main DrupalValetDriver.

I've tried refactoring addSubdirectory to use a Collection, but currently that causes the tests to fail again. I plan on looking into this again.