### PR TITLE
Only serve statically cached files on GET requests for Statamic

### DIFF
--- a/cli/drivers/StatamicValetDriver.php
+++ b/cli/drivers/StatamicValetDriver.php
@@ -48,7 +48,7 @@ class StatamicValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        if ($this->isActualFile($staticPath = $this->getStaticPath($sitePath))) {
+        if ($_SERVER['REQUEST_METHOD'] === 'GET' && $this->isActualFile($staticPath = $this->getStaticPath($sitePath))) {
             return $staticPath;
         }
 


### PR DESCRIPTION
Statamic's Live Preview feature does a POST request to an item's actual URL with updated data so you can preview the item. If the item had already been statically cached, the same html file would load every time, and not reflect your changes.

We ship Statamic with sample config files for this situation. An htaccess for Apache, an nginx conf for Nginx, and this PR is the equivalent for Valet users.