### PR TITLE
Pre-create the parent .config dir if needed

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -41,6 +41,8 @@ class Configuration
      */
     function createConfigurationDirectory()
     {
+        $this->files->ensureDirExists(preg_replace('~/valet$~', '', VALET_HOME_PATH), user());
+
         $oldPath = posix_getpwuid(fileowner(__FILE__))['dir'].'/.valet';
 
         if ($this->files->isDir($oldPath)) {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -28,6 +28,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     public function test_configuration_directory_is_created_if_it_doesnt_exist()
     {
         $files = Mockery::mock(Filesystem::class.'[ensureDirExists,isDir]');
+        $files->shouldReceive('ensureDirExists')->once()->with(preg_replace('~/valet$~', '', VALET_HOME_PATH), user());
         $files->shouldReceive('ensureDirExists')->once()->with(VALET_HOME_PATH, user());
         $files->shouldReceive('isDir')->once();
         swap(Filesystem::class, $files);


### PR DESCRIPTION
On a fresh OSX install, the ~/.config/ dir doesn't always exist. 
This improves the installation process by checking and creating it if needed.