### PR TITLE
Sanity check for tld config

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -63,13 +63,16 @@ $app->command('install', function () {
  */
 if (is_dir(VALET_HOME_PATH)) {
     /**
+     * Upgrade helper: ensure the tld config exists
+     */
+    if (empty(Configuration::read()['tld'])) {
+        Configuration::writeBaseConfiguration();
+    }
+
+    /**
      * Get or set the TLD currently being used by Valet.
      */
     $app->command('tld [tld]', function ($tld = null) {
-        if (empty(Configuration::read()['tld'])) {
-            Configuration::writeBaseConfiguration();
-        }
-
         if ($tld === null) {
             return info(Configuration::read()['tld']);
         }


### PR DESCRIPTION
In some cases of mixed older versions and configs, the 'tld' config entry was not set.
This now updates (sets) the `tld` config entry if it is not set.