### PR TITLE
Change valet share to use port 60

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -43,7 +43,7 @@ server {
 }
 
 server {
-    listen 88;
+    listen 60;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/valet
+++ b/valet
@@ -41,11 +41,11 @@ then
         fi
     done
 
-	# Decide the correct PORT to use according if the site has a secure 
+	# Decide the correct PORT to use according if the site has a secure
 	# config or not.
 	if grep --quiet 443 ~/.config/valet/Nginx/$HOST*
 	then
-		PORT=88
+		PORT=60
 	else
 		PORT=80
 	fi


### PR DESCRIPTION
Since the current TCP port 88 clashes with Kerberos, changing it to port 60 which IANA shows as unassigned, and other databases show as not being used in general practice.

Several alternates were researched, but show (although limited use, nevertheless possible) clashes with other systems, including ports 47, 81-90, 8080-8090, and 100. Various sources were referenced, and the overall conclusion is that 60 seems to be the safest and least likely to conflict.

Tested against a few limited firewall configs without issue.
Tested with both fresh new valet installs and an older install upgraded from 2.0.x.