### PR TITLE
Disable xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 sudo: false
 
 before_install:
+  - phpenv config-rm xdebug.ini || true
   - travis_retry composer self-update
 
 cache:


### PR DESCRIPTION
This should speedup builds a bit and makes it more consistent with other Laravel libraries.