### PR TITLE
Remove redundant return.

### DIFF
--- a/cli/Valet/Filesystem.php
+++ b/cli/Valet/Filesystem.php
@@ -58,7 +58,7 @@ class Filesystem
      */
     function mkdirAsUser($path, $mode = 0755)
     {
-        return $this->mkdir($path, user(), $mode);
+        $this->mkdir($path, user(), $mode);
     }
 
     /**
@@ -118,7 +118,7 @@ class Filesystem
      * @param  string  $path
      * @param  string  $contents
      * @param  string|null  $owner
-     * @return string
+     * @return void
      */
     function put($path, $contents, $owner = null)
     {
@@ -134,11 +134,11 @@ class Filesystem
      *
      * @param  string  $path
      * @param  string  $contents
-     * @return string
+     * @return void
      */
     function putAsUser($path, $contents)
     {
-        return $this->put($path, $contents, user());
+        $this->put($path, $contents, user());
     }
 
     /**


### PR DESCRIPTION
`Filesystem::mkdir()` / `put()` always return void. So these `return`s are redundant and should be removed.