### PR TITLE
Change default PHP install pkg to 'php'

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -37,7 +37,7 @@ class PhpFpm
     function install()
     {
         if (! $this->brew->hasInstalledPhp()) {
-            $this->brew->ensureInstalled('php71', [], $this->taps);
+            $this->brew->ensureInstalled('php', [], $this->taps);
         }
 
         $this->files->ensureDirExists('/usr/local/var/log', user());


### PR DESCRIPTION
When no homebrew-installed PHP version is found, Valet attempts to install one.
The old default was `php71`. This PR changes it to `php`, which will install the latest Homebrew PHP version.
The problem with installing an older version is that Homebrew no longer symlinks it automatically. Rewriting Valet to do the symlinking is a little more involved since we should check for "which" version to link, vs other versions installed, etc.
Simply changing the default to the primary supported PHP version allows Valet to rely on Homebrew symlinking it properly ... ie: currently that means it'll install PHP 7.3

This should resolve recent complaints in old issue #533 related to "new installs of Valet on a fresh OSX"