### PR TITLE
switch php version 

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -288,27 +288,6 @@ class Brew
     }
 
     /**
-     * Search for a formula and return found, optional grep to filter results
-     *
-     * @param $formula
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    function search($formula) {
-        return collect(explode(PHP_EOL, $this->cli->runAsUser(
-            sprintf('brew search %s', $formula),
-            function ($exitCode, $errorOutput) use ($formula) {
-                output($errorOutput);
-
-                throw new DomainException('Brew was unable to find [' . $formula . '].');
-            }
-        )))->filter(function ($formulaFound) {
-            // Filter out empty and search category headers
-            return $formulaFound && !in_array($formulaFound, ['==> Formulae', '==> Casks']);
-        });
-    }
-
-    /**
      * Get the currently running brew services
      *
      * @return \Illuminate\Support\Collection

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -2,7 +2,6 @@
 
 namespace Valet;
 
-use Exception;
 use DomainException;
 
 class Brew
@@ -292,33 +291,32 @@ class Brew
      * Search for a formula and return found, optional grep to filter results
      *
      * @param $formula
-     * @param null $grep
      *
-     * @return string
+     * @return \Illuminate\Support\Collection
      */
-    function search($formula, $grep = null) {
-        return str_replace(PHP_EOL, '', $this->cli->runAsUser(
-            sprintf('brew search %s%s', $formula, $grep ? ' | grep ' . $grep : ''),
+    function search($formula) {
+        return collect(explode(PHP_EOL, $this->cli->runAsUser(
+            sprintf('brew search %s', $formula),
             function ($exitCode, $errorOutput) use ($formula) {
                 output($errorOutput);
 
                 throw new DomainException('Brew was unable to find [' . $formula . '].');
             }
-        ));
+        )))->filter(function ($formulaFound) {
+            // Filter out empty and search category headers
+            return $formulaFound && !in_array($formulaFound, ['==> Formulae', '==> Casks']);
+        });
     }
 
     /**
      * Get the currently running brew services
      *
-     * @param null $grep
      * @return \Illuminate\Support\Collection
      */
-    function getRunningServices($grep = null)
+    function getRunningServices()
     {
-        $grep = 'started' . ($grep ? '.*' . $grep : '');
-
         return collect(array_filter(explode(PHP_EOL, $this->cli->runAsUser(
-            sprintf('brew services list | grep %s | awk \'{ print $1; }\'', $grep),
+            'brew services list | grep started | awk \'{ print $1; }\'',
             function ($exitCode, $errorOutput) {
                 output($errorOutput);
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -137,6 +137,7 @@ class PhpFpm
      * Use a specific version of php
      *
      * @param $version
+     * @return string
      */
     function useVersion($version)
     {
@@ -147,17 +148,17 @@ class PhpFpm
 
         info(sprintf('Finding brew formula for: %s', $version));
         $foundVersion = $this->brew->search($version)
-            ->filter(function ($service) {
+            ->first(function ($service) {
                 return $this->brew->supportedPhpVersions()->contains($service);
-            })
-            ->first();
-        info(sprintf('Found brew formula: %s', $foundVersion));
+            });
 
-        if (!$this->brew->supportedPhpVersions()->contains($foundVersion)) {
+        if (is_null($foundVersion)) {
             throw new DomainException(
-                sprintf('Valet doesn\'t support PHP version: %s', $foundVersion)
+                sprintf('Valet can\'t find a supported version of PHP for: %s', $version)
             );
         }
+
+        info(sprintf('Found brew formula: %s', $foundVersion));
 
         if ($this->brew->hasLinkedPhp()) {
             $currentVersion = $this->brew->linkedPhp();
@@ -171,5 +172,7 @@ class PhpFpm
         $this->brew->link($foundVersion, true);
 
         $this->install();
+
+        return $foundVersion;
     }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -121,6 +121,16 @@ class PhpFpm
             : "/usr/local/etc/php/${versionNormalized}/php-fpm.d/www.conf";
     }
 
+    /**
+     * Only stop running php services
+     */
+    function stopRunning()
+    {
+        $this->brew->stopService(
+            $this->brew->getRunningServices('php')->all()
+        );
+    }
+
     function useVersion($version)
     {
         // Ensure we have php{version}
@@ -128,11 +138,13 @@ class PhpFpm
             $version = 'php' . $version;
         }
 
-        $foundResult = $this->brew->search($version, 'php');
+        info(sprintf('Finding brew formula for: %s', $version));
+        $foundVersion = $this->brew->search($version, 'php');
+        info(sprintf('Found brew formula: %s', $foundVersion));
 
-        if (!$this->brew->supportedPhpVersions()->contains($version)) {
+        if (!$this->brew->supportedPhpVersions()->contains($foundVersion)) {
             throw new DomainException(
-                sprintf('Valet doesn\'t support PHP version: %s', $version)
+                sprintf('Valet doesn\'t support PHP version: %s', $foundVersion)
             );
         }
 
@@ -142,10 +154,10 @@ class PhpFpm
             $this->brew->unlink($currentVersion);
         }
 
-        $this->brew->ensureInstalled($version);
+        $this->brew->ensureInstalled($foundVersion);
 
-        info(sprintf('Linking new version: %s', $version));
-        $this->brew->link($version, true);
+        info(sprintf('Linking new version: %s', $foundVersion));
+        $this->brew->link($foundVersion, true);
 
         $this->install();
     }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -120,4 +120,33 @@ class PhpFpm
             ? '/usr/local/etc/php/5.6/php-fpm.conf'
             : "/usr/local/etc/php/${versionNormalized}/php-fpm.d/www.conf";
     }
+
+    function useVersion($version)
+    {
+        // Ensure we have php{version}
+        if (substr($version, 0, 3) !== 'php') {
+            $version = 'php' . $version;
+        }
+
+        $foundResult = $this->brew->search($version, 'php');
+
+        if (!$this->brew->supportedPhpVersions()->contains($version)) {
+            throw new DomainException(
+                sprintf('Valet doesn\'t support PHP version: %s', $version)
+            );
+        }
+
+        if ($this->brew->hasLinkedPhp()) {
+            $currentVersion = $this->brew->linkedPhp();
+            info(sprintf('Unlinking current version: %s', $currentVersion));
+            $this->brew->unlink($currentVersion);
+        }
+
+        $this->brew->ensureInstalled($version);
+
+        info(sprintf('Linking new version: %s', $version));
+        $this->brew->link($version, true);
+
+        $this->install();
+    }
 }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -275,6 +275,20 @@ if (is_dir(VALET_HOME_PATH)) {
 
         info('Sudoers entries have been added for Brew and Valet.');
     })->descriptions('Add sudoers files for Brew and Valet to make Valet commands run without passwords');
+
+    /**
+     * Allow the user to use another version of php
+     */
+    $app->command('use phpVersion', function ($phpVersion = null) {
+        PhpFpm::stop();
+
+        PhpFpm::useVersion($phpVersion);
+
+        Nginx::restart();
+        info(sprintf('Valet is now using %s.', $phpVersion));
+    })->descriptions('Change the version of php used by valet', [
+        'phpVersion' => 'The PHP version you want to use, e.g php72',
+    ]);
 }
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -277,9 +277,9 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Add sudoers files for Brew and Valet to make Valet commands run without passwords');
 
     /**
-     * Allow the user to use another version of php
+     * Allow the user to change the version of php valet uses
      */
-    $app->command('use phpVersion', function ($phpVersion = null) {
+    $app->command('use phpVersion', function ($phpVersion) {
         PhpFpm::stopRunning();
 
         PhpFpm::useVersion($phpVersion);
@@ -287,7 +287,7 @@ if (is_dir(VALET_HOME_PATH)) {
         Nginx::restart();
         info(sprintf('Valet is now using %s.', $phpVersion));
     })->descriptions('Change the version of php used by valet', [
-        'phpVersion' => 'The PHP version you want to use, e.g php72',
+        'phpVersion' => 'The PHP version you want to use, e.g php@7.2',
     ]);
 }
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -280,7 +280,7 @@ if (is_dir(VALET_HOME_PATH)) {
      * Allow the user to use another version of php
      */
     $app->command('use phpVersion', function ($phpVersion = null) {
-        PhpFpm::stop();
+        PhpFpm::stopRunning();
 
         PhpFpm::useVersion($phpVersion);
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -282,10 +282,10 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('use phpVersion', function ($phpVersion) {
         PhpFpm::stopRunning();
 
-        PhpFpm::useVersion($phpVersion);
+        $newVersion = PhpFpm::useVersion($phpVersion);
 
         Nginx::restart();
-        info(sprintf('Valet is now using %s.', $phpVersion));
+        info(sprintf('Valet is now using %s.', $newVersion));
     })->descriptions('Change the version of php used by valet', [
         'phpVersion' => 'The PHP version you want to use, e.g php@7.2',
     ]);

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -338,39 +338,6 @@ php7');
         $this->assertSame('Some output', resolve(Brew::class)->unlink('aformula'));
     }
 
-    public function test_search_will_pass_to_brew_search_and_return_array()
-    {
-        $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->withArgs([
-            'brew search term',
-            Mockery::type('callable')
-        ])->andReturn('==> Formulae' . PHP_EOL . 'found' . PHP_EOL . '==> Casks' . PHP_EOL . 'another found' . PHP_EOL);
-
-        swap(CommandLine::class, $cli);
-        $result = resolve(Brew::class)->search('term');
-        $this->assertInstanceOf(Collection::class, $result);
-        $this->assertSame([
-            'found',
-            'another found',
-        ], array_values($result->all()));
-    }
-
-    /**
-     * @expectedException DomainException
-     */
-    public function test_search_will_throw_exception_on_failure()
-    {
-        $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->withArgs([
-            'brew search term',
-            Mockery::type('callable'),
-        ])->andReturnUsing(function ($command, $onError) {
-            $onError(1, 'test error output');
-        });
-        swap(CommandLine::class, $cli);
-        resolve(Brew::class)->search('term');
-    }
-
     /**
      * @expectedException DomainException
      */

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -336,4 +336,10 @@ php7');
         swap(CommandLine::class, $cli);
         $this->assertSame('Some output', resolve(Brew::class)->unlink('aformula'));
     }
+
+    // TODO: search will pass to brew search
+    // TODO: search will pass into grep if passed
+    // TODO: search will throw if fails
+    // TODO: getRunningServices will return array of services currently started
+    // TODO: getRunningServices can pass grep to filter result
 }

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Valet\Brew;
 use Valet\PhpFpm;
 use function Valet\user;
+use function Valet\swap;
 use function Valet\resolve;
 use Illuminate\Container\Container;
 
@@ -36,6 +38,29 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
         $this->assertContains("\nlisten = ".VALET_HOME_PATH."/valet.sock", $contents);
     }
 
+    public function test_stopRunning_will_pass_filtered_result_of_getRunningServices_to_stopService()
+    {
+        $brewMock = Mockery::mock(Brew::class);
+        $brewMock->shouldReceive('getRunningServices')->once()
+            ->andReturn(collect([
+                'php7.2',
+                'php@7.3',
+                'php56',
+                'php',
+                'nginx',
+                'somethingelse',
+            ]));
+        $brewMock->shouldReceive('stopService')->once()->with([
+            'php7.2',
+            'php@7.3',
+            'php56',
+            'php',
+        ]);
+
+        swap(Brew::class, $brewMock);
+        resolve(PhpFpm::class)->stopRunning();
+    }
+
     // TODO: useVersion if no php at start it will prefix
     // TODO: useVersion will pass version to Brew::search and then check if it's supported
     // TODO:     - if not supported will through
@@ -43,8 +68,6 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
     // TODO: useVersion will ensure new version is installed
     // TODO: useVersion will link found version (force)
     // TODO: useVersion will call install at end
-
-    // TODO: stopRunning will get the running php services and stop them
 }
 
 

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -63,7 +63,7 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
         resolve(PhpFpm::class)->stopRunning();
     }
 
-    public function test_use_version_if_no_php_at_start_will_prefix()
+    public function test_use_version_will_convert_passed_php_version()
     {
         $brewMock = Mockery::mock(Brew::class);
         $phpFpmMock = Mockery::mock(PhpFpm::class, [
@@ -74,9 +74,6 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
 
         $phpFpmMock->shouldReceive('install');
 
-        $brewMock->shouldReceive('search')->with('php7.2')->twice()->andReturn(collect([
-            'php@7.2'
-        ]));
         $brewMock->shouldReceive('supportedPhpVersions')->twice()->andReturn(collect([
             'php@7.2',
             'php@5.6',
@@ -86,28 +83,24 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
         $brewMock->shouldReceive('link')->withArgs(['php@7.2', true]);
 
         // Test both non prefixed and prefixed
-        $this->assertSame('php@7.2', $phpFpmMock->useVersion('7.2'));
         $this->assertSame('php@7.2', $phpFpmMock->useVersion('php7.2'));
+        $this->assertSame('php@7.2', $phpFpmMock->useVersion('php72'));
     }
 
     /**
      * @expectedException DomainException
-     * @expectedExceptionMessage Valet can't find a supported version of PHP for: php7.2
      */
-    public function test_use_version_will_throw_if_searched_version_is_not_supported()
+    public function test_use_version_will_throw_if_version_not_supported()
     {
         $brewMock = Mockery::mock(Brew::class);
         swap(Brew::class, $brewMock);
 
-        $brewMock->shouldReceive('search')->with('php7.2')->andReturn(collect([
-            'php@7.2'
-        ]));
         $brewMock->shouldReceive('supportedPhpVersions')->andReturn(collect([
             'php@7.3',
             'php@7.1',
         ]));
 
-        resolve(PhpFpm::class)->useVersion('7.2');
+        resolve(PhpFpm::class)->useVersion('php@7.2');
     }
 
     public function test_use_version_if_already_linked_php_will_unlink_before_installing()
@@ -120,9 +113,6 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
         ])->makePartial();
         $phpFpmMock->shouldReceive('install');
 
-        $brewMock->shouldReceive('search')->with('php@7.2')->andReturn(collect([
-            'php@7.2'
-        ]));
         $brewMock->shouldReceive('supportedPhpVersions')->andReturn(collect([
             'php@7.2',
             'php@5.6',

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -36,7 +36,15 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
         $this->assertContains("\nlisten = ".VALET_HOME_PATH."/valet.sock", $contents);
     }
 
-    // TODO: useVersion
+    // TODO: useVersion if no php at start it will prefix
+    // TODO: useVersion will pass version to Brew::search and then check if it's supported
+    // TODO:     - if not supported will through
+    // TODO: useVersion if already linked php will unlink it
+    // TODO: useVersion will ensure new version is installed
+    // TODO: useVersion will link found version (force)
+    // TODO: useVersion will call install at end
+
+    // TODO: stopRunning will get the running php services and stop them
 }
 
 

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -35,6 +35,8 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
         $this->assertContains("\ngroup = staff", $contents);
         $this->assertContains("\nlisten = ".VALET_HOME_PATH."/valet.sock", $contents);
     }
+
+    // TODO: useVersion
 }
 
 


### PR DESCRIPTION
A currently working version of #378 which also adds some functionality that would support #708 .

Usage:
```
valet use php@7.2
valet use php7.2 // We will convert to php@7.2
valet use php72 // We will convert to php@7.2
```
All passed php versions are checked against the supported versions in the Brew class.

Couple of things this has brought up, there is a current bug which I've documented here: #709 (i'll put a PR in for it)
Valet doesn't want to work on my machine when I've linked php@5.6, I'm running high sierra and I think this is just a compatibility bug rather than with this feature, I'd value someone else having a test though.