### PR TITLE
Fix SSL Certificate creation

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -304,7 +304,7 @@ class Site
             $caSrlParam = ' -CAserial ' . $caSrlPath;
         }
 
-        $this->cli->runAsUser(sprintf(
+        $this->cli->run(sprintf(
             'openssl x509 -req -sha256 -days 730 -CA "%s" -CAkey "%s"%s -in "%s" -out "%s" -extensions v3_req -extfile "%s"',
             $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath
         ));

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -304,10 +304,18 @@ class Site
             $caSrlParam = ' -CAserial ' . $caSrlPath;
         }
 
-        $this->cli->run(sprintf(
+        $result = $this->cli->runAsUser(sprintf(
             'openssl x509 -req -sha256 -days 730 -CA "%s" -CAkey "%s"%s -in "%s" -out "%s" -extensions v3_req -extfile "%s"',
             $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath
         ));
+
+        // If cert could not be created using runAsUser(), use run().
+        if (strpos($result, 'Permission denied')) {
+            $this->cli->run(sprintf(
+                'openssl x509 -req -sha256 -days 730 -CA "%s" -CAkey "%s"%s -in "%s" -out "%s" -extensions v3_req -extfile "%s"',
+                $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath
+            ));
+        }
 
         $this->trustCertificate($crtPath);
     }


### PR DESCRIPTION
Resolves issue identified in #654.

---

## Issue

When running `valet secure`, generated `.crt` file is empty and site is not reachable.

## Test steps

From within Laravel site root:

```
$ valet secure
Restarting nginx...
The [site-name] site has been secured with a fresh TLS certificate.
$ cat ~/.config/valet/Certificates/<site-name>.test.crt
```

Without code change, `.crt` file is empty.