### PR TITLE
Remove outdated option in brew install options

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -41,7 +41,7 @@ class Nginx
     function install()
     {
         if (!$this->brew->hasInstalledNginx()) {
-            $this->brew->installOrFail('nginx', ['--with-http2']);
+            $this->brew->installOrFail('nginx', []);
         }
 
         $this->installConfiguration();


### PR DESCRIPTION
Resolves #725 

Homebrew has been removing options on all formulas, therefore specifying an install option breaks the install of Valet.