### PR TITLE
Add support to setup Kirby above webroot

### DIFF
--- a/cli/drivers/KirbyValetDriver.php
+++ b/cli/drivers/KirbyValetDriver.php
@@ -25,9 +25,11 @@ class KirbyValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-       if ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
-           return $staticFilePath;
-       }
+        if ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
+            return $staticFilePath;
+        } elseif ($this->isActualFile($staticFilePath = $sitePath.'/public'.$uri)) {
+            return $staticFilePath;
+        }
 
        return false;
     }
@@ -42,19 +44,27 @@ class KirbyValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        // Needed to force Kirby to use *.dev to generate its URLs...
+        $scriptName = '/index.php';
+
+        if ($this->isActualFile($sitePath.'/index.php')) {
+            $indexPath = $sitePath.'/index.php';
+        }
+
+        if ($isAboveWebroot = $this->isActualFile($sitePath.'/public/index.php')) {
+            $indexPath = $sitePath.'/public/index.php';
+        }
+
+        if (preg_match('/^\/panel/', $uri) && $this->isActualFile($sitePath.'/panel/index.php')) {
+            $scriptName = '/panel/index.php';
+            $indexPath = $sitePath.'/panel/index.php';
+        }
+
+        $sitePathPrefix = ($isAboveWebroot) ? $sitePath.'/public' : $sitePath;
+
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+        $_SERVER['SCRIPT_NAME'] = $scriptName;
+        $_SERVER['SCRIPT_FILENAME'] = $sitePathPrefix.$scriptName;
 
-        if (preg_match('/^\/panel/', $uri) && file_exists($sitePath . '/panel/index.php')) {
-            $_SERVER['SCRIPT_NAME'] = '/panel/index.php';
-
-            return $sitePath.'/panel/index.php';
-        }
-
-        if (file_exists($indexPath = $sitePath.'/index.php')) {
-            $_SERVER['SCRIPT_NAME'] = '/index.php';
-
-            return $indexPath;
-        }
+        return $indexPath;
     }
 }


### PR DESCRIPTION
Kirby 3 now supports keeping site files above webroot. This PR adds support for it in Valet.

This driver has been tested with Kirby 2 and Kirby 3. Both versions are still supported by the same driver.