### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -78,7 +78,7 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
             'php@7.2',
             'php@5.6',
         ]));
-        $brewMock->shouldReceive('hasLinkedPhp')->andReturn(False);
+        $brewMock->shouldReceive('hasLinkedPhp')->andReturn(false);
         $brewMock->shouldReceive('ensureInstalled')->with('php@7.2');
         $brewMock->shouldReceive('link')->withArgs(['php@7.2', true]);
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!