### PR TITLE
TravisCI - change nightly(8.0) PHP to 7.4snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - nightly
+  - 7.4snapshot
 
 env:
   global:


### PR DESCRIPTION
Fixes the failing tests.

The former approach of using `nightly` to grab the latest in-dev PHP version isn't working well now that the `nightly` build is an alias for 8.0 ... and 8.0 isn't resolving composer packages since most haven't tagged anything compatible with it yet.
So switching to `7.4snapshot` allows testing against the next announced PHP version set to release later this year.