### PR TITLE
#548 Refinements ("valet logs" Command)

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -295,10 +295,8 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('log [-f|--follow] [-l|--lines=] [key]', function ($follow, $lines, $key = null) {
         $defaultLogs = [
-            'php' => VALET_HOME_PATH.'/Log/php.log',
             'php-fpm' => '/usr/local/var/log/php-fpm.log',
             'nginx' => VALET_HOME_PATH.'/Log/nginx-error.log',
-            'mysql' => VALET_HOME_PATH.'/Log/mysql.log',
             'mailhog' => '/usr/local/var/log/mailhog.log',
             'redis' => '/usr/local/var/log/redis.log',
         ];

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -291,7 +291,7 @@ if (is_dir(VALET_HOME_PATH)) {
     ]);
 
     /**
-     * Tail log files.
+     * Tail log file.
      */
     $app->command('logs [-f|--follow] [-l|--lines=] [key]', function ($follow, $lines, $key = null) {
         $defaultLogs = [
@@ -304,46 +304,60 @@ if (is_dir(VALET_HOME_PATH)) {
         ];
 
         $configLogs = data_get(Configuration::read(), 'logs');
-        if (!is_array($configLogs)) $configLogs = [];
+        if (! is_array($configLogs)) {
+            $configLogs = [];
+        }
 
         $logs = collect(array_merge($defaultLogs, $configLogs))->sortKeys();
 
-        if (!$key) {
+        if (! $key) {
             info(implode(PHP_EOL, [
-                'Here are the logs you might be interested in.',
-                null,
-                'In order to tail a log, pass the relevant log key (e.g. "php")',
+                'In order to tail a log, pass the relevant log key (e.g. "nginx")',
                 'along with any optional tail parameters (e.g. "-f" for follow).',
                 null,
-                'For example: "valet logs php -f --lines=3"',
+                'For example: "valet logs nginx -f --lines=3"',
+                null,
+                'Here are the logs you might be interested in.',
                 null,
             ]));
+
             table(
                 ['Keys', 'Files'],
                 collect($logs)->map(function ($file, $key) {
                     return [$key, $file];
                 })->toArray()
             );
+
             info(implode(PHP_EOL, [
                 null,
                 'Tip: Set custom logs by adding a "logs" key/file object',
                 'to your "'.Configuration::path().'" file.',
             ]));
+
             exit;
         }
 
-        if (!isset($logs[$key])) return warning('No logs found for ['.$key.'].');
+        if (! isset($logs[$key])) {
+            return warning('No logs found for ['.$key.'].');
+        }
 
         $file = $logs[$key];
-        if (!file_exists($file)) return warning('Log path ['.$file.'] does not (yet) exist.');
+        if (! file_exists($file)) {
+            return warning('Log path ['.$file.'] does not (yet) exist.');
+        }
 
         $options = [];
-        if ($follow) $options[] = '-f';
-        if ((int) $lines) $options[] = '-n '.(int) $lines;
+        if ($follow) {
+            $options[] = '-f';
+        }
+        if ((int) $lines) {
+            $options[] = '-n '.(int) $lines;
+        }
 
         $command = implode(' ', array_merge(['tail'], $options, [$file]));
+
         passthru($command);
-    })->descriptions('Tail log files');
+    })->descriptions('Tail log file');
 }
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -289,6 +289,28 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Change the version of php used by valet', [
         'phpVersion' => 'The PHP version you want to use, e.g php@7.2',
     ]);
+
+    /**
+     * Tail log file.
+     */
+    $app->command('logs [-f|--follow] [--lines=] [file]', function ($follow, $lines, $file = null) {
+        $defaultLogFile = VALET_HOME_PATH.'/Log/nginx-error.log';
+
+        $logFile = data_get(Configuration::read(), "logs.$file", $defaultLogFile);
+
+        $options = [];
+        
+        if ($follow) $options[] = '-f';
+
+        if ((int) $lines) {
+            $options[] = '-n';
+            $options[] = (int) $lines;
+        }
+
+        $logCommand = implode(' ', array_merge(['tail'], $options, [$logFile]));
+
+        passthru($logCommand);
+    })->descriptions('Tail log file');
 }
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -293,7 +293,7 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Tail log file.
      */
-    $app->command('logs [-f|--follow] [-l|--lines=] [key]', function ($follow, $lines, $key = null) {
+    $app->command('log [-f|--follow] [-l|--lines=] [key]', function ($follow, $lines, $key = null) {
         $defaultLogs = [
             'php' => VALET_HOME_PATH.'/Log/php.log',
             'php-fpm' => '/usr/local/var/log/php-fpm.log',

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -291,26 +291,59 @@ if (is_dir(VALET_HOME_PATH)) {
     ]);
 
     /**
-     * Tail log file.
+     * Tail log files.
      */
-    $app->command('logs [-f|--follow] [--lines=] [file]', function ($follow, $lines, $file = null) {
-        $defaultLogFile = VALET_HOME_PATH.'/Log/nginx-error.log';
+    $app->command('logs [-f|--follow] [-l|--lines=] [key]', function ($follow, $lines, $key = null) {
+        $defaultLogs = [
+            'php' => VALET_HOME_PATH.'/Log/php.log',
+            'php-fpm' => '/usr/local/var/log/php-fpm.log',
+            'nginx' => VALET_HOME_PATH.'/Log/nginx-error.log',
+            'mysql' => VALET_HOME_PATH.'/Log/mysql.log',
+            'mailhog' => '/usr/local/var/log/mailhog.log',
+            'redis' => '/usr/local/var/log/redis.log',
+        ];
 
-        $logFile = data_get(Configuration::read(), "logs.$file", $defaultLogFile);
+        $configLogs = data_get(Configuration::read(), 'logs');
+        if (!is_array($configLogs)) $configLogs = [];
 
-        $options = [];
-        
-        if ($follow) $options[] = '-f';
+        $logs = collect(array_merge($defaultLogs, $configLogs))->sortKeys();
 
-        if ((int) $lines) {
-            $options[] = '-n';
-            $options[] = (int) $lines;
+        if (!$key) {
+            info(implode(PHP_EOL, [
+                'Here are the logs you might be interested in.',
+                null,
+                'In order to tail a log, pass the relevant log key (e.g. "php")',
+                'along with any optional tail parameters (e.g. "-f" for follow).',
+                null,
+                'For example: "valet logs php -f --lines=3"',
+                null,
+            ]));
+            table(
+                ['Keys', 'Files'],
+                collect($logs)->map(function ($file, $key) {
+                    return [$key, $file];
+                })->toArray()
+            );
+            info(implode(PHP_EOL, [
+                null,
+                'Tip: Set custom logs by adding a "logs" key/file object',
+                'to your "'.Configuration::path().'" file.',
+            ]));
+            exit;
         }
 
-        $logCommand = implode(' ', array_merge(['tail'], $options, [$logFile]));
+        if (!isset($logs[$key])) return warning('No logs found for ['.$key.'].');
 
-        passthru($logCommand);
-    })->descriptions('Tail log file');
+        $file = $logs[$key];
+        if (!file_exists($file)) return warning('Log path ['.$file.'] does not (yet) exist.');
+
+        $options = [];
+        if ($follow) $options[] = '-f';
+        if ((int) $lines) $options[] = '-n '.(int) $lines;
+
+        $command = implode(' ', array_merge(['tail'], $options, [$file]));
+        passthru($command);
+    })->descriptions('Tail log files');
 }
 
 /**


### PR DESCRIPTION
This PR is submitted in response to @mattstauffer's recent tweet regarding @gahlawat's #548:

[<img width="591" alt="tweet" src="https://user-images.githubusercontent.com/1914481/55528457-a90b4400-56e8-11e9-9006-fafb8401c19a.png">
](https://twitter.com/stauffermatt/status/1113538473976324105)

By default, the `logs` command tails Valet's `/Log/nginx-error.log` file:

```
valet logs
```

To tail **custom** log files, add relevant `"logs"` key/path values to `~/.config/valet/config.json`…

```
{
    "tld": "test",
    "paths": [
        "…"
    ],
    "logs": {
        "nginx-access": "/path/to/nginx-access.log",
        "php-error": "/path/to/php-fpm-errors.log",
        "dnsmasq": "/path/to/dnsmasq.log",
        "etc": "…"
    }
}
```

…then pass the relevant `"logs"` key when calling the `logs` command:

```
valet logs nginx-access
valet logs php-error
valet logs dnsmasq
```

To **follow** the tailed log file, pass the `-f|--follow` flag:

```
valet logs -f
valet logs --follow
```

To **restrict** the number of tailed lines, pass the `--lines` flag (`-n` was taken):

```
valet logs --lines 1
valet logs --lines=1
```

Hope these tweaks add the refinement you're looking for.

Cheers!

🤓🤞