### PR TITLE
Fix issue with CA serial params

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -299,20 +299,20 @@ class Site
         $this->createPrivateKey($keyPath);
         $this->createSigningRequest($url, $keyPath, $csrPath, $confPath);
 
-        $caSrlParam = ' -CAcreateserial';
-        if ($this->files->exists($caSrlPath)) {
-            $caSrlParam = ' -CAserial ' . $caSrlPath;
+        $caSrlParam = '-CAserial ' . $caSrlPath;
+        if (! $this->files->exists($caSrlPath)) {
+            $caSrlParam .= ' -CAcreateserial';
         }
 
         $result = $this->cli->runAsUser(sprintf(
-            'openssl x509 -req -sha256 -days 730 -CA "%s" -CAkey "%s"%s -in "%s" -out "%s" -extensions v3_req -extfile "%s"',
+            'openssl x509 -req -sha256 -days 730 -CA "%s" -CAkey "%s" %s -in "%s" -out "%s" -extensions v3_req -extfile "%s"',
             $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath
         ));
 
         // If cert could not be created using runAsUser(), use run().
         if (strpos($result, 'Permission denied')) {
             $this->cli->run(sprintf(
-                'openssl x509 -req -sha256 -days 730 -CA "%s" -CAkey "%s"%s -in "%s" -out "%s" -extensions v3_req -extfile "%s"',
+                'openssl x509 -req -sha256 -days 730 -CA "%s" -CAkey "%s" %s -in "%s" -out "%s" -extensions v3_req -extfile "%s"',
                 $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath
             ));
         }


### PR DESCRIPTION
Should always provide CAserial, but should only provide CAcreateserial if file does not exist. Should probably fix permissions issue mentioned in the comments when attempting to create certificate.