### PR TITLE
Fixes deprecated Process argument passed as string

### DIFF
--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -74,7 +74,7 @@ class CommandLine
     {
         $onError = $onError ?: function () {};
 
-        $process = new Process($command);
+        $process = Process::fromShellCommandline($command);
 
         $processOutput = '';
         $process->setTimeout(null)->run(function ($type, $line) use (&$processOutput) {


### PR DESCRIPTION
Passing a command as string is deprecated since Symfony 4.2. Since we don't have command available as array, we should use `Process::fromShellCommandline()` instead.