### PR TITLE
Allow TravisCI to fail on PHP7.4snapshot builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ php:
   - 7.3
   - 7.4snapshot
 
+matrix:
+  allow_failures:
+    - php: 7.4snapshot
+
 env:
   global:
     - setup=basic


### PR DESCRIPTION
Until it's stable we probably shouldn't be failing builds that run into glitches with the nightly snapshots.