### PR TITLE
Fixed warning on newer symfony/process versions

### DIFF
--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -74,7 +74,11 @@ class CommandLine
     {
         $onError = $onError ?: function () {};
 
-        $process = new Process($command);
+        if (method_exists(Process::class, 'fromShellCommandline')) {
+            $process = Process::fromShellCommandline($command);
+        } else {
+            $process = new Process($command);
+        }
 
         $processOutput = '';
         $process->setTimeout(null)->run(function ($type, $line) use (&$processOutput) {

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -74,6 +74,9 @@ class CommandLine
     {
         $onError = $onError ?: function () {};
 
+        // Symfony 4.x throws a warning when the command string is passed to the constructor
+        // But the version constraint allows older versions, too
+        // For more information, see: https://github.com/laravel/valet/pull/761
         if (method_exists(Process::class, 'fromShellCommandline')) {
             $process = Process::fromShellCommandline($command);
         } else {


### PR DESCRIPTION
And also check whether the method exists, see Issue #763 which was caused by my previous attempt to fix a warning., which can be found here: #761 