### PR TITLE
HOME Autoloader

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -6,8 +6,10 @@
  */
 if (file_exists(__DIR__.'/../vendor/autoload.php')) {
     require __DIR__.'/../vendor/autoload.php';
-} else {
+} elseif (file_exists(__DIR__.'/../../../autoload.php')) {
     require __DIR__.'/../../../autoload.php';
+} else {
+    require getenv('HOME').'/.composer/vendor/autoload.php';
 }
 
 use Silly\Application;


### PR DESCRIPTION
## Overview

This PR adds a `HOME` path to the list of potential autoloaders at the head of Valet's CLI file.

![home-autoloader](https://user-images.githubusercontent.com/1914481/56011545-7508d200-5d2b-11e9-898a-385b0b62db29.png)

## Background

To work on third-party open source PRs, I use [franzliedke/studio](https://github.com/franzliedke/studio) (installed globally).

My `studio` workflow for Valet PRs is to…

- Clone `laravel/valet` locally
- Create a new PR branch (e.g. `new-pr-branch`)
- From within `~/.composer` run `studio load [path to local laravel/valet clone]`
- Open `~/.composer/composer.json`
- Update `"laravel/valet": [version]` to `"laravel/valet": "dev-new-pr-branch"`
- Run `composer global update laravel/valet`

After stepping through my workflow…

- Without this PR, `valet` exits as no autoloader path can be found.
- With this PR, `valet` boots normally as the `HOME` autoloader path is found.

I understand…

- This PR may be of no use to Windows users.
- My PR workflow is probably an edge case.

Cheers!

🤓🤞