### PR TITLE
Enable subdomains

### DIFF
--- a/server.php
+++ b/server.php
@@ -88,10 +88,14 @@ foreach ($valetConfig['paths'] as $path) {
         $valetSitePath = $path.'/'.$siteName;
         break;
     }
+}
 
-    if (is_dir($path.'/'.$domain)) {
-        $valetSitePath = $path.'/'.$domain;
-        break;
+if (is_null($valetSitePath)) {
+    foreach ($valetConfig['paths'] as $path) {
+        if (is_dir($path.'/'.$domain)) {
+            $valetSitePath = $path.'/'.$domain;
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
I know this has been talked about before, but I've already done the work so thought I'd post & get some feedback.

So this is very basic way to enable some sort of subdomain structure.
Should be fully backwards compatible, only change is looping through `$valetConfig['paths']` twice, checking first for `$sitename`, then for `$domain` - instead of checking them both in the same loop.

The payoff being you can now structure your folders like `project1.company`, `project2.company` - matching `project1.company.test`, `project2.company.test` etc..

In my case I also have a company folder: `company/project1.company` etc.. adding more organzation. (just have to `park` the company folder).