### PR TITLE
Preserve user Home and env when calling sudo commands

### DIFF
--- a/valet
+++ b/valet
@@ -22,7 +22,7 @@ fi
 
 if [[ "$EUID" -ne 0 ]]
 then
-    sudo "$SOURCE" "$@"
+    sudo --preserve-env "$SOURCE" "$@"
     exit
 fi
 


### PR DESCRIPTION
Fixes #321 where valet home path was getting set into /var/root folder
Creds to @Patistar