### PR TITLE
Fix "sudo: sorry, you are not allowed to preserve the environment" msg

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -272,7 +272,7 @@ class Brew
         $this->files->ensureDirExists('/etc/sudoers.d');
 
         $this->files->put('/etc/sudoers.d/brew', 'Cmnd_Alias BREW = /usr/local/bin/brew *
-%admin ALL=(root) NOPASSWD: BREW'.PHP_EOL);
+%admin ALL=(root) NOPASSWD:SETENV: BREW'.PHP_EOL);
     }
 
     /**

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -79,6 +79,6 @@ class Valet
         $this->files->ensureDirExists('/etc/sudoers.d');
 
         $this->files->put('/etc/sudoers.d/valet', 'Cmnd_Alias VALET = /usr/local/bin/valet *
-%admin ALL=(root) NOPASSWD: VALET'.PHP_EOL);
+%admin ALL=(root) NOPASSWD:SETENV: VALET'.PHP_EOL);
     }
 }


### PR DESCRIPTION
If you've previously run `valet trust` to allow valet to run without specifying `sudo` repeatedly or entering your password with various valet commands, recent updates to MacOS may give you a `sudo: sorry, you are not allowed to preserve the environment` response when trying to run those `valet` commands.

The fix is in updating the sudoers entry that `valet trust` creates.

This PR tells valet how to update the sudoers entry so that this message doesn't continue.

YOU WILL NEED TO RE-RUN `valet trust` IF YOU HAD PREVIOUSLY RUN IT, after installing this update, in order for this code change to have any effect.

(Technical explanation: the sudoers protections have become stricter, so we have to be more explicit that we do indeed want environment variables to flow through to the sudo user's environment when using valet via sudoers entries.)

Updates #770 and related to #321