### PR TITLE
Replace sortKeys with native ksort to avoid bumping Collect dependency

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -308,7 +308,8 @@ if (is_dir(VALET_HOME_PATH)) {
             $configLogs = [];
         }
 
-        $logs = collect(array_merge($defaultLogs, $configLogs))->sortKeys();
+        $logs = array_merge($defaultLogs, $configLogs);
+        ksort($logs);
 
         if (! $key) {
             info(implode(PHP_EOL, [


### PR DESCRIPTION
We require Collect@5.3 but sortKeys was introduced in 5.6.6. This small change avoids bumping up that dependency for a simple sort.