### PR TITLE
remove unnecessary confusion

### DIFF
--- a/cli/drivers/LaravelValetDriver.php
+++ b/cli/drivers/LaravelValetDriver.php
@@ -33,10 +33,6 @@ class LaravelValetDriver extends ValetDriver
 
         $storageUri = $uri;
 
-        if (strpos($uri, '/storage/') === 0) {
-            $storageUri = substr($uri, 8);
-        }
-
         if ($this->isActualFile($storagePath = $sitePath.'/storage/app/public'.$storageUri)) {
             return $storagePath;
         }


### PR DESCRIPTION
I know this won't be accepted but am putting this out there if you people haven't noticed!!  
When developing Laravel apps with Valet on the localhost, all static files (especially images) are accessible without the `storage` word in the URL due to this function but once you deploy to production the URL isn't accessible anymore even after running the `storage:link` command  
Lots of times am writing code logic based on the accessibility of the files without the `storage` in URL and this breaks in production, especially when storing user uploaded images to the root of the public storage directory!!  