### PR TITLE
Add link to upgrade instructions in outdated version error message

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -262,9 +262,10 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('on-latest-version', function () use ($version) {
         if (Valet::onLatestVersion($version)) {
-            output('YES');
+            output('Yes');
         } else {
-            output('NO');
+            output(sprintf('Your version of Valet (%s) is not the latest version available.', $version));
+            output('Upgrade instructions can be found in the docs: https://laravel.com/docs/valet#upgrading');
         }
     })->descriptions('Determine if this is the latest version of Valet');
 
@@ -288,7 +289,7 @@ if (is_dir(VALET_HOME_PATH)) {
 
         Nginx::restart();
         info(sprintf('Valet is now using %s.', $newVersion));
-    })->descriptions('Change the version of php used by valet', [
+    })->descriptions('Change the version of PHP used by valet', [
         'phpVersion' => 'The PHP version you want to use, e.g php@7.2',
     ]);
 


### PR DESCRIPTION
Previously when checking if the Valet version in use was the latest,
you'd have to go to Valet repo on GitHub, find out that all the docs
were on laravel.com, go there, find the upgrade instructions, and then
upgrade.

This can be simplified by giving the user the option to view the link.

Sample output:
```
$ ./valet on-latest-version
Your version of Valet (2.3.3) is not the latest version available.
Upgrade instructions can be found in the docs: https://laravel.com/docs/valet#upgrading
```

Future potential improvements:
- Add option asking the user if they would like to have the docs opened for them (and open the page in their browser if they do want that)