### PR TITLE
Fire the .valet-env environment var detection earlier

### DIFF
--- a/server.php
+++ b/server.php
@@ -122,6 +122,13 @@ if (isset($_SERVER['HTTP_X_ORIGINAL_HOST']) && !isset($_SERVER['HTTP_X_FORWARDED
 }
 
 /**
+ * Attempt to load server environment variables.
+ */
+$valetDriver->loadServerEnvironmentVariables(
+    $valetSitePath, $siteName
+);
+
+/**
  * Allow driver to mutate incoming URL.
  */
 $uri = $valetDriver->mutateUri($uri);
@@ -134,13 +141,6 @@ $isPhpFile = pathinfo($uri, PATHINFO_EXTENSION) === 'php';
 if ($uri !== '/' && ! $isPhpFile && $staticFilePath = $valetDriver->isStaticFile($valetSitePath, $siteName, $uri)) {
     return $valetDriver->serveStaticFile($staticFilePath, $valetSitePath, $siteName, $uri);
 }
-
-/**
- * Attempt to load server environment variables.
- */
-$valetDriver->loadServerEnvironmentVariables(
-    $valetSitePath, $siteName
-);
 
 /**
  * Attempt to dispatch to a front controller.


### PR DESCRIPTION
To support smarter detection of static-file detection and allow Valet to mutate the URI for externally-hosted assets (save bandwidth and local storage etc), detecting any custom-inserted environment variables needs to happen slightly sooner in the execution cycle.

Discovered this issue when troubleshooting #729 and #247. While they have other workarounds, this PR simplifies things, and potentially makes custom drivers slightly easier too ... when the use-case applies.