### PR TITLE
Increase nginx buffer sizes in dev

### DIFF
--- a/cli/stubs/fastcgi_params
+++ b/cli/stubs/fastcgi_params
@@ -18,3 +18,17 @@ fastcgi_param SERVER_NAME  $server_name;
 fastcgi_param HTTPS   $https if_not_empty;
 fastcgi_param REDIRECT_STATUS  200;
 fastcgi_param HTTP_PROXY  "";
+
+
+
+# Very large cookies/headers may throw errors without the following (extremely generous) settings:
+#fastcgi_buffer_size 4096k;
+#fastcgi_buffers 128 4096k;
+#fastcgi_busy_buffers_size 4096k;
+
+# Long-running/slow services
+fastcgi_read_timeout 300;
+#proxy_connect_timeout 600;
+#proxy_send_timeout 600;
+#proxy_read_timeout 600;
+#send_timeout 600;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -31,3 +31,15 @@ server {
         deny all;
     }
 }
+
+
+## Size Limits & Buffer Overflows 
+## the size may be configured based on the needs. 
+client_body_buffer_size 100k;
+client_header_buffer_size 1k;
+large_client_header_buffers 2 1k;
+
+# large buffer support
+#proxy_buffer_size 4096k;
+#proxy_buffers 128 4096k;
+#proxy_busy_buffers_size 4096k;


### PR DESCRIPTION
These larger buffer sizes accommodate larger requests that are often complained about in Valet support issues.
These updates are inspired by common configs in Homestead.

I've been using these in my local Valet config for 4+ months, without any negative side-effects.