### PR TITLE
Improve security by listening on 127.0.0.1 only

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,11 +1,11 @@
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
 }
 
 server {
-    listen 443 ssl http2;
+    listen 127.0.0.1:443 ssl http2;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
@@ -43,7 +43,7 @@ server {
 }
 
 server {
-    listen 60;
+    listen 127.0.0.1:60;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen 127.0.0.1:80 default_server;
     root /;
     charset utf-8;
     client_max_body_size 128M;


### PR DESCRIPTION
Fixes #772

I've been using this config change since Aug 17, 2019, without any negative side-effects.
All Valet services continue to work properly, and Valet Share still works just as expected.

If someone were to have a challenge with it, there's an easy downgrade: just remove the `127.0.0.1:` from these files, and run `valet tld test` to rebuild the individual site configs. Or just manually edit the `~/.config/valet/Nginx` site file manually.