### PR TITLE
Add compatibility with global illuminate 6.0 pkgs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     },
     "require": {
         "php": ">=5.6",
-        "illuminate/container": "~5.1",
+        "illuminate/container": "~5.1 | ^6.0",
         "mnapoli/silly": "~1.0",
         "symfony/process": "~2.7|~3.0|~4.0",
         "nategood/httpful": "~0.2",
-        "tightenco/collect": "^5.3"
+        "tightenco/collect": "^5.3 | ^6.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",


### PR DESCRIPTION
While the "technical" underlying code hasn't changed much, the version number dependencies do create some challenges (ref #815). Hence, I think it's sensible to update the versions.

Tests appear to pass properly when updating to ^6.0 and thus far it runs happily in my environment.
