### PR TITLE
Allow for longer domain names

### DIFF
--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -11,6 +11,7 @@ http {
 
     sendfile on;
     keepalive_timeout  65;
+    types_hash_max_size 2048;
     client_max_body_size 128M;
 
     server_names_hash_bucket_size 128;
@@ -20,6 +21,7 @@ http {
     gzip_min_length 256;
     gzip_proxied any;
     gzip_vary on;
+    
     ssi on;
 
     gzip_types

--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -13,6 +13,8 @@ http {
     keepalive_timeout  65;
     client_max_body_size 128M;
 
+    server_names_hash_bucket_size 128;
+
     gzip  on;
     gzip_comp_level 5;
     gzip_min_length 256;


### PR DESCRIPTION
Increases domain name length support in Valet per #543 and #808

These are the same settings used in Forge.