### PR TITLE
Turn off logging of hits to robots.txt and favicon.ico

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -25,6 +25,9 @@ server {
         rewrite ^ "VALET_SERVER_PATH" last;
     }
 
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
     access_log off;
     error_log "VALET_HOME_PATH/Log/nginx-error.log";
 
@@ -59,6 +62,9 @@ server {
     location / {
         rewrite ^ "VALET_SERVER_PATH" last;
     }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "VALET_HOME_PATH/Log/nginx-error.log";

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -14,6 +14,9 @@ server {
         rewrite ^ "VALET_SERVER_PATH" last;
     }
 
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
     access_log off;
     error_log "VALET_HOME_PATH/Log/nginx-error.log";
 


### PR DESCRIPTION
A long-requested adjustment to Valet is to bypass the logging of robots.txt and favicon.ico hits. Particularly when keeping an Ngrok session alive.

This update is consistent with default logging settings in Forge.