### PR TITLE
Allow custom .php files to be executed for Magento2

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -142,6 +142,11 @@ class Magento2ValetDriver extends ValetDriver
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
         $this->checkMageMode($sitePath);
+        
+        if (file_exists($sitePath . $uri) {
+            $_SERVER['DOCUMENT_ROOT'] = $sitePath;
+            return $sitePath . $uri;
+        }
 
         if ('developer' === $this->mageMode) {
             $_SERVER['DOCUMENT_ROOT'] = $sitePath;


### PR DESCRIPTION
By Default Valet pushes all non-static file requests to index.php without checking if the requested file even exists. 

In Production, this would be whitelisted inside of .htaccess or nginx. 

Currently, in Valet there is no option to allow custom php files in this driver
