### PR TITLE
Add 'parked' command to show all sites which have been parked

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -109,7 +109,7 @@ class Site
 
         $certs = $this->getCertificates($certsPath);
 
-        return $this->getLinks($this->sitesPath(), $certs);
+        return $this->getSites($this->sitesPath(), $certs);
     }
 
     /**
@@ -155,8 +155,7 @@ class Site
     }
 
     /**
-     * Get list of links and present them formatted.
-     * Use generic getSites which works for link and non link sites
+     * @deprecated Use getSites instead which works for both normal and symlinked paths.
      *
      * @param string $path
      * @param \Illuminate\Support\Collection $certs

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -102,6 +102,15 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Register the current working (or specified) directory with Valet');
 
     /**
+     * Get all the current sites within paths parked with 'park {path}'
+     */
+    $app->command('parked', function () {
+        $parked = Site::parked();
+
+        table(['Site', 'SSL', 'URL', 'Path'], $parked->all());
+    })->descriptions('Display all the current sites within parked paths');
+
+    /**
      * Remove the current working directory from the paths configuration.
      */
     $app->command('forget [path]', function ($path = null) {


### PR DESCRIPTION
Feature to provide functionality requested in #799 

Added under a separate command to be used alongside 'links' for only parked paths.

I left Site::getLinks as I wasn't sure if I should just replace it's usage with the newly added Site::getSites, I can do if that would be better.

<img width="785" alt="Screen Shot 2019-10-02 at 12 32 04" src="https://user-images.githubusercontent.com/6758366/66048338-43760400-e521-11e9-923b-ece3e112c493.png">
