### PR TITLE
fastcgi_split_path_info location regex fix

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -33,12 +33,13 @@ server {
 
     error_page 404 "VALET_SERVER_PATH";
 
-    location ~ \.php$ {
+    location ~ [^/]\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass "unix:VALET_HOME_PATH/valet.sock";
         fastcgi_index "VALET_SERVER_PATH";
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
+        fastcgi_param PATH_INFO $fastcgi_path_info;
     }
 
     location ~ /\.ht {
@@ -71,12 +72,13 @@ server {
 
     error_page 404 "VALET_SERVER_PATH";
 
-    location ~ \.php$ {
+    location ~ [^/]\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass "unix:VALET_HOME_PATH/valet.sock";
         fastcgi_index "VALET_SERVER_PATH";
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
+        fastcgi_param PATH_INFO $fastcgi_path_info;
     }
 
     location ~ /\.ht {

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -22,12 +22,13 @@ server {
 
     error_page 404 "VALET_SERVER_PATH";
 
-    location ~ \.php$ {
+    location ~ [^/]\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass "unix:VALET_HOME_PATH/valet.sock";
         fastcgi_index "VALET_SERVER_PATH";
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
+        fastcgi_param PATH_INFO $fastcgi_path_info;
     }
 
     location ~ /\.ht {


### PR DESCRIPTION
The `fastcgi_split_path_info` directive is ineffective in this NGINX configuration.
More @ https://github.com/laravel/docs/pull/4867