### PR TITLE
Ignore parked paths that are not directories when getting sites

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -198,6 +198,8 @@ class Site
                 $realPath = $this->files->realpath($sitePath);
             }
             return [$site => $realPath];
+        })->filter(function ($path) {
+            return $this->files->isDir($path);
         })->map(function ($path, $site) use ($certs, $config) {
             $secured = $certs->has($site);
             $url = ($secured ? 'https': 'http').'://'.$site.'.'.$config['tld'];


### PR DESCRIPTION
When I added the parked command I forgot about non directory paths, I only noticed this today when a .DS_Store file was created in the directory and showed up in the parked output.

This fix filters out the sites by ensuring the path is a directory.