### PR TITLE
Do not show sites in parked if they would not be served

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -125,14 +125,21 @@ class Site
 
         $certs = $this->getCertificates($certsPath);
 
+        $links = $this->getSites($this->sitesPath(), $certs);
+
         $config = $this->config->read();
         $parkedLinks = collect();
-        foreach ($config['paths'] as $path) {
+        foreach (array_reverse($config['paths']) as $path) {
             if ($path === $this->sitesPath()) {
                 continue;
             }
 
-            $parkedLinks = $parkedLinks->merge($this->getSites($path, $certs));
+            // Only merge on the parked sites that don't interfere with the linked sites
+            $sites = $this->getSites($path, $certs)->filter(function ($site, $key) use ($links) {
+                return !$links->has($key);
+            });
+
+            $parkedLinks = $parkedLinks->merge($sites);
         }
 
         return $parkedLinks;


### PR DESCRIPTION
Another issue I saw, this with duplicate site names.
Currently a linked site takes precedence over a parked site so it shouldn't be shown under 'parked' as it will never be served.
This also fixes an issue if you have multiple parked directories, the later parked ones would overwrite the previous if they share a site name, I've reversed this.