### PR TITLE
Symfony/Process 4.4.0 compatibility

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -479,7 +479,7 @@ class Site
         $this->cli->run(sprintf('sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain', $url));
         $this->cli->run(sprintf('sudo security delete-certificate -c "*.%s" /Library/Keychains/System.keychain', $url));
         $this->cli->run(sprintf(
-            'sudo security find-certificate -e "%s%s" -a -Z | grep SHA-1 | sudo awk \'{system("security delete-certificate -Z "$NF" /Library/Keychains/System.keychain")}\'',
+            'sudo security find-certificate -e "%s%s" -a -Z | grep SHA-1 | sudo awk \'{system("security delete-certificate -Z \'$NF\' /Library/Keychains/System.keychain")}\'',
             $url, '@laravel.valet'
         ));
     }


### PR DESCRIPTION
Process `4.4.0` changed command-line parsing by being more aggressive with substitutions, causing our intended literal `"$NF"` to throw an exception.

https://github.com/symfony/process/compare/v4.3.8...v4.4.0#diff-9a01fc0e340da4c3f1e4a16029a63977R1644-R1653

The change made in this PR still functions correctly on both Process `4.3.8` and `4.4.0`. (I watched it update Keychain correctly, as well as generate the certificates in Valet's folders.)

Fixes #810 
Fixes #842 