### PR TITLE
Add comment to consider running composer global update after switching php version

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -298,6 +298,7 @@ if (is_dir(VALET_HOME_PATH)) {
 
         Nginx::restart();
         info(sprintf('Valet is now using %s.', $newVersion));
+        info('Note that you might need to run <comment>composer global update</comment> if your PHP version change affects the dependencies of global packages required by composer.');
     })->descriptions('Change the version of PHP used by valet', [
         'phpVersion' => 'The PHP version you want to use, e.g php@7.2',
     ]);


### PR DESCRIPTION
When switching to older PHP versions there may be a composer package dependency conflict. This PR adds a note to consider running `composer global update` to update those dependencies. It's only a comment since not all changes in PHP version will require running the update.

Fixes #822