### PR TITLE
Drop unnecessary symfony/process 2.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": ">=5.6",
         "illuminate/container": "~5.1 | ^6.0",
         "mnapoli/silly": "~1.0",
-        "symfony/process": "~2.7|~3.0|~4.0|~5.0",
+        "symfony/process": "~3.0|~4.0|~5.0",
         "nategood/httpful": "~0.2",
         "tightenco/collect": "^5.3 | ^6.0"
     },


### PR DESCRIPTION
Since we require PHP > 5.6 there's no need to support symfony/process 2.x 

However, symfony/process 4.x requires minimum PHP 7.1 so have to retain 3.x for now if we wish to support PHP 7.0 or older without complications.

As referenced in #845 comments.