### PR TITLE
Display nginx config errors on start

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -115,7 +115,7 @@ class Nginx
      */
     private function lint()
     {
-        $this->cli->quietly(
+        $this->cli->run(
             'sudo nginx -c '.static::NGINX_CONF.' -t',
             function ($exitCode, $outputMessage) {
                 throw new DomainException("Nginx cannot start, please check your nginx.conf [$exitCode: $outputMessage].");


### PR DESCRIPTION
While since #268 valet has been checking nginx configs for errors when starting/restarting, the captured errors are never displayed if there is a failure because it's being run using `quietly()`. 
This PR causes the errors to pass through to the console so we can more readily understand why nginx may not be starting or not serving properly.