### PR TITLE
Include dnsmasq in valet start/restart command

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -49,6 +49,11 @@ class DnsMasq
         info('Valet is configured to serve for TLD [.'.$tld.']');
     }
 
+    function restart()
+    {
+        $this->brew->restartService('dnsmasq');
+    }
+
     /**
      * Append the custom DnsMasq configuration file to the main configuration file.
      *

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -228,6 +228,8 @@ if (is_dir(VALET_HOME_PATH)) {
      * Start the daemon services.
      */
     $app->command('start', function () {
+        DnsMasq::restart();
+
         PhpFpm::restart();
 
         Nginx::restart();
@@ -239,6 +241,8 @@ if (is_dir(VALET_HOME_PATH)) {
      * Restart the daemon services.
      */
     $app->command('restart', function () {
+        DnsMasq::restart();
+
         PhpFpm::restart();
 
         Nginx::restart();


### PR DESCRIPTION
While it's rare that the dnsmasq won't be started, it feels incomplete to not include the service when starting/restarting valet, since valet depends on it.