### PR TITLE
Add --all parameter to valet unsecure command

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -484,6 +484,37 @@ class Site
         ));
     }
 
+    function unsecureAll()
+    {
+        $tld = $this->config->read()['tld'];
+
+        $secured = $this->parked()
+            ->merge($this->links())
+            ->sort()
+            ->where('secured', ' X');
+
+        if ($secured->count() === 0) {
+            return info('No sites to unsecure. You may list all servable sites or links by running <comment>valet parked</comment> or <comment>valet links</comment>.');
+        }
+
+        info('Attempting to unsecure the following sites:');
+        table(['Site', 'SSL', 'URL', 'Path'], $secured->toArray());
+
+        foreach ($secured->pluck('site') as $url) {
+            $this->unsecure($url . '.' . $tld);
+        }
+
+        $remaining = $this->parked()
+            ->merge($this->links())
+            ->sort()
+            ->where('secured', ' X');
+        if ($remaining->count() > 0) {
+            warning('We were not succesful in unsecuring the following sites:');
+            table(['Site', 'SSL', 'URL', 'Path'], $remaining->toArray());
+        }
+        info('unsecure --all was successful.');
+    }
+
     /**
      * Get the path to the linked Valet sites.
      *

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -164,7 +164,13 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.
      */
-    $app->command('unsecure [domain]', function ($domain = null) {
+    $app->command('unsecure [domain] [--all]', function ($domain = null, $all) {
+
+        if ($all) {
+            Site::unsecureAll();
+            return;
+        }
+
         $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
 
         Site::unsecure($url);


### PR DESCRIPTION
This PR allows passing `--all` to `valet unsecure` to have it remove all certificates from all Valet configs AND from the MacOS Keychain.
This effectively cleans up certificate fragments or broken configs, and can help with troubleshooting.