### PR TITLE
Set robots nofollow for all valet share traffic

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -54,6 +54,8 @@ server {
     charset utf-8;
     client_max_body_size 128M;
 
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
     location /VALET_STATIC_PREFIX/ {
         internal;
         alias /;


### PR DESCRIPTION
Replaces and closes #575 ... for reasons described there.

I've been using this for a couple months without issue. (Granted, I don't leave valet share running for extended periods.)