### PR TITLE
Move PHP-FPM pool config to separate valet-specific file

### DIFF
--- a/cli/stubs/etc-phpfpm-valet.conf
+++ b/cli/stubs/etc-phpfpm-valet.conf
@@ -1,0 +1,26 @@
+; FPM pool configuration for Valet
+
+[valet]
+user = VALET_USER
+group = staff
+listen = VALET_HOME_PATH/valet.sock
+listen.owner = VALET_USER
+listen.group = staff
+listen.mode = 0777
+
+
+php_admin_value[memory_limit] = 128M
+php_admin_value[upload_max_filesize] = 128M
+php_admin_value[post_max_size] = 128M
+
+;php_admin_value[error_log] = VALET_HOME_PATH/Log/fpm-php.www.log
+;php_admin_flag[log_errors] = on
+
+
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+


### PR DESCRIPTION
This allows the valet FPM pool configuration to stand separately from the default config.

This benefits troubleshooting, makes customization of FPM workers and other settings easer
and allows for easier uninstallation.

(Note: existing Valet installs will have had their PHP `/usr/local/etc/php/7.4/php-fpm.d/www.conf` files already altered by Valet. It will be best to restore this file to the default version installed by PHP to prevent duplicate FPM pool instances that conflict with each other. 
Or, simply delete the `www.conf` file.)