### PR TITLE
Cater for filepaths with spaces

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -365,7 +365,7 @@ class Site
         $this->createPrivateKey($keyPath);
         $this->createSigningRequest($url, $keyPath, $csrPath, $confPath);
 
-        $caSrlParam = '-CAserial ' . $caSrlPath;
+        $caSrlParam = '-CAserial "' . $caSrlPath . '"';
         if (! $this->files->exists($caSrlPath)) {
             $caSrlParam .= ' -CAcreateserial';
         }
@@ -420,7 +420,7 @@ class Site
     function trustCa($caPemPath)
     {
         $this->cli->run(sprintf(
-            'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain %s', $caPemPath
+            'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "%s"', $caPemPath
         ));
     }
 
@@ -433,7 +433,7 @@ class Site
     function trustCertificate($crtPath)
     {
         $this->cli->run(sprintf(
-            'sudo security add-trusted-cert -d -r trustAsRoot -k /Library/Keychains/System.keychain %s', $crtPath
+            'sudo security add-trusted-cert -d -r trustAsRoot -k /Library/Keychains/System.keychain "%s"', $crtPath
         ));
     }
 


### PR DESCRIPTION
Fixes issue where certificates fail to be generated when there is a space in the certificate file path

Closes #862 