### PR TITLE
Fix auto-detection amongst multiple ngrok processes

### DIFF
--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -14,16 +14,16 @@ class Ngrok
      *
      * @return string
      */
-    function currentTunnelUrl()
+    function currentTunnelUrl($domain = null)
     {
-        return retry(20, function () {
+        return retry(20, function () use ($domain) {
             $body = Request::get($this->tunnelsEndpoint)->send()->body;
 
             // If there are active tunnels on the Ngrok instance we will spin through them and
             // find the one responding on HTTP. Each tunnel has an HTTP and a HTTPS address
             // but for local testing purposes we just desire the plain HTTP URL endpoint.
             if (isset($body->tunnels) && count($body->tunnels) > 0) {
-                return $this->findHttpTunnelUrl($body->tunnels);
+                return $this->findHttpTunnelUrl($body->tunnels, $domain);
             } else {
                 throw new DomainException("Tunnel not established.");
             }
@@ -36,10 +36,10 @@ class Ngrok
      * @param  array  $tunnels
      * @return string|null
      */
-    function findHttpTunnelUrl($tunnels)
+    function findHttpTunnelUrl($tunnels, $domain)
     {
         foreach ($tunnels as $tunnel) {
-            if ($tunnel->proto === 'http') {
+            if ($tunnel->proto === 'http' && strpos($tunnel->config->addr, $domain) ) {
                 return $tunnel->public_url;
             }
         }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -226,8 +226,8 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Echo the currently tunneled URL.
      */
-    $app->command('fetch-share-url', function () {
-        output(Ngrok::currentTunnelUrl());
+    $app->command('fetch-share-url [domain]', function ($domain = null) {
+        output(Ngrok::currentTunnelUrl($domain ?: Site::host(getcwd()).'.'.Configuration::read()['tld']));
     })->descriptions('Get the URL to the current Ngrok tunnel');
 
     /**


### PR DESCRIPTION
Ngrok Pro plans allow multiple processes, which means you could be serving several sites simultaneously. This PR allows Valet to correctly identify amongst the active ngrok process URLs.

Fixes #145