### PR TITLE
Allow Valet to uninstall itself

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -62,7 +62,7 @@ class Brew
     }
 
     /**
-     * Get a list of supported PHP versions
+     * Get a list of supported PHP versions.
      *
      * @return \Illuminate\Support\Collection
      */
@@ -83,7 +83,7 @@ class Brew
     }
 
     /**
-     * Return name of the nginx service installed via Homebrewed.
+     * Return name of the nginx service installed via Homebrew.
      *
      * @return string
      */
@@ -185,7 +185,7 @@ class Brew
     }
 
     /**
-     * Determine if php is currently linked
+     * Determine if php is currently linked.
      *
      * @return bool
      */
@@ -195,7 +195,7 @@ class Brew
     }
 
     /**
-     * Get the linked php parsed
+     * Get the linked php parsed.
      *
      * @return mixed
      */
@@ -277,7 +277,17 @@ class Brew
     }
 
     /**
-     * Link passed formula
+     * Remove the "sudoers.d" entry for running Brew.
+     *
+     * @return void
+     */
+    function removeSudoersEntry()
+    {
+        $this->cli->quietly('rm /etc/sudoers.d/brew');
+    }
+
+    /**
+     * Link passed formula.
      *
      * @param $formula
      * @param bool $force
@@ -297,7 +307,7 @@ class Brew
     }
 
     /**
-     * Unlink passed formula
+     * Unlink passed formula.
      * @param $formula
      *
      * @return string
@@ -315,7 +325,7 @@ class Brew
     }
 
     /**
-     * Get the currently running brew services
+     * Get the currently running brew services.
      *
      * @return \Illuminate\Support\Collection
      */
@@ -329,5 +339,46 @@ class Brew
                 throw new DomainException('Brew was unable to check which services are running.');
             }
         ))));
+    }
+
+    /**
+     * Tell Homebrew to forcefully remove all PHP versions that Valet supports.
+     * 
+     * @return string
+     */
+    function uninstallAllPhpVersions()
+    {
+        $this->supportedPhpVersions()->each(function ($formula) {
+            $this->uninstallFormula($formula);
+        });
+
+        return 'PHP versions removed.';
+    }
+
+    /**
+     * Uninstall a Homebrew app by formula name.
+     * @param  string $formula
+     * 
+     * @return void
+     */
+    function uninstallFormula($formula)
+    {
+        $this->cli->runAsUser('brew uninstall --force '.$formula);
+        $this->cli->run('rm -rf /usr/local/Cellar/'.$formula);
+    }
+
+    /**
+     * Run Homebrew's cleanup commands.
+     * 
+     * @return string
+     */
+    function cleanupBrew()
+    {
+        return $this->cli->runAsUser(
+            'brew cleanup && brew services cleanup',
+            function ($exitCode, $errorOutput) {
+                output($errorOutput);
+            }
+        );
     }
 }

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -35,6 +35,16 @@ class Configuration
     }
 
     /**
+     * Forcefully delete the Valet home configuration directory and contents.
+     * 
+     * @return void
+     */
+    function uninstall()
+    {
+        $this->files->unlink(VALET_HOME_PATH);
+    }
+
+    /**
      * Create the Valet configuration directory.
      *
      * @return void

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -51,6 +51,23 @@ class DnsMasq
         info('Valet is configured to serve for TLD [.'.$tld.']');
     }
 
+    /**
+     * Forcefully uninstall dnsmasq.
+     * 
+     * @return void
+     */
+    function uninstall()
+    {
+        $this->brew->stopService('dnsmasq');
+        $this->brew->uninstallFormula('dnsmasq');
+        $this->cli->run('rm -rf /usr/local/etc/dnsmasq.d/dnsmasq-valet.conf');
+    }
+
+    /**
+     * Tell Homebrew to restart dnsmasq
+     * 
+     * @return void
+     */
     function restart()
     {
         $this->brew->restartService('dnsmasq');

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -160,12 +160,14 @@ class Nginx
     }
 
     /**
-     * Prepare Nginx for uninstallation.
+     * Forcefully uninstall Nginx.
      *
      * @return void
      */
     function uninstall()
     {
-        $this->stop();
+        $this->brew->stopService(['nginx', 'nginx-full']);
+        $this->brew->uninstallFormula('nginx nginx-full');
+        $this->cli->quietly('rm -rf /usr/local/etc/nginx /usr/local/var/log/nginx');
     }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -46,6 +46,18 @@ class PhpFpm
     }
 
     /**
+     * Forcefully uninstall all of Valet's supported PHP versions and configurations
+     * 
+     * @return void
+     */
+    function uninstall()
+    {
+        $this->brew->uninstallAllPhpVersions();
+        rename('/usr/local/etc/php', '/usr/local/etc/php-valet-bak'.time());
+        $this->cli->run('rm -rf /usr/local/var/log/php-fpm.log');
+    }
+
+    /**
      * Update the PHP FPM configuration.
      *
      * @return void

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -35,6 +35,16 @@ class Valet
     }
 
     /**
+     * Remove the symlink from the user's local bin.
+     *
+     * @return void
+     */
+    function unlinkFromUsersBin()
+    {
+        $this->cli->quietlyAsUser('rm '.$this->valetBin);
+    }
+
+    /**
      * Get the paths to all of the Valet extensions.
      *
      * @return array
@@ -80,5 +90,31 @@ class Valet
 
         $this->files->put('/etc/sudoers.d/valet', 'Cmnd_Alias VALET = /usr/local/bin/valet *
 %admin ALL=(root) NOPASSWD:SETENV: VALET'.PHP_EOL);
+    }
+
+    /**
+     * Remove the "sudoers.d" entry for running Valet.
+     *
+     * @return void
+     */
+    function removeSudoersEntry()
+    {
+        $this->cli->quietly('rm /etc/sudoers.d/valet');
+    }
+
+    /**
+     * Run composer global diagnose
+     */
+    function composerGlobalDiagnose()
+    {
+        $this->cli->runAsUser('composer global diagnose');
+    }
+
+    /**
+     * Run composer global update
+     */
+    function composerGlobalUpdate()
+    {
+        $this->cli->runAsUser('composer global update');
     }
 }


### PR DESCRIPTION
`valet uninstall` only displays information about how to manually uninstall and clean up after Valet.

This PR adds a `--force` parameter, which will forcefully remove Valet and the Homebrew services it installs, as well as clean up the config files and log files.
But for a few post-uninstall composer dependencies, cleanup is very thorough.

This brings idempotency to both `valet install` and `valet uninstall --force`

(There may still be edge cases where other Homebrew or composer packages might create interference with install/uninstall, but this makes things much easier to self-troubleshoot.)