### PR TITLE
Improve verbosity

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -33,7 +33,7 @@ class DnsMasq
      *
      * @return void
      */
-    function install($tld = 'test')
+    function install($tld = 'test', $verbosity)
     {
         $this->brew->ensureInstalled('dnsmasq');
 
@@ -46,7 +46,7 @@ class DnsMasq
 
         $this->createTldResolver($tld);
 
-        $this->brew->restartService('dnsmasq');
+        $this->brew->restartService('dnsmasq', $verbosity);
 
         info('Valet is configured to serve for TLD [.'.$tld.']');
     }
@@ -68,9 +68,9 @@ class DnsMasq
      * 
      * @return void
      */
-    function restart()
+    function restart($verbosity)
     {
-        $this->brew->restartService('dnsmasq');
+        $this->brew->restartService('dnsmasq', $verbosity);
     }
 
     /**

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -140,11 +140,11 @@ class Nginx
      *
      * @return void
      */
-    function restart()
+    function restart($verbosity)
     {
         $this->lint();
 
-        $this->brew->restartService($this->brew->nginxServiceName());
+        $this->brew->restartService($this->brew->nginxServiceName(), $verbosity);
     }
 
     /**

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -32,7 +32,7 @@ class PhpFpm
      *
      * @return void
      */
-    function install()
+    function install($verbosity)
     {
         if (! $this->brew->hasInstalledPhp()) {
             $this->brew->ensureInstalled('php', [], $this->taps);
@@ -42,7 +42,7 @@ class PhpFpm
 
         $this->updateConfiguration();
 
-        $this->restart();
+        $this->restart($verbosity);
     }
 
     /**
@@ -107,9 +107,9 @@ class PhpFpm
      *
      * @return void
      */
-    function restart()
+    function restart($verbosity)
     {
-        $this->brew->restartLinkedPhp();
+        $this->brew->restartLinkedPhp($verbosity);
     }
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -48,14 +48,14 @@ if (is_dir(VALET_HOME_PATH)) {
 /**
  * Install Valet and any required services.
  */
-$app->command('install', function () {
+$app->command('install', function ($output) {
     Nginx::stop();
 
-    Configuration::install();
-    Nginx::install();
-    PhpFpm::install();
-    DnsMasq::install(Configuration::read()['tld']);
-    Nginx::restart();
+    Configuration::install($output->getVerbosity());
+    Nginx::install($output->getVerbosity());
+    PhpFpm::install($output->getVerbosity());
+    DnsMasq::install(Configuration::read()['tld'], $output->getVerbosity());
+    Nginx::restart($output->getVerbosity());
     Valet::symlinkToUsersBin();
 
     output(PHP_EOL.'<info>Valet installed successfully!</info>');
@@ -234,12 +234,12 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Start the daemon services.
      */
-    $app->command('start', function () {
-        DnsMasq::restart();
+    $app->command('start', function ($output) {
+        DnsMasq::restart($output->getVerbosity());
 
-        PhpFpm::restart();
+        PhpFpm::restart($output->getVerbosity());
 
-        Nginx::restart();
+        Nginx::restart($output->getVerbosity());
 
         info('Valet services have been started.');
     })->descriptions('Start the Valet services');
@@ -247,12 +247,12 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Restart the daemon services.
      */
-    $app->command('restart', function () {
-        DnsMasq::restart();
+    $app->command('restart', function ($output) {
+        DnsMasq::restart($output->getVerbosity());
 
-        PhpFpm::restart();
+        PhpFpm::restart($output->getVerbosity());
 
-        Nginx::restart();
+        Nginx::restart($output->getVerbosity());
 
         info('Valet services have been restarted.');
     })->descriptions('Restart the Valet services');


### PR DESCRIPTION
Detect whether `-v` is passed to certain Valet commands, and cause that to display more detailed Homebrew output in case there's a need to troubleshoot.
(I don't think every command needs a bunch of extra verbosity. But restarting of services, and initial install seem to be logical times to want more verbosity.)

Ideally there'd be a better way to persist the value without having to pass it around all over. Insights appreciated.

Fixes #317