### PR TITLE
Allow valet share to support multiple domains from same app

### DIFF
--- a/cli/scripts/fetch-share-url.sh
+++ b/cli/scripts/fetch-share-url.sh
@@ -2,4 +2,4 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-php $DIR/../valet.php fetch-share-url | pbcopy
+php $DIR/../valet.php fetch-share-url $1 | pbcopy

--- a/valet
+++ b/valet
@@ -31,7 +31,7 @@ fi
 # process to retrieve the live Ngrok tunnel URL in the background.
 if [[ "$1" = "share" ]]
 then
-    # check for parameters to passthru to ngrok (they start with '-' or '--')
+    # Check for parameters to pass through to ngrok (these will start with '-' or '--')
     PARAMS=${3:-$2}
     if [[ ${PARAMS:0:1} != '-' ]]; then
         PARAMS=''
@@ -39,18 +39,18 @@ then
 
     HOST="${PWD##*/}"
 
-    # check for custom domain passed through to the share command ($2 w/o '-' prefix)
+    # Check for custom domain passed through to the share command ($2 w/o '-' prefix)
     if [[ ${2:0:1} != '-' ]]; then
-        # if not blank and is a link or is the cwd use it
+        # If not blank and is a link, or is the cwd, use it
         if [[ ! -z $2 && (-L ~/.config/valet/Sites/$2 || $2 == $HOST) ]]; then
             HOST=$2
             CLIHOST=$2
         fi
     fi
 
-    # if no custom domain passed then check if there's a linked site for cwd
+    # If no custom domain passed, then check if there's a linked site for cwd
     if [[ -z $CLIHOST ]]; then
-        # find the first linked site for the current dir, if one exists
+        # Find the first linked site for the current dir, if one exists
         for linkname in ~/.config/valet/Sites/*; do
             if [[ "$(readlink $linkname)" = "$PWD" ]]
             then

--- a/valet
+++ b/valet
@@ -31,18 +31,38 @@ fi
 # process to retrieve the live Ngrok tunnel URL in the background.
 if [[ "$1" = "share" ]]
 then
+    # check for parameters to passthru to ngrok (they start with '-' or '--')
+    PARAMS=${3:-$2}
+    if [[ ${PARAMS:0:1} != '-' ]]; then
+        PARAMS=''
+    fi
+
     HOST="${PWD##*/}"
+
+    # check for custom domain passed through to the share command ($2 w/o '-' prefix)
+    if [[ ${2:0:1} != '-' ]]; then
+        # if not blank and is a link or is the cwd use it
+        if [[ ! -z $2 && (-L ~/.config/valet/Sites/$2 || $2 == $HOST) ]]; then
+            HOST=$2
+            CLIHOST=$2
+        fi
+    fi
+
+    # if no custom domain passed then check if there's a linked site for cwd
+    if [[ -z $CLIHOST ]]; then
+        # find the first linked site for the current dir, if one exists
+        for linkname in ~/.config/valet/Sites/*; do
+            if [[ "$(readlink $linkname)" = "$PWD" ]]
+            then
+                HOST="${linkname##*/}"
+                break
+            fi
+        done
+    fi
+
     TLD=$(php "$DIR/cli/valet.php" tld)
 
-    for linkname in ~/.config/valet/Sites/*; do
-        if [[ "$(readlink $linkname)" = "$PWD" ]]
-        then
-            HOST="${linkname##*/}"
-        fi
-    done
-
-	# Decide the correct PORT to use according if the site has a secure
-	# config or not.
+	# Decide the correct PORT: uses 60 for secure, else 80
 	if grep --quiet --no-messages 443 ~/.config/valet/Nginx/$HOST*
 	then
 		PORT=60
@@ -51,8 +71,8 @@ then
 	fi
 
 	# Fetch Ngrok URL In Background...
-	bash "$DIR/cli/scripts/fetch-share-url.sh" &
-	sudo -u "$(logname)" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite ${*:2}
+	bash "$DIR/cli/scripts/fetch-share-url.sh" "$HOST" &
+	sudo -u "$(logname)" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
This PR allows passing a specific domain name to `valet share` in order to have the app be served for that domain.
Now how it works is this:
- **(NEW)** if a domain name is passed, it checks whether it matches a link (which would be required for multiple domains served by same app project), and uses that
- if a domain name is NOT passed, it looks up any links for current directory, and uses the first found link
- else falls back to current project foldername

It also still allows passing through custom ngrok parameters if desired (ref: #112), as either the 2nd parameter (no domain name passed) or **(NEW)** 3rd parameter

Fixes #537