### PR TITLE
Part 2: Fix auto-detection amongst multiple ngrok processes

### DIFF
--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -7,7 +7,10 @@ use DomainException;
 
 class Ngrok
 {
-    var $tunnelsEndpoint = 'http://127.0.0.1:4040/api/tunnels';
+    var $tunnelsEndpoints = [
+        'http://127.0.0.1:4040/api/tunnels',
+        'http://127.0.0.1:4041/api/tunnels',
+    ];
 
     /**
      * Get the current tunnel URL from the Ngrok API.
@@ -16,18 +19,24 @@ class Ngrok
      */
     function currentTunnelUrl($domain = null)
     {
-        return retry(20, function () use ($domain) {
-            $body = Request::get($this->tunnelsEndpoint)->send()->body;
+        // wait a second for ngrok to start before attempting to find available tunnels
+        sleep(1);
 
-            // If there are active tunnels on the Ngrok instance we will spin through them and
-            // find the one responding on HTTP. Each tunnel has an HTTP and a HTTPS address
-            // but for local testing purposes we just desire the plain HTTP URL endpoint.
-            if (isset($body->tunnels) && count($body->tunnels) > 0) {
-                return $this->findHttpTunnelUrl($body->tunnels, $domain);
-            } else {
-                throw new DomainException("Tunnel not established.");
+        foreach ($this->tunnelsEndpoints as $endpoint) {
+            $response = retry(20, function () use ($endpoint, $domain) {
+                $body = Request::get($endpoint)->send()->body;
+
+                if (isset($body->tunnels) && count($body->tunnels) > 0) {
+                    return $this->findHttpTunnelUrl($body->tunnels, $domain);
+                }
+            }, 250);
+
+            if (!empty($response)) {
+                return $response;
             }
-        }, 250);
+        }
+
+        throw new DomainException("Tunnel not established.");
     }
 
     /**
@@ -38,6 +47,9 @@ class Ngrok
      */
     function findHttpTunnelUrl($tunnels, $domain)
     {
+        // If there are active tunnels on the Ngrok instance we will spin through them and
+        // find the one responding on HTTP. Each tunnel has an HTTP and a HTTPS address
+        // but for local dev purposes we just desire the plain HTTP URL endpoint.
         foreach ($tunnels as $tunnel) {
             if ($tunnel->proto === 'http' && strpos($tunnel->config->addr, $domain) ) {
                 return $tunnel->public_url;


### PR DESCRIPTION
Thanks to the generosity of Alan at Ngrok, I've been able to do some additional testing with temporary added features.
Turns out #864 was incomplete. This PR now also loops through the default endpoints in order to find a process matching the passed domain.

Ref: #864
Ref: #145

Also supercedes and Closes #869 and Fixes #868 the same way #869 proposed.