### PR TITLE
Enable multiple ngrok arguments from command line

### DIFF
--- a/valet
+++ b/valet
@@ -32,10 +32,15 @@ fi
 if [[ "$1" = "share" ]]
 then
     # Check for parameters to pass through to ngrok (these will start with '-' or '--')
-    PARAMS=${3:-$2}
-    if [[ ${PARAMS:0:1} != '-' ]]; then
-        PARAMS=''
-    fi
+    PARAMS=(${@:2})
+    for PARAM in ${PARAMS[@]}
+    do
+        if [[ ${PARAM:0:1} != '-' ]]; then
+            PARAMS=("${PARAMS[@]/$PARAM}") #Quotes when working with strings
+        fi
+    done
+
+    PARAMS=${PARAMS[@]}
 
     HOST="${PWD##*/}"
 
@@ -72,6 +77,7 @@ then
 
 	# Fetch Ngrok URL In Background...
 	bash "$DIR/cli/scripts/fetch-share-url.sh" "$HOST" &
+    
 	sudo -u "$(logname)" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
     exit
 


### PR DESCRIPTION
Enable the possibility to pass more than one argument to ngrok.

before this patch, it was not possible to pass more than one argument beginning with --.

now you can add something like this:
valet share --region=eu --authtoken=tokenstring

before this patch, only the first arg --region was used