### PR TITLE
Comment out memory limits so other configs take precedence

### DIFF
--- a/cli/stubs/etc-phpfpm-valet.conf
+++ b/cli/stubs/etc-phpfpm-valet.conf
@@ -8,10 +8,10 @@ listen.owner = VALET_USER
 listen.group = staff
 listen.mode = 0777
 
-
-php_admin_value[memory_limit] = 128M
-php_admin_value[upload_max_filesize] = 128M
-php_admin_value[post_max_size] = 128M
+# when uncommented, these values will take precedence over settings declared elsewhere
+;php_admin_value[memory_limit] = 128M
+;php_admin_value[upload_max_filesize] = 128M
+;php_admin_value[post_max_size] = 128M
 
 ;php_admin_value[error_log] = VALET_HOME_PATH/Log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on


### PR DESCRIPTION
The default FPM stub was overriding related settings, making customization more complex.
Commenting out the overrides so they can be used only if specific FPM settings need to supercede CLI settings.

Fixes #884 