### PR TITLE
Allow for global environment variables to be configured.

### DIFF
--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -192,6 +192,9 @@ abstract class ValetDriver
     {
         $varFilePath = $sitePath . '/.valet-env.php';
         if (! file_exists($varFilePath)) {
+            $varFilePath = VALET_HOME_PATH . '/.valet-env.php';
+        }
+        if (! file_exists($varFilePath)) {
             return;
         }
 


### PR DESCRIPTION
This leverages the existing `.valet-env.php` file capability, but just adds the Valet Home directory as a fallback-lookup location.

So, now Valet will check for `.valet-env.php` in:
- the current project folder
and if not found, then fallback to:
- `~/.config/valet/`

As discussed at https://github.com/laravel/valet/issues/789#issuecomment-565112046

Fixes #789