### PR TITLE
Adds a directory-listing setting for dev convenience

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -462,6 +462,25 @@ You might also want to investigate your global Composer configs. Helpful command
 
         passthru($command);
     })->descriptions('Tail log file');
+
+    /**
+      * Configure or display the directory-listing setting.
+      */
+    $app->command('directory-listing [status]', function ($status = null) {
+        $key = 'directory-listing';
+        $config = Configuration::read();
+
+        if (in_array($status, ['on', 'off'])) {
+            $config[$key] = $status;
+            Configuration::write($config);
+            return output('Directory listing setting is now: '.$status);
+        }
+
+        $current = isset($config[$key]) ? $config[$key] : 'off';
+        output('Directory listing is '.$current);
+    })->descriptions('Determine directory-listing behavior. Default is off, which means a 404 will display.', [
+        'status' => 'on or off. (default=off) will show a 404 page; [on] will display a listing if project folder exists but requested URI not found'
+    ]);
 }
 
 /**

--- a/server.php
+++ b/server.php
@@ -18,6 +18,35 @@ function show_valet_404()
 }
 
 /**
+ * Show directory listing or 404 if directory doesn't exist.
+ */
+function show_directory_listing($valetSitePath, $uri)
+{ 
+    $is_root = ($uri == '/');
+    $directory = ($is_root) ? $valetSitePath : $valetSitePath.$uri;
+
+    if (!file_exists($directory)) { 
+        show_valet_404(); 
+    }
+
+    // Sort directories at the top
+    $paths = glob("$directory/*");
+    usort($paths, function ($a, $b) {
+        return (is_dir($a) == is_dir($b)) ? strnatcasecmp($a, $b) : (is_dir($a) ? -1 : 1);
+    });
+
+    // Output the HTML for the directory listing
+    echo "<h1>Index of $uri</h1>";
+    echo "<hr>";
+    echo implode("<br>\n", array_map(function ($path) use ($uri, $is_root) {
+        $file = basename($path);
+        return ($is_root) ? "<a href='/$file'>/$file</a>" : "<a href='$uri/$file'>$uri/$file/</a>";
+    }, $paths));
+
+    exit;
+}
+
+/**
  * You may use wildcard DNS providers xip.io or nip.io as a tool for testing your site via an IP address.
  * It's simple to use: First determine the IP address of your local computer (like 192.168.0.10).
  * Then simply use http://project.your-ip.xip.io - ie: http://laravel.192.168.0.10.xip.io
@@ -150,6 +179,10 @@ $frontControllerPath = $valetDriver->frontControllerPath(
 );
 
 if (! $frontControllerPath) {
+    if (isset($valetConfig['directory-listing']) && $valetConfig['directory-listing'] == 'on') {
+        show_directory_listing($valetSitePath, $uri);
+    }
+
     show_valet_404();
 }
 


### PR DESCRIPTION
After running `valet directory-listing on` if a URI points to a directory that exists, but the requested file cannot be found in that directory, a directory listing will be displayed.

A 404 will still happen if the project directory cannot be found.

Running `valet directory-listing off` makes a 404 display (without a listing) if the requested file cannot be found.

Supersedes and Closes #349 and Closes #587