### PR TITLE
Cleanup old tld refs when switching tld or uninstalling

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -7,7 +7,7 @@ use Symfony\Component\Process\Process;
 
 class DnsMasq
 {
-    var $brew, $cli, $files;
+    var $brew, $cli, $files, $configuration;
 
     var $dnsmasqMasterConfigFile = '/usr/local/etc/dnsmasq.conf';
     var $dnsmasqSystemConfDir = '/usr/local/etc/dnsmasq.d';
@@ -21,11 +21,12 @@ class DnsMasq
      * @param  Filesystem  $files
      * @return void
      */
-    function __construct(Brew $brew, CommandLine $cli, Filesystem $files)
+    function __construct(Brew $brew, CommandLine $cli, Filesystem $files, Configuration $configuration)
     {
         $this->cli = $cli;
         $this->brew = $brew;
         $this->files = $files;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -61,6 +62,8 @@ class DnsMasq
         $this->brew->stopService('dnsmasq');
         $this->brew->uninstallFormula('dnsmasq');
         $this->cli->run('rm -rf /usr/local/etc/dnsmasq.d/dnsmasq-valet.conf');
+        $tld = $this->configuration->read()['tld'];
+        $this->files->unlink($this->resolverPath.'/'.$tld);
     }
 
     /**
@@ -145,6 +148,7 @@ class DnsMasq
     function updateTld($oldTld, $newTld)
     {
         $this->files->unlink($this->resolverPath.'/'.$oldTld);
+        $this->files->unlink($this->dnsmasqUserConfigDir() . 'tld-' . $oldTld . '.conf');
 
         $this->install($newTld);
     }

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -2,9 +2,6 @@
 
 namespace Valet;
 
-use Exception;
-use Symfony\Component\Process\Process;
-
 class DnsMasq
 {
     var $brew, $cli, $files, $configuration;
@@ -15,11 +12,6 @@ class DnsMasq
 
     /**
      * Create a new DnsMasq instance.
-     *
-     * @param  Brew  $brew
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @return void
      */
     function __construct(Brew $brew, CommandLine $cli, Filesystem $files, Configuration $configuration)
     {

--- a/tests/DnsMasqTest.php
+++ b/tests/DnsMasqTest.php
@@ -4,6 +4,7 @@ use Valet\Brew;
 use Valet\DnsMasq;
 use Valet\Filesystem;
 use Valet\CommandLine;
+use Valet\Configuration;
 use function Valet\user;
 use function Valet\resolve;
 use function Valet\swap;
@@ -60,7 +61,8 @@ class DnsMasqTest extends PHPUnit_Framework_TestCase
     {
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('quietly')->with('rm /etc/resolver/old');
-        $dnsMasq = Mockery::mock(DnsMasq::class.'[install]', [resolve(Brew::class), $cli, new Filesystem]);
+        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['tld' => 'test']]));
+        $dnsMasq = Mockery::mock(DnsMasq::class.'[install]', [resolve(Brew::class), $cli, new Filesystem, $config]);
         $dnsMasq->shouldReceive('install')->with('new');
         $dnsMasq->updateTld('old', 'new');
     }


### PR DESCRIPTION
Previously we would leave old tld stubs around; while it's harmless, it's less tidy.