### PR TITLE
Add --off option for valet trust command

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -373,12 +373,21 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * Install the sudoers.d entries so password is no longer required.
      */
-    $app->command('trust', function () {
+    $app->command('trust [--off]', function ($off) {
+        if ($off) {
+            Brew::removeSudoersEntry();
+            Valet::removeSudoersEntry();
+
+            return info('Sudoers entries have been removed for Brew and Valet.');
+        }
+
         Brew::createSudoersEntry();
         Valet::createSudoersEntry();
 
         info('Sudoers entries have been added for Brew and Valet.');
-    })->descriptions('Add sudoers files for Brew and Valet to make Valet commands run without passwords');
+    })->descriptions('Add sudoers files for Brew and Valet to make Valet commands run without passwords', [
+        '--off' => 'Remove the sudoers files so normal sudo password prompts are required.'
+    ]);
 
     /**
      * Allow the user to change the version of php valet uses


### PR DESCRIPTION
While `valet trust` enables (creates) sudoers entries, there was no cleanup/removal option for this, apart from complete forced uninstall of Valet.

This adds `valet trust --off` so that the sudoers entries can be removed from Valet CLI.