### PR TITLE
php config comments must only use semicolons, not hash symbols

### DIFF
--- a/cli/stubs/etc-phpfpm-valet.conf
+++ b/cli/stubs/etc-phpfpm-valet.conf
@@ -8,7 +8,7 @@ listen.owner = VALET_USER
 listen.group = staff
 listen.mode = 0777
 
-# when uncommented, these values will take precedence over settings declared elsewhere
+;; When uncommented, the following values will take precedence over settings declared elsewhere
 ;php_admin_value[memory_limit] = 128M
 ;php_admin_value[upload_max_filesize] = 128M
 ;php_admin_value[post_max_size] = 128M


### PR DESCRIPTION
PHP configs no longer support `#` for comments. Must use semicolons `;`.

Otherwise PHP may not start, and may show a confusing error in logs: `value is NULL for a ZEND_INI_PARSER_ENTRY`

Updates #885 