### PR TITLE
Detect running php when no version constraint specified with use command

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -72,6 +72,15 @@ class Brew
     }
 
     /**
+     * Get the aliased formula version from Homebrew
+     */
+    function determineAliasedVersion($formula)
+    {
+        $details = json_decode($this->cli->runAsUser("brew info $formula --json"));
+        return $details[0]->aliases[0] ?: 'ERROR - NO BREW ALIAS FOUND';
+    }
+
+    /**
      * Determine if a compatible nginx version is Homebrewed.
      *
      * @return bool

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -384,15 +384,16 @@ You might also want to investigate your global Composer configs. Helpful command
      * Allow the user to change the version of php valet uses
      */
     $app->command('use phpVersion', function ($phpVersion) {
-        PhpFpm::stopRunning();
+        PhpFpm::validateRequestedVersion($phpVersion);
 
+        PhpFpm::stopRunning();
         $newVersion = PhpFpm::useVersion($phpVersion);
 
         Nginx::restart();
-        info(sprintf('Valet is now using %s.', $newVersion));
+        info(sprintf('Valet is now using %s.', $newVersion) . PHP_EOL);
         info('Note that you might need to run <comment>composer global update</comment> if your PHP version change affects the dependencies of global packages required by Composer.');
     })->descriptions('Change the version of PHP used by valet', [
-        'phpVersion' => 'The PHP version you want to use, e.g php@7.2',
+        'phpVersion' => 'The PHP version you want to use, e.g php@7.3',
     ]);
 
     /**


### PR DESCRIPTION
Fixes #756

Previously if `php` was installed as just `php` (the default Homebrew alias), Valet would not detect **_which_** PHP version was actually installed, and therefore `valet use` might do incorrect or unnecessary installations/links/etc.

NOTE: This does NOT "convert" existing `php` alias to a numbered version. It merely accepts it as-is, but notes its version in an attempt to avoid extra installations.

**NOTE: Specifally tested with PHP 7.4 and 7.3. No promises about old 5.6, etc aliases.**