### PR TITLE
Enabling IPv6 listen

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,13 +1,13 @@
 server {
     listen 127.0.0.1:80;
-    listen [::1]:80;
+    listen [::]:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
 }
 
 server {
     listen 127.0.0.1:443 ssl http2;
-    listen [::1]:443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
@@ -51,7 +51,7 @@ server {
 
 server {
     listen 127.0.0.1:60;
-    listen [::1]:60;
+    listen [::]:60;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,11 +1,13 @@
 server {
     listen 127.0.0.1:80;
+    listen [::1]:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
 }
 
 server {
     listen 127.0.0.1:443 ssl http2;
+    listen [::1]:443 ssl http2;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
@@ -49,6 +51,7 @@ server {
 
 server {
     listen 127.0.0.1:60;
+    listen [::1]:60;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -1,5 +1,6 @@
 server {
     listen 127.0.0.1:80 default_server;
+    listen [::1]:80 default_server;
     root /;
     charset utf-8;
     client_max_body_size 128M;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -1,6 +1,6 @@
 server {
     listen 127.0.0.1:80 default_server;
-    listen [::1]:80 default_server;
+    listen [::]:80 default_server;
     root /;
     charset utf-8;
     client_max_body_size 128M;


### PR DESCRIPTION
Enabling IPv6 listen.  
Nginx on macOS via brew comes built with "--with-ipv6".  
[Dnsmasq options](https://github.com/laravel/valet/blob/master/cli/Valet/DnsMasq.php#L117) do not need to be changed.