### PR TITLE
Add proxy site-handling commands

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -68,7 +68,7 @@ class Site
     function host($path)
     {
         foreach ($this->files->scandir($this->sitesPath()) as $link) {
-            if ($resolved = realpath($this->sitesPath().'/'.$link) === $path) {
+            if ($resolved = realpath($this->sitesPath($link)) === $path) {
                 return $link;
             }
         }
@@ -103,7 +103,7 @@ class Site
      */
     function links()
     {
-        $certsPath = VALET_HOME_PATH.'/Certificates';
+        $certsPath = $this->certificatesPath();
 
         $this->files->ensureDirExists($certsPath, user());
 
@@ -119,11 +119,7 @@ class Site
      */
     function parked()
     {
-        $certsPath = VALET_HOME_PATH.'/Certificates';
-
-        $this->files->ensureDirExists($certsPath, user());
-
-        $certs = $this->getCertificates($certsPath);
+        $certs = $this->getCertificates();
 
         $links = $this->getSites($this->sitesPath(), $certs);
 
@@ -152,11 +148,14 @@ class Site
      */
     function proxies()
     {
-        $dir = VALET_HOME_PATH.'/Nginx/';
+        $dir = $this->nginxPath();
         $tld = $this->config->read()['tld'];
         $links = $this->links();
-        $certsPath = VALET_HOME_PATH.'/Certificates';
-        $certs = $this->getCertificates($certsPath);
+        $certs = $this->getCertificates();
+
+        if (! $this->files->exists($dir)) {
+            return collect();
+        }
 
         $proxies = collect($this->files->scandir($dir))
         ->filter(function ($site, $key) use ($tld) {
@@ -173,9 +172,9 @@ class Site
         })->reject(function ($host, $site) {
             // If proxy host is null, it may be just a normal SSL stub, or something else; either way we exclude it from the list
             return $host === '(other)';
-        })->map(function ($host, $site) use ($certs) {
+        })->map(function ($host, $site) use ($certs, $tld) {
             $secured = $certs->has($site);
-            $url = ($secured ? 'https': 'http').'://'.$site;
+            $url = ($secured ? 'https': 'http').'://'.$site.'.'.$tld;
 
             return [
                 'site' => $site,
@@ -205,13 +204,12 @@ class Site
         return $host;
     }
 
-    function getSiteConfigFileContents($site, $dir = null)
+    function getSiteConfigFileContents($site)
     {
         $config = $this->config->read();
-        $dir = $dir ?: VALET_HOME_PATH.'/Nginx/';
         $suffix = '.'.$config['tld'];
-        $file = $dir.str_replace($suffix,'',$site).$suffix;
-        return $this->files->get($file);
+        $file = str_replace($suffix,'',$site).$suffix;
+        return $this->files->get($this->nginxPath($file));
     }
 
     /**
@@ -220,8 +218,12 @@ class Site
      * @param string $path
      * @return \Illuminate\Support\Collection
      */
-    function getCertificates($path)
+    function getCertificates($path = null)
     {
+        $path = $path ?: $this->certificatesPath();
+
+        $this->files->ensureDirExists($path, user());
+
         $config = $this->config->read();
 
         return collect($this->files->scandir($path))->filter(function ($value, $key) {
@@ -265,6 +267,8 @@ class Site
     {
         $config = $this->config->read();
 
+        $this->files->ensureDirExists($path, user());
+
         return collect($this->files->scandir($path))->mapWithKeys(function ($site) use ($path) {
             $sitePath = $path.'/'.$site;
 
@@ -299,7 +303,7 @@ class Site
     {
         $name = $this->getRealSiteName($name);
 
-        if ($this->files->exists($path = $this->sitesPath().'/'.$name)) {
+        if ($this->files->exists($path = $this->sitesPath($name))) {
             $this->files->unlink($path);
         }
 
@@ -349,7 +353,7 @@ class Site
 
     /**
      * Parse Nginx site config file contents to swap old domain to new.
-     * 
+     *
      * @param  string $siteConf Nginx site config content
      * @param  string $old  Old domain
      * @param  string $new  New domain
@@ -399,12 +403,14 @@ class Site
 
         $this->files->ensureDirExists($this->certificatesPath(), user());
 
+        $this->files->ensureDirExists($this->nginxPath(), user());
+
         $this->createCa();
 
         $this->createCertificate($url);
 
         $this->files->putAsUser(
-            VALET_HOME_PATH.'/Nginx/'.$url, $this->buildSecureNginxServer($url, $siteConf)
+            $this->nginxPath($url), $this->buildSecureNginxServer($url, $siteConf)
         );
     }
 
@@ -415,8 +421,8 @@ class Site
      */
     function createCa()
     {
-        $caPemPath = $this->caPath().'/LaravelValetCASelfSigned.pem';
-        $caKeyPath = $this->caPath().'/LaravelValetCASelfSigned.key';
+        $caPemPath = $this->caPath('LaravelValetCASelfSigned.pem');
+        $caKeyPath = $this->caPath('LaravelValetCASelfSigned.key');
 
         if ($this->files->exists($caKeyPath) && $this->files->exists($caPemPath)) {
             return;
@@ -452,13 +458,13 @@ class Site
      */
     function createCertificate($url)
     {
-        $caPemPath = $this->caPath().'/LaravelValetCASelfSigned.pem';
-        $caKeyPath = $this->caPath().'/LaravelValetCASelfSigned.key';
-        $caSrlPath = $this->caPath().'/LaravelValetCASelfSigned.srl';
-        $keyPath = $this->certificatesPath().'/'.$url.'.key';
-        $csrPath = $this->certificatesPath().'/'.$url.'.csr';
-        $crtPath = $this->certificatesPath().'/'.$url.'.crt';
-        $confPath = $this->certificatesPath().'/'.$url.'.conf';
+        $caPemPath = $this->caPath('LaravelValetCASelfSigned.pem');
+        $caKeyPath = $this->caPath('LaravelValetCASelfSigned.key');
+        $caSrlPath = $this->caPath('LaravelValetCASelfSigned.srl');
+        $keyPath = $this->certificatesPath($url, 'key');
+        $csrPath = $this->certificatesPath($url, 'csr');
+        $crtPath = $this->certificatesPath($url, 'crt');
+        $confPath = $this->certificatesPath($url, 'conf');
 
         $this->buildCertificateConf($confPath, $url);
         $this->createPrivateKey($keyPath);
@@ -557,15 +563,20 @@ class Site
      */
     function buildSecureNginxServer($url, $siteConf = null)
     {
-        $path = $this->certificatesPath();
-
         if ($siteConf === null) {
             $siteConf = $this->files->get(__DIR__.'/../stubs/secure.valet.conf');
         }
 
         return str_replace(
             ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_CERT', 'VALET_KEY'],
-            [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, $path.'/'.$url.'.crt', $path.'/'.$url.'.key'],
+            [
+                $this->valetHomePath(),
+                VALET_SERVER_PATH,
+                VALET_STATIC_PREFIX,
+                $url,
+                $this->certificatesPath($url, 'crt'),
+                $this->certificatesPath($url, 'key'),
+            ],
             $siteConf
         );
     }
@@ -578,13 +589,13 @@ class Site
      */
     function unsecure($url)
     {
-        if ($this->files->exists($this->certificatesPath().'/'.$url.'.crt')) {
-            $this->files->unlink(VALET_HOME_PATH.'/Nginx/'.$url);
+        if ($this->files->exists($this->certificatesPath($url, 'crt'))) {
+            $this->files->unlink($this->nginxPath($url));
 
-            $this->files->unlink($this->certificatesPath().'/'.$url.'.conf');
-            $this->files->unlink($this->certificatesPath().'/'.$url.'.key');
-            $this->files->unlink($this->certificatesPath().'/'.$url.'.csr');
-            $this->files->unlink($this->certificatesPath().'/'.$url.'.crt');
+            $this->files->unlink($this->certificatesPath($url, 'conf'));
+            $this->files->unlink($this->certificatesPath($url, 'key'));
+            $this->files->unlink($this->certificatesPath($url, 'csr'));
+            $this->files->unlink($this->certificatesPath($url, 'crt'));
         }
 
         $this->cli->run(sprintf('sudo security delete-certificate -c "%s" /Library/Keychains/System.keychain', $url));
@@ -648,7 +659,7 @@ class Site
 
         $siteConf = str_replace(
             ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PROXY_HOST'],
-            [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, $host],
+            [$this->valetHomePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, $host],
             $siteConf
         );
 
@@ -671,9 +682,22 @@ class Site
         }
 
         $this->unsecure($url);
-        $this->files->unlink(VALET_HOME_PATH.'/Nginx/'.$url);
+        $this->files->unlink($this->nginxPath($url));
 
         info('Valet will no longer proxy [https://'.$url.'].');
+    }
+
+    function valetHomePath()
+    {
+        return VALET_HOME_PATH;
+    }
+
+    /**
+     * Get the path to Nginx site configuration files.
+     */
+    function nginxPath($additionalPath = null)
+    {
+        return $this->valetHomePath().'/Nginx'.($additionalPath ? '/'.$additionalPath : '');
     }
 
     /**
@@ -681,9 +705,9 @@ class Site
      *
      * @return string
      */
-    function sitesPath()
+    function sitesPath($link = null)
     {
-        return VALET_HOME_PATH.'/Sites';
+        return $this->valetHomePath().'/Sites'.($link ? '/'.$link : '');
     }
 
     /**
@@ -691,9 +715,9 @@ class Site
      *
      * @return string
      */
-    function caPath()
+    function caPath($caFile = null)
     {
-        return VALET_HOME_PATH.'/CA';
+        return $this->valetHomePath().'/CA'.($caFile ? '/'.$caFile : '');
     }
 
     /**
@@ -701,8 +725,11 @@ class Site
      *
      * @return string
      */
-    function certificatesPath()
+    function certificatesPath($url = null, $extension = null)
     {
-        return VALET_HOME_PATH.'/Certificates';
+        $url = $url ? '/'.$url : '';
+        $extension = $extension ? '.'.$extension : '';
+
+        return $this->valetHomePath().'/Certificates'.$url.$extension;
     }
 }

--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -16,14 +16,13 @@ http {
 
     server_names_hash_bucket_size 128;
 
+    ssi on;
+
     gzip  on;
     gzip_comp_level 5;
     gzip_min_length 256;
     gzip_proxied any;
     gzip_vary on;
-    
-    ssi on;
-
     gzip_types
     application/atom+xml
     application/javascript

--- a/cli/stubs/proxy.valet.conf
+++ b/cli/stubs/proxy.valet.conf
@@ -1,0 +1,95 @@
+# valet stub: proxy.valet.conf
+
+server {
+    listen 127.0.0.1:80;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 127.0.0.1:443 ssl http2;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+    http2_push_preload on;
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    ssl_certificate "VALET_CERT";
+    ssl_certificate_key "VALET_KEY";
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/VALET_SITE-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location / {
+        proxy_pass VALET_PROXY_HOST;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Client-Verify   SUCCESS;
+        proxy_set_header   X-Client-DN       $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Subject     $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Issuer      $ssl_client_i_dn;
+        proxy_set_header   X-NginX-Proxy true;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_read_timeout 1800;
+        proxy_connect_timeout 1800;
+        chunked_transfer_encoding on;
+        proxy_redirect off;
+        proxy_buffering off;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+server {
+    listen 127.0.0.1:60;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/VALET_SITE-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location / {
+        proxy_pass VALET_PROXY_HOST;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -32,7 +32,7 @@ if (is_dir(VALET_LEGACY_HOME_PATH) && !is_dir(VALET_HOME_PATH)) {
  */
 Container::setInstance(new Container);
 
-$version = '2.8.0';
+$version = '2.8.1';
 
 $app = new Application('Laravel Valet', $version);
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -182,6 +182,35 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Stop serving the given domain over HTTPS and remove the trusted TLS certificate');
 
     /**
+     * Create an Nginx proxy config for the specified domain
+     */
+    $app->command('proxy domain host', function ($domain, $host) {
+
+        Site::proxyCreate($domain, $host);
+        Nginx::restart();
+
+    })->descriptions('Create an Nginx proxy site for the specified host. Useful for docker, mailhog etc.');
+
+    /**
+     * Delete an Nginx proxy config
+     */
+    $app->command('unproxy domain', function ($domain) {
+
+        Site::proxyDelete($domain);
+        Nginx::restart();
+
+    })->descriptions('Delete an Nginx proxy config.');
+
+    /**
+     * Display all of the sites that are proxies.
+     */
+    $app->command('proxies', function () {
+        $proxies = Site::proxies();
+
+        table(['Site', 'SSL', 'URL', 'Host'], $proxies->all());
+    })->descriptions('Display all of the proxy sites');
+
+    /**
      * Determine which Valet driver the current directory is using.
      */
     $app->command('which', function () {

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -514,6 +514,25 @@ You might also want to investigate your global Composer configs. Helpful command
 
         passthru($command);
     })->descriptions('Tail log file');
+
+    /**
+      * Configure or display the directory-listing setting.
+      */
+    $app->command('directory-listing [status]', function ($status = null) {
+        $key = 'directory-listing';
+        $config = Configuration::read();
+
+        if (in_array($status, ['on', 'off'])) {
+            $config[$key] = $status;
+            Configuration::write($config);
+            return output('Directory listing setting is now: '.$status);
+        }
+
+        $current = isset($config[$key]) ? $config[$key] : 'off';
+        output('Directory listing is '.$current);
+    })->descriptions('Determine directory-listing behavior. Default is off, which means a 404 will display.', [
+        'status' => 'on or off. (default=off) will show a 404 page; [on] will display a listing if project folder exists but requested URI not found'
+    ]);
 }
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -32,7 +32,7 @@ if (is_dir(VALET_LEGACY_HOME_PATH) && !is_dir(VALET_HOME_PATH)) {
  */
 Container::setInstance(new Container);
 
-$version = '2.8.1';
+$version = '2.9.0';
 
 $app = new Application('Laravel Valet', $version);
 

--- a/server.php
+++ b/server.php
@@ -18,6 +18,35 @@ function show_valet_404()
 }
 
 /**
+ * Show directory listing or 404 if directory doesn't exist.
+ */
+function show_directory_listing($valetSitePath, $uri)
+{ 
+    $is_root = ($uri == '/');
+    $directory = ($is_root) ? $valetSitePath : $valetSitePath.$uri;
+
+    if (!file_exists($directory)) { 
+        show_valet_404(); 
+    }
+
+    // Sort directories at the top
+    $paths = glob("$directory/*");
+    usort($paths, function ($a, $b) {
+        return (is_dir($a) == is_dir($b)) ? strnatcasecmp($a, $b) : (is_dir($a) ? -1 : 1);
+    });
+
+    // Output the HTML for the directory listing
+    echo "<h1>Index of $uri</h1>";
+    echo "<hr>";
+    echo implode("<br>\n", array_map(function ($path) use ($uri, $is_root) {
+        $file = basename($path);
+        return ($is_root) ? "<a href='/$file'>/$file</a>" : "<a href='$uri/$file'>$uri/$file/</a>";
+    }, $paths));
+
+    exit;
+}
+
+/**
  * You may use wildcard DNS providers xip.io or nip.io as a tool for testing your site via an IP address.
  * It's simple to use: First determine the IP address of your local computer (like 192.168.0.10).
  * Then simply use http://project.your-ip.xip.io - ie: http://laravel.192.168.0.10.xip.io
@@ -150,6 +179,10 @@ $frontControllerPath = $valetDriver->frontControllerPath(
 );
 
 if (! $frontControllerPath) {
+    if (isset($valetConfig['directory-listing']) && $valetConfig['directory-listing'] == 'on') {
+        show_directory_listing($valetSitePath, $uri);
+    }
+
     show_valet_404();
 }
 

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -303,6 +303,12 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
     public function test_no_proxies()
     {
+        $config = Mockery::mock(Configuration::class);
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test']);
+
+        swap(Configuration::class, $config);
+
         /** @var FixturesSiteFake $site */
         $site = resolve(FixturesSiteFake::class);
 
@@ -314,6 +320,12 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
     public function test_lists_proxies()
     {
+        $config = Mockery::mock(Configuration::class);
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test']);
+
+        swap(Configuration::class, $config);
+
         /** @var FixturesSiteFake $site */
         $site = resolve(FixturesSiteFake::class);
 
@@ -338,6 +350,12 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
     public function test_add_proxy()
     {
+        $config = Mockery::mock(Configuration::class);
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test']);
+
+        swap(Configuration::class, $config);
+
         swap(CommandLine::class, resolve(CommandLineFake::class));
 
         /** @var FixturesSiteFake $site */
@@ -366,6 +384,12 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
     public function test_add_proxy_clears_previous_proxy_certificate()
     {
+        $config = Mockery::mock(Configuration::class);
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test']);
+
+        swap(Configuration::class, $config);
+
         swap(CommandLine::class, resolve(CommandLineFake::class));
 
         /** @var FixturesSiteFake $site */
@@ -405,6 +429,12 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
     public function test_add_proxy_clears_previous_non_proxy_certificate()
     {
+        $config = Mockery::mock(Configuration::class);
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test']);
+
+        swap(Configuration::class, $config);
+
         swap(CommandLine::class, resolve(CommandLineFake::class));
 
         /** @var FixturesSiteFake $site */
@@ -440,6 +470,12 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
     public function test_remove_proxy()
     {
+        $config = Mockery::mock(Configuration::class);
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test']);
+
+        swap(Configuration::class, $config);
+
         swap(CommandLine::class, resolve(CommandLineFake::class));
 
         /** @var FixturesSiteFake $site */

--- a/tests/fixtures/Proxies/Nginx/not-a-proxy.com.test
+++ b/tests/fixtures/Proxies/Nginx/not-a-proxy.com.test
@@ -1,0 +1,90 @@
+# valet stub: proxy.valet.conf
+
+server {
+    listen 127.0.0.1:80;
+    server_name not-a-proxy.com.test www.not-a-proxy.com.test *.not-a-proxy.com.test;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 127.0.0.1:443 ssl http2;
+    server_name not-a-proxy.com.test www.not-a-proxy.com.test *.not-a-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+    http2_push_preload on;
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    ssl_certificate "/home/nobody/.config/valet/Certificates/not-a-proxy.com.test.crt";
+    ssl_certificate_key "/home/nobody/.config/valet/Certificates/not-a-proxy.com.test.key";
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/not-a-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_param PHP_VALUE "memory_limit = -1";
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+server {
+    listen 127.0.0.1:60;
+    server_name not-a-proxy.com.test www.not-a-proxy.com.test *.not-a-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/not-a-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_param PHP_VALUE "memory_limit = -1";
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+

--- a/tests/fixtures/Proxies/Nginx/some-other-proxy.com.test
+++ b/tests/fixtures/Proxies/Nginx/some-other-proxy.com.test
@@ -1,0 +1,95 @@
+# valet stub: proxy.valet.conf
+
+server {
+    listen 127.0.0.1:80;
+    server_name some-other-proxy.com.test www.some-other-proxy.com.test *.some-other-proxy.com.test;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 127.0.0.1:443 ssl http2;
+    server_name some-other-proxy.com.test www.some-other-proxy.com.test *.some-other-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+    http2_push_preload on;
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    ssl_certificate "/home/nobody/.config/valet/Certificates/some-other-proxy.com.test.crt";
+    ssl_certificate_key "/home/nobody/.config/valet/Certificates/some-other-proxy.com.test.key";
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/some-other-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location / {
+        proxy_pass https://127.0.0.1:8443;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Client-Verify   SUCCESS;
+        proxy_set_header   X-Client-DN       $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Subject     $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Issuer      $ssl_client_i_dn;
+        proxy_set_header   X-NginX-Proxy true;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_read_timeout 1800;
+        proxy_connect_timeout 1800;
+        chunked_transfer_encoding on;
+        proxy_redirect off;
+        proxy_buffering off;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+server {
+    listen 127.0.0.1:60;
+    server_name some-other-proxy.com.test www.some-other-proxy.com.test *.some-other-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/some-other-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location / {
+        proxy_pass https://127.0.0.1:8443;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+

--- a/tests/fixtures/Proxies/Nginx/some-proxy.com.test
+++ b/tests/fixtures/Proxies/Nginx/some-proxy.com.test
@@ -1,0 +1,95 @@
+# valet stub: proxy.valet.conf
+
+server {
+    listen 127.0.0.1:80;
+    server_name some-proxy.com.test www.some-proxy.com.test *.some-proxy.com.test;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 127.0.0.1:443 ssl http2;
+    server_name some-proxy.com.test www.some-proxy.com.test *.some-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+    http2_push_preload on;
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    ssl_certificate "/home/nobody/.config/valet/Certificates/some-proxy.com.test.crt";
+    ssl_certificate_key "/home/nobody/.config/valet/Certificates/some-proxy.com.test.key";
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/some-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location / {
+        proxy_pass https://127.0.0.1:8443;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Client-Verify   SUCCESS;
+        proxy_set_header   X-Client-DN       $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Subject     $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Issuer      $ssl_client_i_dn;
+        proxy_set_header   X-NginX-Proxy true;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_read_timeout 1800;
+        proxy_connect_timeout 1800;
+        chunked_transfer_encoding on;
+        proxy_redirect off;
+        proxy_buffering off;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+server {
+    listen 127.0.0.1:60;
+    server_name some-proxy.com.test www.some-proxy.com.test *.some-proxy.com.test;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /41c270e4-5535-4daa-b23e-c269744c2f45/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "/home/nobody/.config/valet/Log/some-proxy.com.test-error.log";
+
+    error_page 404 "/home/nobody/.composer/vendor/laravel/valet/server.php";
+
+    location / {
+        proxy_pass https://127.0.0.1:8443;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+


### PR DESCRIPTION
Provides helpers to create an Nginx proxy site for the specified host. 
Useful for `docker`, `vessel`, `mailhog` etc, so that both Valet and those other services can co-exist on the same machine. 
(In the case of docker, proxying avoids the problem where Valet and Docker want to share port 80, which is not allowed.)
(In the case of a service like mailhog, it already intends to run on a different port; but proxying allows this to be given a name that Valet recognizes and can serve quickly and easily.)

Adds 3 new commands:
`valet proxy [domain] [host]`  -- generates a proxy config file (see example below)
`valet unproxy [domain]` -- removes a proxy config file
`valet proxies` -- gives a list of proxies Valet is aware of


eg: 
`valet proxy docker http://127.0.0.1:8080` creates a config file for `docker.test`, which proxies all traffic for `https://docker.test` through to `http://127.0.0.1:8080`

eg:
`valet proxy elasticsearch http://127.0.0.1:9200` creates a config file for `elasticsearch.test`, which proxies all traffic for `https://elasticsearch.test` accordingly.

eg:
`valet proxy mailhog http://localhost:8025` will proxy `https://mailhog.test` to the mailhog service running on localhost.

--

Credit for this comes from discussions with @simensen 

--

Note: This implementation always "secures" the site, without needing to run `valet secure` on it.

--

Race condition (or "precedence"): A proxy config takes precedence because you can only have one config for a site. So, even if you have linked or secured a project to `domain` already, and run `valet proxy` with that domain, it will replace the link with the proxy config instead. To return to non-proxy for that domain, `unproxy` and then re-link and/or re-secure as you would normally for a non-proxy project. Or just don't re-use names unless truly important. :)