### PR TITLE
Increase default PHP memory_limit to 512M

### DIFF
--- a/cli/stubs/etc-phpfpm-valet.conf
+++ b/cli/stubs/etc-phpfpm-valet.conf
@@ -9,7 +9,7 @@ listen.group = staff
 listen.mode = 0777
 
 ;; When uncommented, the following values will take precedence over settings declared elsewhere
-;php_admin_value[memory_limit] = 128M
+;php_admin_value[memory_limit] = 512M
 ;php_admin_value[upload_max_filesize] = 128M
 ;php_admin_value[post_max_size] = 128M
 
@@ -17,7 +17,7 @@ listen.mode = 0777
 ;php_admin_flag[log_errors] = on
 
 
-
+;; Note: increasing these values will increase the demand on your CPU and RAM resources
 pm = dynamic
 pm.max_children = 5
 pm.start_servers = 2

--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -12,7 +12,8 @@ http {
     sendfile on;
     keepalive_timeout  65;
     types_hash_max_size 2048;
-    client_max_body_size 128M;
+
+    client_max_body_size 512M;
 
     server_names_hash_bucket_size 128;
 

--- a/cli/stubs/php-memory-limits.ini
+++ b/cli/stubs/php-memory-limits.ini
@@ -2,7 +2,9 @@
 memory_limit = 512M
 
 ;The maximum size of an uploaded file.
-upload_max_filesize = 128M
+upload_max_filesize = 512M
 
-;Sets max size of post data allowed. This setting also affects file upload. To upload large files, this value must be larger than upload_max_filesize
-post_max_size = 128M
+; Sets max size of post data allowed. 
+; Changes to this will also need to be reflected in Nginx with client_max_body_size
+; This setting also affects file upload. To upload large files, this value must be larger than upload_max_filesize
+post_max_size = 512M

--- a/cli/stubs/php-memory-limits.ini
+++ b/cli/stubs/php-memory-limits.ini
@@ -1,5 +1,5 @@
 ; Max memory per instance
-memory_limit = 128M
+memory_limit = 512M
 
 ;The maximum size of an uploaded file.
 upload_max_filesize = 128M

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -9,7 +9,7 @@ server {
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
-    client_max_body_size 128M;
+    client_max_body_size 512M;
     http2_push_preload on;
 
     location /VALET_STATIC_PREFIX/ {


### PR DESCRIPTION
PHP's default is 128M, but it's becoming common practice to set the value to 512M in dev and production
Plus, currently homestead sets it to 512M as well.

(Note: Only takes effect after running `valet install`, or when `valet use php@X.Y` installs a new X.Y PHP version.)


Also closes #914 