### PR TITLE
chore(deps): allow laravel/container:^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "illuminate/container": "~5.1 | ^6.0",
+        "illuminate/container": "~5.1 | ^6.0 | ^7.0",
         "mnapoli/silly": "~1.0",
         "symfony/process": "~3.0|~4.0|~5.0",
         "nategood/httpful": "~0.2",


### PR DESCRIPTION
This will allow users to install this package with `laravel/vapor-cli`.

This is needed for the following scenarios:

```
composer global require laravel/valet
composer global require laravel/vapor-cli # fails
```

```
composer global require laravel/vapor-cli
composer global require laravel/valet # fails
```