### PR TITLE
Filter Launch* commands output in "diagnose" command

### DIFF
--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -37,9 +37,9 @@ class Diagnose
         'which -a php-fpm',
         '/usr/local/opt/php/sbin/php-fpm -v',
         'sudo /usr/local/opt/php/sbin/php-fpm -y '.PHP_SYSCONFDIR.'/php-fpm.conf --test',
-        'ls -al ~/Library/LaunchAgents',
-        'ls -al /Library/LaunchAgents',
-        'ls -al /Library/LaunchDaemons',
+        'ls -al ~/Library/LaunchAgents | grep homebrew',
+        'ls -al /Library/LaunchAgents | grep homebrew',
+        'ls -al /Library/LaunchDaemons | grep homebrew',
     ];
 
     var $cli, $files, $print, $progressBar;


### PR DESCRIPTION
As discussed in https://github.com/laravel/valet/pull/938, this PR filters the `Launch*` commands to only show `homebrew`-related output.

Let me know if there's anything else!