### PR TITLE
Pass USER as envvar when relaunching valet using sudo. Fixes #904

### DIFF
--- a/valet
+++ b/valet
@@ -22,7 +22,7 @@ fi
 
 if [[ "$EUID" -ne 0 ]]
 then
-    sudo --preserve-env "$SOURCE" "$@"
+    sudo USER="$USER" --preserve-env "$SOURCE" "$@"
     exit
 fi
 
@@ -78,7 +78,7 @@ then
 	# Fetch Ngrok URL In Background...
 	bash "$DIR/cli/scripts/fetch-share-url.sh" "$HOST" &
     
-	sudo -u "$(logname)" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
+	sudo -u "$USER" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
This is a workaround to fix #904. Root cause is VSCode yielding the wrong output for `logname` when launched from the Dock / Spotlight / Finder _(see microsoft/vscode#96463)_. This bug in VSCode prevents `valet share` from working properly, when invoked from VSCode's terminal.

This workaround makes `valet share` work properly again in that case: when relaunching valet using `sudo` it will take in the current`$USER` and pass it in as an environment variable. This (overridden) environment variable is then used when launching `ngrok`.