### PR TITLE
Allow Valet to open project URLs using different browsers

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -2,6 +2,8 @@
 
 namespace Valet;
 
+use Tightenco\Collect\Support\Arr;
+
 class Configuration
 {
     var $files;
@@ -213,6 +215,17 @@ class Configuration
     function read()
     {
         return json_decode($this->files->get($this->path()), true);
+    }
+
+    /**
+     * Get a specified key from the configuration.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    function get($key, $default = null)
+    {
+        return Arr::get($this->read(), $key, $default);
     }
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -242,8 +242,10 @@ if (is_dir(VALET_HOME_PATH)) {
      * Open the current or given directory in the browser.
      */
     $app->command('open [domain]', function ($domain = null) {
-        $url = "http://".($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
-        CommandLine::runAsUser("open ".escapeshellarg($url));
+        $url = 'http://'.($domain ?: Site::host(getcwd())).'.'.Configuration::get('tld');
+        $command = ($browser = Configuration::get('browser')) ? 'open -a '.$browser : 'open';
+
+        CommandLine::runAsUser($command.' '.escapeshellarg($url));
     })->descriptions('Open the site for the current (or specified) directory in your browser');
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -243,22 +243,24 @@ if (is_dir(VALET_HOME_PATH)) {
      * Set the default browser when opening a URL using Valet.
      */
     $app->command('browser', function ($input, $output) {
-        info('Your Valet default browser is: '.Configuration::get('browser', 'None (system default)'));
-
-        $options = [
+        $browsers = [
             "Chrome" => "Google\\ Chrome",
             "Firefox" => "Firefox",
             "Safari" => "Safari",
             "Brave" => "Brave\\ Browser",
-            "None (system default)" => null,
+            "None (system default)" => "",
         ];
+
+        $current = array_flip($browsers)[Configuration::get('browser', 'None (system default)')];
+        info('Your Valet browser is: '.$current);
+
         $helper = $this->getHelperSet()->get('question');
-        $question = new ChoiceQuestion('Which browser should Valet use when opening a URL?', array_keys($options));
-        $browser = $helper->ask($input, $output, $question);
+        $question = new ChoiceQuestion('Which browser should Valet use when opening a URL?', array_keys($browsers));
+        $selected = $helper->ask($input, $output, $question);
 
-        Configuration::updateKey('browser', $options[$browser]);
+        Configuration::updateKey('browser', $browsers[$selected]);
 
-        info('Your Valet default browser has been updated to ['.$browser.'].');
+        info('Your Valet browser has been updated to: '.$selected);
     })->descriptions('Set the default browser when opening a URL using Valet.');
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -14,6 +14,7 @@ if (file_exists(__DIR__.'/../vendor/autoload.php')) {
 
 use Silly\Application;
 use Illuminate\Container\Container;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use function Valet\info;
 use function Valet\output;
@@ -237,6 +238,28 @@ if (is_dir(VALET_HOME_PATH)) {
             info('No paths have been registered.');
         }
     })->descriptions('Get all of the paths registered with Valet');
+
+    /**
+     * Set the default browser when opening a URL using Valet.
+     */
+    $app->command('browser', function ($input, $output) {
+        info('Your Valet default browser is: '.Configuration::get('browser', 'None (system default)'));
+
+        $options = [
+            "Chrome" => "Google\\ Chrome",
+            "Firefox" => "Firefox",
+            "Safari" => "Safari",
+            "Brave" => "Brave\\ Browser",
+            "None (system default)" => null,
+        ];
+        $helper = $this->getHelperSet()->get('question');
+        $question = new ChoiceQuestion('Which browser should Valet use when opening a URL?', array_keys($options));
+        $browser = $helper->ask($input, $output, $question);
+
+        Configuration::updateKey('browser', $options[$browser]);
+
+        info('Your Valet default browser has been updated to ['.$browser.'].');
+    })->descriptions('Set the default browser when opening a URL using Valet.');
 
     /**
      * Open the current or given directory in the browser.


### PR DESCRIPTION
This PR adds a `valet browser` command to set a default browser inside Valet to open project URLs in the browser.

![2020-05-05 17 07 24](https://user-images.githubusercontent.com/5065331/81082049-0167d300-8ef3-11ea-8792-d2184292199f.gif)


Currently the `valet open` command uses the system default browser. Unfortunately, this renders the command useless in my case since my default browser is Safari, but use Chrome for work. I'd love to use the `valet open` command more but this has been a blocking issue so far.

There are no breaking changes as the default behaviour still works as normal if the config option doesn't exist.

Hopefully others find this feature useful too. Let me know if there's any issues/questions!

Side note: within this PR I added a `Configuration::get()` helper function which uses `Tightenco\Collect\Support\Arr::get()` to ensure no errors are thrown if a key doesn't exist in an array yet + adds the ability to enter a fallback default value. I feel it cleans up the code and reads more expressively compared to current setup:

```php
// using isset()
isset(Configuration::read()['browser']) ? Configuration::read()['browser'] : "None (system default)";

// using data_get()
data_get(Configuration::read(), 'browser', "None (system default)");

// using Configuration::get()
Configuration::get('browser', "None (system default)");
```

Happy to revert to `data_get` if you'd prefer not introduce a new method in `Configuration`.