### PR TITLE
Stops interfering with favicon and robots for proxies

### DIFF
--- a/cli/stubs/proxy.valet.conf
+++ b/cli/stubs/proxy.valet.conf
@@ -23,9 +23,6 @@ server {
     ssl_certificate "VALET_CERT";
     ssl_certificate_key "VALET_KEY";
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
-
     access_log off;
     error_log "VALET_HOME_PATH/Log/VALET_SITE-error.log";
 
@@ -71,9 +68,6 @@ server {
         alias /;
         try_files $uri $uri/;
     }
-
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "VALET_HOME_PATH/Log/VALET_SITE-error.log";

--- a/tests/fixtures/Proxies/Nginx/some-other-proxy.com.test
+++ b/tests/fixtures/Proxies/Nginx/some-other-proxy.com.test
@@ -23,9 +23,6 @@ server {
     ssl_certificate "/home/nobody/.config/valet/Certificates/some-other-proxy.com.test.crt";
     ssl_certificate_key "/home/nobody/.config/valet/Certificates/some-other-proxy.com.test.key";
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
-
     access_log off;
     error_log "/home/nobody/.config/valet/Log/some-other-proxy.com.test-error.log";
 
@@ -71,9 +68,6 @@ server {
         alias /;
         try_files $uri $uri/;
     }
-
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "/home/nobody/.config/valet/Log/some-other-proxy.com.test-error.log";

--- a/tests/fixtures/Proxies/Nginx/some-proxy.com.test
+++ b/tests/fixtures/Proxies/Nginx/some-proxy.com.test
@@ -23,9 +23,6 @@ server {
     ssl_certificate "/home/nobody/.config/valet/Certificates/some-proxy.com.test.crt";
     ssl_certificate_key "/home/nobody/.config/valet/Certificates/some-proxy.com.test.key";
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
-
     access_log off;
     error_log "/home/nobody/.config/valet/Log/some-proxy.com.test-error.log";
 
@@ -71,9 +68,6 @@ server {
         alias /;
         try_files $uri $uri/;
     }
-
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "/home/nobody/.config/valet/Log/some-proxy.com.test-error.log";


### PR DESCRIPTION
The stub we used for normal usage as it relates to favicon.ico and robots.txt may not be appropriate for proxies. I'm seeing some weird behavior. I'm not even sure what the current configuration *does*, exactly, but if I remove them entirely Nginx forwards all requests to the proxy which is what I expected.

If someone has a better idea I'd be up for it. :) Otherwise, I think this probably fits better with the intent of the proxies.