### PR TITLE
Alias dev-master to 2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,10 @@
     },
     "bin": [
         "valet"
-    ]
+    ],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
You all seem to be pretty good about updating cutting new releases and updating version numbers quickly, but I thought it would be nice to allow people to target `@dev` more easily (like `^2.10@dev` or something).