### PR TITLE
Add 'unpark' alias to 'forget' command

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -118,7 +118,7 @@ if (is_dir(VALET_HOME_PATH)) {
         Configuration::removePath($path ?: getcwd());
 
         info(($path === null ? "This" : "The [{$path}]") . " directory has been removed from Valet's paths.");
-    })->descriptions('Remove the current working (or specified) directory from Valet\'s list of paths');
+    }, ['unpark'])->descriptions('Remove the current working (or specified) directory from Valet\'s list of paths');
 
     /**
      * Register a symbolic link with Valet.


### PR DESCRIPTION
Sometimes I find myself wondering how to un-park a folder, and it takes me awhile to find `forget` in the list.
Adding `unpark` as an alias may be helpful.