### PR TITLE
fetch-share-url return list of urls instead of the first

### DIFF
--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -57,7 +57,7 @@ function table(array $headers = [], array $rows = [])
 /**
  * Output the given text to the console.
  *
- * @param  string  $output
+ * @param  string|iterable  $output
  * @return void
  */
 function output($output)

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -257,7 +257,7 @@ if (is_dir(VALET_HOME_PATH)) {
      * Echo the currently tunneled URL.
      */
     $app->command('fetch-share-url [domain]', function ($domain = null) {
-        output(Ngrok::currentTunnelUrl($domain ?: Site::host(getcwd()).'.'.Configuration::read()['tld']));
+        output(Ngrok::currentTunnelsUrls($domain ?: Site::host(getcwd()).'.'.Configuration::read()['tld']));
     })->descriptions('Get the URL to the current Ngrok tunnel');
 
     /**


### PR DESCRIPTION
Right now when calling the `fetch-share-url` command, it returns on the Url of the first ngrok.
This PR makes it return the urls of all the opened tunnels.