### PR TITLE
Fix file_get_contents() error in tld command

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -349,7 +349,7 @@ class Site
             if (!empty($siteConf) && strpos($siteConf, '# valet stub: proxy.valet.conf') === 0) {
                 // proxy config
                 $this->unsecure($url);
-                $this->secure($newUrl, $this->replaceOldDomainWithNew($siteConf, '.'.$url, '.'.$newUrl));
+                $this->secure($newUrl, $this->replaceOldDomainWithNew($siteConf, $url, $newUrl));
             } else {
                 // normal config
                 $this->unsecure($url);
@@ -371,6 +371,8 @@ class Site
         $lookups = [];
         $lookups[] = '~server_name .*;~';
         $lookups[] = '~error_log .*;~';
+        $lookups[] = '~ssl_certificate_key .*;~';
+        $lookups[] = '~ssl_certificate .*;~';
 
         foreach ($lookups as $lookup) {
             preg_match($lookup, $siteConf, $matches);


### PR DESCRIPTION
When we added the `proxy` feature in https://github.com/laravel/valet/pull/913 we inadvertently broke the `tld` command.
It was concatenating old+new tld when searching for existing configs, thus it couldn't find the correct file, which triggered the reported error.

Fixes #984 Thanks @kupoback for reporting it.

This PR fixes the lookup by allowing the correct intended lookup tld to be passed in. It also checks that the file exists before trying to read it.
Also fixed the proxy config cleanup done during a tld change (it wasn't rewriting all variants of the old tld, thus leaving them (and nginx) broken).