### PR TITLE
Point PHP-FPM error_log to user directory

### DIFF
--- a/cli/stubs/etc-phpfpm-error_log.ini
+++ b/cli/stubs/etc-phpfpm-error_log.ini
@@ -1,0 +1,5 @@
+# php-fpm error logging directives
+
+error_log="VALET_HOME_PATH/Log/php-fpm.log"
+log_errors=on
+log_level=debug

--- a/cli/stubs/etc-phpfpm-valet.conf
+++ b/cli/stubs/etc-phpfpm-valet.conf
@@ -13,7 +13,7 @@ listen.mode = 0777
 ;php_admin_value[upload_max_filesize] = 128M
 ;php_admin_value[post_max_size] = 128M
 
-;php_admin_value[error_log] = VALET_HOME_PATH/Log/fpm-php.www.log
+;php_admin_value[error_log] = VALET_HOME_PATH/Log/php-fpm.log
 ;php_admin_flag[log_errors] = on
 
 


### PR DESCRIPTION
Point PHP-FPM error_log to user directory

Old:  `/usr/local/var/log/php-fpm.log`
New: `~/.config/valet/Log/php-fpm.log`

(We already put `~/.config/valet/Log/nginx-error.log` in this same directory.)

This avoids ARM Mac differences in directory paths (eg: `/usr/local/` isn't a default anymore).
It also makes it easier for the User to find/access these logs.

Addendum to #992 discussion at https://github.com/laravel/valet/pull/992#pullrequestreview-533730869