### PR TITLE
Update brew list command to remove deprecation warning

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -48,7 +48,7 @@ class Brew
      */
     function installed($formula)
     {
-        return in_array($formula, explode(PHP_EOL, $this->cli->runAsUser('brew list | grep '.$formula)));
+        return in_array($formula, explode(PHP_EOL, $this->cli->runAsUser('brew list --formula | grep '.$formula)));
     }
 
     /**
@@ -354,7 +354,7 @@ class Brew
 
     /**
      * Tell Homebrew to forcefully remove all PHP versions that Valet supports.
-     * 
+     *
      * @return string
      */
     function uninstallAllPhpVersions()
@@ -369,7 +369,7 @@ class Brew
     /**
      * Uninstall a Homebrew app by formula name.
      * @param  string $formula
-     * 
+     *
      * @return void
      */
     function uninstallFormula($formula)
@@ -380,7 +380,7 @@ class Brew
 
     /**
      * Run Homebrew's cleanup commands.
-     * 
+     *
      * @return string
      */
     function cleanupBrew()

--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -18,7 +18,7 @@ class Diagnose
         'brew update > /dev/null 2>&1',
         'brew config',
         'brew services list',
-        'brew list --versions | grep -E "(php|nginx|dnsmasq|mariadb|mysql|mailhog|openssl)(@\d\..*)?\s"',
+        'brew list --formula --versions | grep -E "(php|nginx|dnsmasq|mariadb|mysql|mailhog|openssl)(@\d\..*)?\s"',
         'brew outdated',
         'php -v',
         'which -a php',

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -374,7 +374,7 @@ Then to finish removing any Composer fragments of Valet:
 Run <info>composer global remove laravel/valet</info>
 and then <info>rm /usr/local/bin/valet</info> to remove the Valet bin link if it still exists.
 Optional:
-- <info>brew list</info> will show any other Homebrew services installed, in case you want to make changes to those as well.
+- <info>brew list --formula</info> will show any other Homebrew services installed, in case you want to make changes to those as well.
 - <info>brew doctor</info> can indicate if there might be any broken things left behind.
 - <info>brew cleanup</info> can purge old cached Homebrew downloads.
 <fg=red>If you had customized your Mac DNS settings in System Preferences->Network, you will need to remove 127.0.0.1 from that list.</>
@@ -402,14 +402,14 @@ You can run <comment>composer global remove laravel/valet</comment> to uninstall
 <info>4. Homebrew Services</info>
 <fg=red>You may remove the core services (php, nginx, dnsmasq) by running:</> <comment>brew uninstall --force php nginx dnsmasq</comment>
 <fg=red>You can then remove selected leftover configurations for these services manually</> in both <comment>".BREW_PREFIX."/etc/</comment> and <comment>".BREW_PREFIX."/logs/</comment>.
-(If you have other PHP versions installed, run <info>brew list | grep php</info> to see which versions you should also uninstall manually.)
+(If you have other PHP versions installed, run <info>brew list --formula | grep php</info> to see which versions you should also uninstall manually.)
 
 <error>BEWARE:</error> Uninstalling PHP via Homebrew will leave your Mac with its original PHP version, which may not be compatible with other Composer dependencies you have installed. Thus you may get unexpected errors.
 
 Some additional services which you may have installed (but which Valet does not directly configure or manage) include: <comment>mariadb mysql mailhog</comment>.
 If you wish to also remove them, you may manually run <comment>brew uninstall SERVICENAME</comment> and clean up their configurations in ".BREW_PREFIX."/etc if necessary.
 
-You can discover more Homebrew services by running: <comment>brew services list</comment> and <comment>brew list</comment>
+You can discover more Homebrew services by running: <comment>brew services list</comment> and <comment>brew list --formula</comment>
 
 <fg=red>If you have customized your Mac DNS settings in System Preferences->Network, you may need to add or remove 127.0.0.1 from the top of that list.</>
 

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -34,12 +34,12 @@ class BrewTest extends PHPUnit_Framework_TestCase
     public function test_installed_returns_true_when_given_formula_is_installed()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php@7.4')->andReturn('php@7.4');
+        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php@7.4')->andReturn('php@7.4');
         swap(CommandLine::class, $cli);
         $this->assertTrue(resolve(Brew::class)->installed('php@7.4'));
 
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php')->andReturn('php
+        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php')->andReturn('php
 php@7.4');
         swap(CommandLine::class, $cli);
         $this->assertTrue(resolve(Brew::class)->installed('php'));
@@ -49,17 +49,17 @@ php@7.4');
     public function test_installed_returns_false_when_given_formula_is_not_installed()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php@7.4')->andReturn('');
+        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php@7.4')->andReturn('');
         swap(CommandLine::class, $cli);
         $this->assertFalse(resolve(Brew::class)->installed('php@7.4'));
 
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php@7.4')->andReturn('php');
+        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php@7.4')->andReturn('php');
         swap(CommandLine::class, $cli);
         $this->assertFalse(resolve(Brew::class)->installed('php@7.4'));
 
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep php@7.4')->andReturn('php
+        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php@7.4')->andReturn('php
 something-else-php@7.4
 php7');
         swap(CommandLine::class, $cli);
@@ -211,7 +211,7 @@ php7');
     public function test_restart_restarts_the_service_using_homebrew_services()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep dnsmasq')->andReturn('dnsmasq');
+        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep dnsmasq')->andReturn('dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services start dnsmasq');
         swap(CommandLine::class, $cli);
@@ -222,7 +222,7 @@ php7');
     public function test_stop_stops_the_service_using_homebrew_services()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list | grep dnsmasq')->andReturn('dnsmasq');
+        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep dnsmasq')->andReturn('dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
         swap(CommandLine::class, $cli);
         resolve(Brew::class)->stopService('dnsmasq');


### PR DESCRIPTION
`brew list` does not support TTY. So a raises a warning or error when used with pipe.
This PR solves the above situation.

Ex) 
```
❯ /opt/homebrew/bin/brew list | grep php
Error: Calling `brew list` to only list formulae is disabled! Use `brew list --formula` instead.
```
```
❯ /usr/local/bin/brew list | grep go
Warning: Calling `brew list` to only list formulae is deprecated! Use `brew list --formula` instead.
go
```

## Reference
[Homebrew/brew#8851](https://github.com/Homebrew/brew/pull/8851)
[Homebrew/brew#8229](https://github.com/Homebrew/brew/pull/8229)