### PR TITLE
Specify 8.0 as latest PHP version

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -23,7 +23,7 @@ class Brew
         'php56'
     ];
 
-    const LATEST_PHP_VERSION = 'php@7.4';
+    const LATEST_PHP_VERSION = 'php@8.0';
 
     var $cli, $files;
 


### PR DESCRIPTION
Specify 8.0 as latest PHP version
This is used mainly for new installs