### PR TITLE
Include resolv conf in diagnose command

### DIFF
--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -40,6 +40,8 @@ class Diagnose
         'ls -al ~/Library/LaunchAgents | grep homebrew',
         'ls -al /Library/LaunchAgents | grep homebrew',
         'ls -al /Library/LaunchDaemons | grep homebrew',
+        'ls -aln /etc/resolv.conf',
+        'cat /etc/resolv.conf',
     ];
 
     var $cli, $files, $print, $progressBar;


### PR DESCRIPTION
Including the linked resolv.conf helps with troubleshooting situations where dns appears to not be working.
(Mostly the goal is to determine whether a conflicting entry is listed too early, or if the localhost is not listed first when others are present.)