### PR TITLE
Improvements to "valet use" command

### DIFF
--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -20,6 +20,7 @@ class Diagnose
         'brew services list',
         'brew list --formula --versions | grep -E "(php|nginx|dnsmasq|mariadb|mysql|mailhog|openssl)(@\d\..*)?\s"',
         'brew outdated',
+        'brew tap',
         'php -v',
         'which -a php',
         'php --ini',

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -10,6 +10,7 @@ class PhpFpm
 
     var $taps = [
         'homebrew/homebrew-core',
+        'shivammathur/php',
     ];
 
     /**

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -142,11 +142,8 @@ class PhpFpm
     {
         $version = $this->brew->linkedPhp();
 
-        $versionNormalized = preg_replace(
-            '/php@?(\d)\.?(\d)/',
-            '$1.$2',
-            $version === 'php' ? Brew::LATEST_PHP_VERSION : $version
-        );
+        $versionNormalized = $this->normalizePhpVersion($version === 'php' ? Brew::LATEST_PHP_VERSION : $version);
+        $versionNormalized = preg_replace('~[^\d\.]~', '', $versionNormalized);
 
         return $versionNormalized === '5.6'
             ? BREW_PREFIX.'/etc/php/5.6/php-fpm.conf'
@@ -195,6 +192,15 @@ class PhpFpm
         return $version === 'php' ? $this->brew->determineAliasedVersion($version) : $version;
     }
 
+
+    /**
+     * If passed php7.4 or php74 formats, normalize to php@7.4 format.
+     */
+    function normalizePhpVersion($version)
+    {
+        return preg_replace('/(php)([0-9+])(?:.)?([0-9+])/i', '$1@$2.$3', $version);
+    }
+
     /**
      * Validate the requested version to be sure we can support it.
      *
@@ -203,8 +209,7 @@ class PhpFpm
      */
     function validateRequestedVersion($version)
     {
-        // If passed php7.2 or php72 formats, normalize to php@7.2 format:
-        $version = preg_replace('/(php)([0-9+])(?:.)?([0-9+])/i', '$1@$2.$3', $version);
+        $version = $this->normalizePhpVersion($version);
 
         if ($version === 'php') {
             if (strpos($this->brew->determineAliasedVersion($version), '@')) {

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -172,6 +172,26 @@ if (! function_exists('ends_with')) {
     }
 }
 
+if (! function_exists('starts_with')) {
+    /**
+     * Determine if a given string starts with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|string[]  $needles
+     * @return bool
+     */
+    function starts_with($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 /**
  * Get the user
  */

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -462,15 +462,14 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * Allow the user to change the version of php valet uses
      */
-    $app->command('use [phpVersion]', function ($phpVersion) {
+    $app->command('use [phpVersion] [--force]', function ($phpVersion, $force) {
         if (!$phpVersion) {
             return info('Valet is using ' . Brew::linkedPhp());
         }
 
         PhpFpm::validateRequestedVersion($phpVersion);
 
-        PhpFpm::stopRunning();
-        $newVersion = PhpFpm::useVersion($phpVersion);
+        $newVersion = PhpFpm::useVersion($phpVersion, $force);
 
         Nginx::restart();
         info(sprintf('Valet is now using %s.', $newVersion) . PHP_EOL);

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -462,7 +462,11 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * Allow the user to change the version of php valet uses
      */
-    $app->command('use phpVersion', function ($phpVersion) {
+    $app->command('use [phpVersion]', function ($phpVersion) {
+        if (!$phpVersion) {
+            return info('Valet is using ' . Brew::linkedPhp());
+        }
+
         PhpFpm::validateRequestedVersion($phpVersion);
 
         PhpFpm::stopRunning();

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -34,13 +34,14 @@ class BrewTest extends PHPUnit_Framework_TestCase
     public function test_installed_returns_true_when_given_formula_is_installed()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php@7.4')->andReturn('php@7.4');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info php@7.4 --json')
+        ->andReturn('[{"name":"php@7.4","full_name":"php@7.4","aliases":[],"versioned_formulae":[],"versions":{"stable":"7.4.5"},"installed":[{"version":"7.4.5"}]}]');
         swap(CommandLine::class, $cli);
         $this->assertTrue(resolve(Brew::class)->installed('php@7.4'));
 
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php')->andReturn('php
-php@7.4');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info php --json')
+        ->andReturn('[{"name":"php","full_name":"php","aliases":["php@8.0"],"versioned_formulae":[],"versions":{"stable":"8.0.0"},"installed":[{"version":"8.0.0"}]}]');
         swap(CommandLine::class, $cli);
         $this->assertTrue(resolve(Brew::class)->installed('php'));
     }
@@ -49,19 +50,12 @@ php@7.4');
     public function test_installed_returns_false_when_given_formula_is_not_installed()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php@7.4')->andReturn('');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info php@7.4 --json')->andReturn('');
         swap(CommandLine::class, $cli);
         $this->assertFalse(resolve(Brew::class)->installed('php@7.4'));
 
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php@7.4')->andReturn('php');
-        swap(CommandLine::class, $cli);
-        $this->assertFalse(resolve(Brew::class)->installed('php@7.4'));
-
-        $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep php@7.4')->andReturn('php
-something-else-php@7.4
-php7');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info php@7.4 --json')->andReturn('Error: No formula found');
         swap(CommandLine::class, $cli);
         $this->assertFalse(resolve(Brew::class)->installed('php@7.4'));
     }
@@ -69,131 +63,49 @@ php7');
 
     public function test_has_installed_php_indicates_if_php_is_installed_via_brew()
     {
-        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@8.1')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@8.0')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@7.4')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@7.3')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php74')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php73')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@8.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.4')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.3')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php74')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php73')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@8.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.4')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.3')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php74')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php73')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.4')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.3')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php74')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php73')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.4')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.3')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php74')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php73')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.4')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.3')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(true);
-        $brew->shouldReceive('installed')->with('php74')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php73')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(true);
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installed')->with('php')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@8.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.4')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.3')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php74')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php73')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php72')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php71')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php70')->andReturn(false);
-        $brew->shouldReceive('installed')->with('php56')->andReturn(false);
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@5.5']));
         $this->assertFalse($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@8.1']));
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@8.0']));
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@7.4']));
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@7.3']));
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php73']));
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@7.2', 'php72']));
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php71', 'php@7.1']));
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@7.0']));
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@5.6']));
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php56']));
+        $this->assertTrue($brew->hasInstalledPhp());
     }
 
 
@@ -211,7 +123,7 @@ php7');
     public function test_restart_restarts_the_service_using_homebrew_services()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep dnsmasq')->andReturn('dnsmasq');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info dnsmasq --json')->andReturn('[{"name":"dnsmasq","full_name":"dnsmasq","aliases":[],"versioned_formulae":[],"versions":{"stable":"1"},"installed":[{"version":"1"}]}]');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services start dnsmasq');
         swap(CommandLine::class, $cli);
@@ -222,7 +134,7 @@ php7');
     public function test_stop_stops_the_service_using_homebrew_services()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->once()->with('brew list --formula | grep dnsmasq')->andReturn('dnsmasq');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info dnsmasq --json')->andReturn('[{"name":"dnsmasq","full_name":"dnsmasq","aliases":[],"versioned_formulae":[],"versions":{"stable":"1"},"installed":[{"version":"1"}]}]');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
         swap(CommandLine::class, $cli);
         resolve(Brew::class)->stopService('dnsmasq');

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -79,8 +79,13 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
             'php@5.6',
         ]));
         $brewMock->shouldReceive('hasLinkedPhp')->andReturn(false);
-        $brewMock->shouldReceive('ensureInstalled')->with('php@7.2');
+        $brewMock->shouldReceive('ensureInstalled')->with('php@7.2', [], $phpFpmMock->taps);
+        $brewMock->shouldReceive('determineAliasedVersion')->with('php@7.2')->andReturn('php@7.2');
         $brewMock->shouldReceive('link')->withArgs(['php@7.2', true]);
+        $brewMock->shouldReceive('linkedPhp');
+        $brewMock->shouldReceive('installed');
+        $brewMock->shouldReceive('getRunningServices')->andReturn(collect());
+        $brewMock->shouldReceive('stopService');
 
         // Test both non prefixed and prefixed
         $this->assertSame('php@7.2', $phpFpmMock->useVersion('php7.2'));
@@ -120,8 +125,13 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
         $brewMock->shouldReceive('hasLinkedPhp')->andReturn(true);
         $brewMock->shouldReceive('getLinkedPhpFormula')->andReturn('php@7.1');
         $brewMock->shouldReceive('unlink')->with('php@7.1');
-        $brewMock->shouldReceive('ensureInstalled')->with('php@7.2');
+        $brewMock->shouldReceive('ensureInstalled')->with('php@7.2', [], $phpFpmMock->taps);
+        $brewMock->shouldReceive('determineAliasedVersion')->with('php@7.2')->andReturn('php@7.2');
         $brewMock->shouldReceive('link')->withArgs(['php@7.2', true]);
+        $brewMock->shouldReceive('linkedPhp');
+        $brewMock->shouldReceive('installed');
+        $brewMock->shouldReceive('getRunningServices')->andReturn(collect());
+        $brewMock->shouldReceive('stopService');
 
         // Test both non prefixed and prefixed
         $this->assertSame('php@7.2', $phpFpmMock->useVersion('php@7.2'));


### PR DESCRIPTION
Improvements to "valet use" command

- `valet use` can now display the currently-linked PHP version, for quick inspection
- properly detects if the requested version is already installed, and skips re-installing/re-starting/re-configuring
    - allows `--force` to re-configure anyway
- smarter treatment of short 'php' name when it's aliased to another specific installed version


All in all, should be faster and a little more user-friendly.