### PR TITLE
Update test suite to PHPUnit with symfony/phpunit-bridge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,13 +29,8 @@ jobs:
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
-        if: matrix.php != 8.0
-
-      - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --ignore-platform-req=php
-        if: matrix.php == 8.0
 
       - name: Execute tests
         env:
           APP_ENV: testing
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/simple-phpunit --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 composer.lock
 error.log
 .idea
+.phpunit.result.cache

--- a/cli/stubs/etc-phpfpm-error_log.ini
+++ b/cli/stubs/etc-phpfpm-error_log.ini
@@ -1,4 +1,4 @@
-# php-fpm error logging directives
+; php-fpm error logging directives
 
 error_log="VALET_HOME_PATH/Log/php-fpm.log"
 log_errors=on

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",
-        "phpunit/phpunit": ">=5.7",
         "symfony/phpunit-bridge": "^5.1"
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": ">=5.7",
+        "symfony/phpunit-bridge": "^5.1"
     },
     "bin": [
         "valet"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,12 +7,16 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         beStrictAboutTestsThatDoNotTestAnything="false">
     <testsuites>
         <testsuite name="Valet Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
     <php>
         <env name="APP_ENV" value="testing"/>
     </php>

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Valet\Brew;
 use Valet\Filesystem;
 use Valet\CommandLine;
@@ -9,27 +11,26 @@ use function Valet\swap;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 
-class BrewTest extends PHPUnit_Framework_TestCase
+class BrewTest extends TestCase
 {
-    public function setUp()
+    use SetUpTearDownTrait;
+
+    public function doSetUp()
     {
         $_SERVER['SUDO_USER'] = user();
 
         Container::setInstance(new Container);
     }
 
-
-    public function tearDown()
+    public function doTearDown()
     {
         Mockery::close();
     }
-
 
     public function test_brew_can_be_resolved_from_container()
     {
         $this->assertInstanceOf(Brew::class, resolve(Brew::class));
     }
-
 
     public function test_installed_returns_true_when_given_formula_is_installed()
     {
@@ -44,7 +45,6 @@ php@7.4');
         swap(CommandLine::class, $cli);
         $this->assertTrue(resolve(Brew::class)->installed('php'));
     }
-
 
     public function test_installed_returns_false_when_given_formula_is_not_installed()
     {
@@ -65,7 +65,6 @@ php7');
         swap(CommandLine::class, $cli);
         $this->assertFalse(resolve(Brew::class)->installed('php@7.4'));
     }
-
 
     public function test_has_installed_php_indicates_if_php_is_installed_via_brew()
     {
@@ -196,7 +195,6 @@ php7');
         $this->assertFalse($brew->hasInstalledPhp());
     }
 
-
     public function test_tap_taps_the_given_homebrew_repository()
     {
         $cli = Mockery::mock(CommandLine::class);
@@ -206,7 +204,6 @@ php7');
         swap(CommandLine::class, $cli);
         resolve(Brew::class)->tap('php@7.1', 'php@7.0', 'php@5.6');
     }
-
 
     public function test_restart_restarts_the_service_using_homebrew_services()
     {
@@ -218,7 +215,6 @@ php7');
         resolve(Brew::class)->restartService('dnsmasq');
     }
 
-
     public function test_stop_stops_the_service_using_homebrew_services()
     {
         $cli = Mockery::mock(CommandLine::class);
@@ -227,7 +223,6 @@ php7');
         swap(CommandLine::class, $cli);
         resolve(Brew::class)->stopService('dnsmasq');
     }
-
 
     public function test_linked_php_returns_linked_php_formula_name()
     {
@@ -262,17 +257,14 @@ php7');
         $this->assertSame('php@5.6', $getBrewMock($files)->linkedPhp());
     }
 
-
-    /**
-     * @expectedException DomainException
-     */
     public function test_linked_php_throws_exception_if_no_php_link()
     {
+        $this->expectException(DomainException::class);
+
         $brewMock = Mockery::mock(Brew::class)->makePartial();
         $brewMock->shouldReceive('hasLinkedPhp')->once()->andReturn(false);
         $brewMock->linkedPhp();
     }
-
 
     public function test_has_linked_php_returns_true_if_php_link_exists()
     {
@@ -285,19 +277,16 @@ php7');
         $this->assertTrue($brew->hasLinkedPhp());
     }
 
-
-    /**
-     * @expectedException DomainException
-     */
     public function test_linked_php_throws_exception_if_unsupported_php_version_is_linked()
     {
+        $this->expectException(DomainException::class);
+
         $files = Mockery::mock(Filesystem::class);
         $files->shouldReceive('isLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn(true);
         $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn('/test/path/php/5.4.14/test');
         swap(Filesystem::class, $files);
         resolve(Brew::class)->linkedPhp();
     }
-
 
     public function test_install_or_fail_will_install_brew_formulas()
     {
@@ -306,7 +295,6 @@ php7');
         swap(CommandLine::class, $cli);
         resolve(Brew::class)->installOrFail('dnsmasq');
     }
-
 
     public function test_install_or_fail_can_install_taps()
     {
@@ -318,12 +306,10 @@ php7');
         $brew->installOrFail('dnsmasq', [], ['test/tap']);
     }
 
-
-    /**
-     * @expectedException DomainException
-     */
     public function test_install_or_fail_throws_exception_on_failure()
     {
+        $this->expectException(DomainException::class);
+
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('runAsUser')->andReturnUsing(function ($command, $onError) {
             $onError(1, 'test error ouput');
@@ -332,11 +318,10 @@ php7');
         resolve(Brew::class)->installOrFail('dnsmasq');
     }
 
-    /**
-     * @expectedException DomainException
-     */
     public function test_link_will_throw_exception_on_failure()
     {
+        $this->expectException(DomainException::class);
+
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('runAsUser')->once()->withArgs([
             'brew link aformula',
@@ -372,11 +357,10 @@ php7');
         $this->assertSame('Some output forced', resolve(Brew::class)->link('aformula', true));
     }
 
-    /**
-     * @expectedException DomainException
-     */
     public function test_unlink_will_throw_exception_on_failure()
     {
+        $this->expectException(DomainException::class);
+
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('runAsUser')->once()->withArgs([
             'brew unlink aformula',
@@ -400,11 +384,10 @@ php7');
         $this->assertSame('Some output', resolve(Brew::class)->unlink('aformula'));
     }
 
-    /**
-     * @expectedException DomainException
-     */
     public function test_getRunningServices_will_throw_exception_on_failure()
     {
+        $this->expectException(DomainException::class);
+
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('runAsUser')->once()->withArgs([
             'brew services list | grep started | awk \'{ print $1; }\'',
@@ -485,48 +468,48 @@ php7');
     {
         return [
             [
-                '/test/path/php/7.3.0/test', // linked path
+                '/test/path/php/7.4.0/test', // linked path
                 [ // matches
-                    'path/php/7.3.0/test',
+                    'path/php/7.4.0/test',
                     'php',
                     '',
-                    '7.3',
+                    '7.4',
                     '.0',
                 ],
                 'php', // expected link formula
             ],
             [
-                '/test/path/php@7.2/7.2.13/test',
+                '/test/path/php@7.4/7.4.13/test',
                 [
-                    'path/php@7.2/7.2.13/test',
+                    'path/php@7.4/7.4.13/test',
                     'php',
-                    '@7.2',
-                    '7.2',
+                    '@7.4',
+                    '7.4',
                     '.13',
                 ],
-                'php@7.2'
+                'php@7.4'
             ],
             [
-                '/test/path/php/7.2.9_2/test',
+                '/test/path/php/7.4.9_2/test',
                 [
-                    'path/php/7.2.9_2/test',
+                    'path/php/7.4.9_2/test',
                     'php',
                     '',
-                    '7.2',
+                    '7.4',
                     '.9_2',
                 ],
                 'php',
             ],
             [
-                '/test/path/php72/7.2.9_2/test',
+                '/test/path/php74/7.4.9_2/test',
                 [
-                    'path/php72/7.2.9_2/test',
+                    'path/php74/7.4.9_2/test',
                     'php',
-                    '72',
-                    '7.2',
+                    '74',
+                    '7.4',
                     '.9_2',
                 ],
-                'php72',
+                'php74',
             ],
             [
                 '/test/path/php56/test',

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Valet\Brew;
 use Valet\Valet;
 use Valet\Filesystem;
@@ -9,21 +11,21 @@ use function Valet\resolve;
 use function Valet\swap;
 use Illuminate\Container\Container;
 
-class ConfigurationTest extends PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
-    public function setUp()
+    use SetUpTearDownTrait;
+
+    public function doSetUp()
     {
         $_SERVER['SUDO_USER'] = user();
 
         Container::setInstance(new Container);
     }
 
-
-    public function tearDown()
+    public function doTearDown()
     {
         Mockery::close();
     }
-
 
     public function test_configuration_directory_is_created_if_it_doesnt_exist()
     {
@@ -34,7 +36,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         swap(Filesystem::class, $files);
         resolve(Configuration::class)->createConfigurationDirectory();
     }
-
 
     public function test_drivers_directory_is_created_with_sample_driver_if_it_doesnt_exist()
     {
@@ -76,7 +77,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $config->addPath('path-3');
     }
 
-
     public function test_paths_may_be_removed_from_the_configuration()
     {
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
@@ -88,7 +88,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         ]);
         $config->removePath('path-2');
     }
-
 
     public function test_prune_removes_directories_from_paths_that_no_longer_exist()
     {
@@ -107,7 +106,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $config->prune();
     }
 
-
     public function test_prune_doesnt_execute_if_configuration_directory_doesnt_exist()
     {
         $files = Mockery::mock(Filesystem::class.'[exists]');
@@ -119,7 +117,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $config->prune();
     }
 
-
     public function test_update_key_updates_the_specified_configuration_key()
     {
         $config = Mockery::mock(Configuration::class.'[read,write]', [new Filesystem]);
@@ -127,7 +124,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $config->shouldReceive('write')->once()->with(['foo' => 'bar', 'bar' => 'baz']);
         $config->updateKey('bar', 'baz');
     }
-
 
     public function test_trust_adds_the_sudoer_files()
     {

--- a/tests/DnsMasqTest.php
+++ b/tests/DnsMasqTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Valet\Brew;
 use Valet\DnsMasq;
 use Valet\Filesystem;
@@ -10,17 +12,18 @@ use function Valet\resolve;
 use function Valet\swap;
 use Illuminate\Container\Container;
 
-class DnsMasqTest extends PHPUnit_Framework_TestCase
+class DnsMasqTest extends TestCase
 {
-    public function setUp()
+    use SetUpTearDownTrait;
+
+    public function doSetUp()
     {
         $_SERVER['SUDO_USER'] = user();
 
         Container::setInstance(new Container);
     }
 
-
-    public function tearDown()
+    public function doTearDown()
     {
         exec('rm -rf '.__DIR__.'/output');
         mkdir(__DIR__.'/output');
@@ -28,7 +31,6 @@ class DnsMasqTest extends PHPUnit_Framework_TestCase
 
         Mockery::close();
     }
-
 
     public function test_install_installs_and_places_configuration_files_in_proper_locations()
     {
@@ -56,7 +58,6 @@ class DnsMasqTest extends PHPUnit_Framework_TestCase
         );
     }
 
-
     public function test_update_tld_removes_old_resolver_and_reinstalls()
     {
         $cli = Mockery::mock(CommandLine::class);
@@ -67,7 +68,6 @@ class DnsMasqTest extends PHPUnit_Framework_TestCase
         $dnsMasq->updateTld('old', 'new');
     }
 }
-
 
 class StubForCreatingCustomDnsMasqConfigFiles extends DnsMasq
 {

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -1,16 +1,19 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Valet\Filesystem;
 
-class FilesystemTest extends PHPUnit_Framework_TestCase
+class FilesystemTest extends TestCase
 {
-    public function tearDown()
+    use SetUpTearDownTrait;
+
+    public function doTearDown()
     {
         exec('rm -rf '.__DIR__.'/output');
         mkdir(__DIR__.'/output');
         touch(__DIR__.'/output/.gitkeep');
     }
-
 
     public function test_remove_broken_links_removes_broken_symlinks()
     {
@@ -20,6 +23,6 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         $this->assertFileExists(__DIR__.'/output/file.link');
         unlink(__DIR__.'/output/file.out');
         $files->removeBrokenLinksAt(__DIR__.'/output');
-        $this->assertFileNotExists(__DIR__.'/output/file.link');
+        $this->assertFileDoesNotExist(__DIR__.'/output/file.link');
     }
 }

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Valet\Brew;
 use Valet\PhpFpm;
 use Valet\Filesystem;
@@ -9,17 +11,18 @@ use function Valet\swap;
 use function Valet\resolve;
 use Illuminate\Container\Container;
 
-class PhpFpmTest extends PHPUnit_Framework_TestCase
+class PhpFpmTest extends TestCase
 {
-    public function setUp()
+    use SetUpTearDownTrait;
+
+    public function doSetUp()
     {
         $_SERVER['SUDO_USER'] = user();
 
         Container::setInstance(new Container);
     }
 
-
-    public function tearDown()
+    public function doTearDown()
     {
         exec('rm -rf '.__DIR__.'/output');
         mkdir(__DIR__.'/output');
@@ -35,9 +38,9 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
         copy(__DIR__.'/files/php-memory-limits.ini', __DIR__.'/output/conf.d/php-memory-limits.ini');
         resolve(StubForUpdatingFpmConfigFiles::class)->updateConfiguration();
         $contents = file_get_contents(__DIR__.'/output/fpm.conf');
-        $this->assertContains(sprintf("\nuser = %s", user()), $contents);
-        $this->assertContains("\ngroup = staff", $contents);
-        $this->assertContains("\nlisten = ".VALET_HOME_PATH."/valet.sock", $contents);
+        $this->assertStringContainsString(sprintf("\nuser = %s", user()), $contents);
+        $this->assertStringContainsString("\ngroup = staff", $contents);
+        $this->assertStringContainsString("\nlisten = ".VALET_HOME_PATH."/valet.sock", $contents);
     }
 
     public function test_stopRunning_will_pass_filtered_result_of_getRunningServices_to_stopService()
@@ -87,11 +90,10 @@ class PhpFpmTest extends PHPUnit_Framework_TestCase
         $this->assertSame('php@7.2', $phpFpmMock->useVersion('php72'));
     }
 
-    /**
-     * @expectedException DomainException
-     */
     public function test_use_version_will_throw_if_version_not_supported()
     {
+        $this->expectException(DomainException::class);
+
         $brewMock = Mockery::mock(Brew::class);
         swap(Brew::class, $brewMock);
 

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Valet\CommandLine;
 use Valet\Site;
 use Valet\Filesystem;
@@ -9,17 +11,18 @@ use function Valet\resolve;
 use function Valet\swap;
 use Illuminate\Container\Container;
 
-class SiteTest extends PHPUnit_Framework_TestCase
+class SiteTest extends TestCase
 {
-    public function setUp()
+    use SetUpTearDownTrait;
+
+    public function doSetUp()
     {
         $_SERVER['SUDO_USER'] = user();
 
         Container::setInstance(new Container);
     }
 
-
-    public function tearDown()
+    public function doTearDown()
     {
         exec('rm -rf '.__DIR__.'/output');
         mkdir(__DIR__.'/output');
@@ -27,7 +30,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
         Mockery::close();
     }
-
 
     public function test_get_certificates_will_return_with_multi_segment_tld()
     {
@@ -52,7 +54,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
         $certs = $site->getCertificates($certPath);
         $this->assertSame(['helloworld' => 0], $certs->all());
     }
-
 
     public function test_get_sites_will_return_if_secured()
     {
@@ -108,7 +109,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
         ], $sites->last());
     }
 
-
     public function test_get_sites_will_work_with_non_symlinked_path()
     {
         $files = Mockery::mock(Filesystem::class);
@@ -151,7 +151,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
         ], $sites->first());
     }
 
-
     public function test_get_sites_will_not_return_if_path_is_not_directory()
     {
         $files = Mockery::mock(Filesystem::class);
@@ -188,7 +187,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
             'path' => $dirPath . '/siteone',
         ], $sites->first());
     }
-
 
     public function test_get_sites_will_work_with_symlinked_path()
     {
@@ -248,20 +246,18 @@ class SiteTest extends PHPUnit_Framework_TestCase
         $this->assertSame(VALET_HOME_PATH.'/Sites/link', $linkPath);
     }
 
-
     public function test_unlink_removes_existing_symlink()
     {
         file_put_contents(__DIR__.'/output/file.out', 'test');
         symlink(__DIR__.'/output/file.out', __DIR__.'/output/link');
         $site = resolve(StubForRemovingLinks::class);
         $site->unlink('link');
-        $this->assertFileNotExists(__DIR__.'/output/link');
+        $this->assertFileDoesNotExist(__DIR__.'/output/link');
 
         $site = resolve(StubForRemovingLinks::class);
         $site->unlink('link');
-        $this->assertFileNotExists(__DIR__.'/output/link');
+        $this->assertFileDoesNotExist(__DIR__.'/output/link');
     }
-
 
     public function test_prune_links_removes_broken_symlinks_in_sites_path()
     {
@@ -270,9 +266,8 @@ class SiteTest extends PHPUnit_Framework_TestCase
         unlink(__DIR__.'/output/file.out');
         $site = resolve(StubForRemovingLinks::class);
         $site->pruneLinks();
-        $this->assertFileNotExists(__DIR__.'/output/link');
+        $this->assertFileDoesNotExist(__DIR__.'/output/link');
     }
-
 
     public function test_certificates_trim_tld_for_custom_tlds()
     {
@@ -300,7 +295,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('fiveletters', $certs->last());
     }
 
-
     public function test_no_proxies()
     {
         $config = Mockery::mock(Configuration::class);
@@ -316,7 +310,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $site->proxies()->all());
     }
-
 
     public function test_lists_proxies()
     {
@@ -346,7 +339,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
             ],
         ], $site->proxies()->all());
     }
-
 
     public function test_add_proxy()
     {
@@ -380,7 +372,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
             ],
         ], $site->proxies()->all());
     }
-
 
     public function test_add_proxy_clears_previous_proxy_certificate()
     {
@@ -426,7 +417,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
         ], $site->proxies()->all());
     }
 
-
     public function test_add_proxy_clears_previous_non_proxy_certificate()
     {
         $config = Mockery::mock(Configuration::class);
@@ -466,7 +456,6 @@ class SiteTest extends PHPUnit_Framework_TestCase
             ],
         ], $site->proxies()->all());
     }
-
 
     public function test_remove_proxy()
     {
@@ -602,7 +591,7 @@ class FixturesSiteFake extends Site
 
     public function assertNginxNotExists($urlWithTld)
     {
-        SiteTest::assertFileNotExists($this->nginxPath($urlWithTld));
+        SiteTest::assertFileDoesNotExist($this->nginxPath($urlWithTld));
     }
 
     public function assertCertificateExists($urlWithTld)
@@ -613,8 +602,8 @@ class FixturesSiteFake extends Site
 
     public function assertCertificateNotExists($urlWithTld)
     {
-        SiteTest::assertFileNotExists($this->certificatesPath($urlWithTld, 'crt'));
-        SiteTest::assertFileNotExists($this->certificatesPath($urlWithTld, 'key'));
+        SiteTest::assertFileDoesNotExist($this->certificatesPath($urlWithTld, 'crt'));
+        SiteTest::assertFileDoesNotExist($this->certificatesPath($urlWithTld, 'key'));
     }
 
     public function assertCertificateExistsWithCounterValue($urlWithTld, $counter)


### PR DESCRIPTION
Use `simple-phpunit` instead of `phpunit`, that's all

The PHPUnit Bridge provides utilities to report legacy tests and usage of deprecated code and helpers for mocking native functions related to time, DNS and class existence.

##Reference
[Symfony PHPUnit Bridge Document](https://symfony.com/doc/current/components/phpunit_bridge.html)

* * *
This PR is an implementation of #1004 using `symfony/phpunit-bridge` instead `yoast/phpunit-polyfills`.

this closes #1002