### PR TITLE
Site path found, break from loops

### DIFF
--- a/server.php
+++ b/server.php
@@ -137,10 +137,11 @@ foreach ($valetConfig['paths'] as $path) {
             // match dir for lowercase, because Nginx only tells us lowercase names
             if (strtolower($file) === $siteName) {
                 $valetSitePath = $path.'/'.$file;
-                break;
+                break 2;
             }
             if (strtolower($file) === $domain) {
                 $valetSitePath = $path.'/'.$file;
+                break 2;
             }
         }
         closedir($handle);

--- a/server.php
+++ b/server.php
@@ -137,14 +137,18 @@ foreach ($valetConfig['paths'] as $path) {
             // match dir for lowercase, because Nginx only tells us lowercase names
             if (strtolower($file) === $siteName) {
                 $valetSitePath = $path.'/'.$file;
-                break 2;
+                break;
             }
             if (strtolower($file) === $domain) {
                 $valetSitePath = $path.'/'.$file;
-                break 2;
+                break;
             }
         }
         closedir($handle);
+        
+        if ($valetSitePath) {
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
I don't know exactly since when my issue exists but I believe #997 has something to do with it. If I have 'parked' my `~/PhpstormProjects` directory filled with Laravel projects and have a linked directory inside one of those Laravel projects as a subdomain the parked directory is used instead of the linked directory. This PR prevents that.

To be clear:
```
cd ~/PhpstormProjects
valet park

cd ~/PhpstormProjects/project/subdomain
valet link subdomain.project
```

Then `subdomain.project.test` should link to `~/PhpstormProjects/project/subdomain`, but now it links to `~/PhpstormProjects/project`. After this PR is merged it links to `~/PhpstormProjects/project/subdomain`.