### PR TITLE
Force removal of orphaned valet.sock file

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -202,6 +202,10 @@ class PhpFpm
 
         $this->stopRunning();
 
+        // remove any orphaned valet.sock files that PHP didn't clean up due to version conflicts
+        $this->files->unlink(VALET_HOME_PATH.'/valet.sock');
+        $this->cli->quietly('sudo rm ' . VALET_HOME_PATH.'/valet.sock');
+
         // ensure configuration is correct and start the linked version
         $this->install();
 


### PR DESCRIPTION
When switching PHP versions the valet.sock file may not be removed if the linked PHP process doesn't get shut down properly. This can happen when Homebrew switches default `php` version aliases and if one has started multiple homebrew PHP instances under different permission levels or different users.

This patch merely forces the .sock file's removal when switching versions. 

In very rare cases a filesystem lock may prevent the file's proper removal, in which case a reboot might be required.

To prevent these issues, keep Homebrew up-to-date by running `brew upgrade` on a regular basis (weekly is good).

Fixes #1010 