### PR TITLE
Fix issue with `valet share` on Hyper

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -77,7 +77,7 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('tld [tld]', function ($tld = null) {
         if ($tld === null) {
-            return info(Configuration::read()['tld']);
+            return output(Configuration::read()['tld']);
         }
 
         DnsMasq::updateTld(


### PR DESCRIPTION
Related: https://github.com/laravel/valet/issues/790#issuecomment-765559963

Changing from `info()` to just `output()` avoids ANSI char output for color display (which Vercel Hyper is misinterpreting), and this particular line doesn't "need" colored output particularly.