### PR TITLE
Typo3 Driver: Fix for $documentRoot

### DIFF
--- a/cli/drivers/Typo3ValetDriver.php
+++ b/cli/drivers/Typo3ValetDriver.php
@@ -17,7 +17,7 @@ class Typo3ValetDriver extends ValetDriver
     | to '', if you don't use a subdirectory but valet link directly.
     |
     */
-    protected $documentRoot = '/web';
+    protected $documentRoot = '/public';
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Latest versions of Typo3 works with public $documentRoot folder name.