### PR TITLE
Add loopback command

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -36,7 +36,7 @@ class Configuration
 
     /**
      * Forcefully delete the Valet home configuration directory and contents.
-     * 
+     *
      * @return void
      */
     function uninstall()
@@ -130,7 +130,7 @@ class Configuration
     function writeBaseConfiguration()
     {
         if (! $this->files->exists($this->path())) {
-            $this->write(['tld' => 'test', 'paths' => []]);
+            $this->write(['tld' => 'test', 'loopback' => VALET_LOOPBACK, 'paths' => []]);
         }
 
         /**
@@ -138,11 +138,13 @@ class Configuration
          */
         $config = $this->read();
 
-        if (isset($config['tld'])) {
-            return;
+        if (! isset($config['tld'])) {
+            $this->updateKey('tld', !empty($config['domain']) ? $config['domain'] : 'test');
         }
 
-        $this->updateKey('tld', !empty($config['domain']) ? $config['domain'] : 'test');
+        if (! isset($config['loopback'])) {
+            $this->updateKey('loopback', VALET_LOOPBACK);
+        }
     }
 
     /**

--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -50,10 +50,6 @@ class Diagnose
         'sh -c \'for file in ~/.config/valet/nginx/*; do echo "------\n~/.config/valet/nginx/$(basename $file)\n---\n"; cat $file | grep -n "# valet loopback"; echo "\n------\n"; done\'',
     ];
 
-    var $methods = [
-
-    ];
-
     var $cli, $files, $print, $progressBar;
 
     /**

--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -41,8 +41,17 @@ class Diagnose
         'ls -al ~/Library/LaunchAgents | grep homebrew',
         'ls -al /Library/LaunchAgents | grep homebrew',
         'ls -al /Library/LaunchDaemons | grep homebrew',
+        'ls -al /Library/LaunchDaemons | grep "com.laravel.valet."',
         'ls -aln /etc/resolv.conf',
         'cat /etc/resolv.conf',
+        'ifconfig lo0',
+        'sh -c \'echo "------\n'.BREW_PREFIX.'/etc/nginx/valet/valet.conf\n---\n"; cat '.BREW_PREFIX.'/etc/nginx/valet/valet.conf | grep -n "# valet loopback"; echo "\n------\n"\'',
+        'sh -c \'for file in ~/.config/valet/dnsmasq.d/*; do echo "------\n~/.config/valet/dnsmasq.d/$(basename $file)\n---\n"; cat $file; echo "\n------\n"; done\'',
+        'sh -c \'for file in ~/.config/valet/nginx/*; do echo "------\n~/.config/valet/nginx/$(basename $file)\n---\n"; cat $file | grep -n "# valet loopback"; echo "\n------\n"; done\'',
+    ];
+
+    var $methods = [
+
     ];
 
     var $cli, $files, $print, $progressBar;

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -46,7 +46,7 @@ class DnsMasq
 
     /**
      * Forcefully uninstall dnsmasq.
-     * 
+     *
      * @return void
      */
     function uninstall()
@@ -60,7 +60,7 @@ class DnsMasq
 
     /**
      * Tell Homebrew to restart dnsmasq
-     * 
+     *
      * @return void
      */
     function restart()
@@ -113,12 +113,13 @@ class DnsMasq
     function createDnsmasqTldConfigFile($tld)
     {
         $tldConfigFile = $this->dnsmasqUserConfigDir() . 'tld-' . $tld . '.conf';
+        $loopback = $this->configuration->read()['loopback'];
 
-        $this->files->putAsUser($tldConfigFile, 'address=/.'.$tld.'/127.0.0.1'.PHP_EOL.'listen-address=127.0.0.1'.PHP_EOL);
+        $this->files->putAsUser($tldConfigFile, 'address=/.'.$tld.'/'.$loopback.PHP_EOL.'listen-address='.$loopback.PHP_EOL);
     }
 
     /**
-     * Create the resolver file to point the configured TLD to 127.0.0.1.
+     * Create the resolver file to point the configured TLD to configured loopback address.
      *
      * @param  string  $tld
      * @return void
@@ -126,8 +127,9 @@ class DnsMasq
     function createTldResolver($tld)
     {
         $this->files->ensureDirExists($this->resolverPath);
+        $loopback = $this->configuration->read()['loopback'];
 
-        $this->files->put($this->resolverPath.'/'.$tld, 'nameserver 127.0.0.1'.PHP_EOL);
+        $this->files->put($this->resolverPath.'/'.$tld, 'nameserver '.$loopback.PHP_EOL);
     }
 
     /**
@@ -143,6 +145,18 @@ class DnsMasq
         $this->files->unlink($this->dnsmasqUserConfigDir() . 'tld-' . $oldTld . '.conf');
 
         $this->install($newTld);
+    }
+
+    /**
+     * Refresh the DnsMasq configuration.
+     *
+     * @return void
+     */
+    function refreshConfiguration()
+    {
+        $tld = $this->configuration->read()['tld'];
+
+        $this->updateTld($tld, $tld);
     }
 
     /**

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -75,20 +75,35 @@ class Nginx
     {
         $this->files->ensureDirExists(BREW_PREFIX.'/etc/nginx/valet');
 
-        $loopback = $this->configuration->read()['loopback'];
-
         $this->files->putAsUser(
             BREW_PREFIX.'/etc/nginx/valet/valet.conf',
             str_replace(
-                ['VALET_LOOPBACK', 'VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX'],
-                [$loopback, VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX],
-                $this->files->get(__DIR__.'/../stubs/valet.conf')
+                ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX'],
+                [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX],
+                $this->replaceLoopback($this->files->get(__DIR__.'/../stubs/valet.conf'))
             )
         );
 
         $this->files->putAsUser(
             BREW_PREFIX.'/etc/nginx/fastcgi_params',
             $this->files->get(__DIR__.'/../stubs/fastcgi_params')
+        );
+    }
+
+    function replaceLoopback($siteConf)
+    {
+        $loopback = $this->configuration->read()['loopback'];
+
+        if ($loopback === VALET_LOOPBACK) {
+            return $siteConf;
+        }
+
+        $str = '#listen VALET_LOOPBACK:80 default_server; # valet loopback';
+
+        return str_replace(
+            $str,
+            substr(str_replace('VALET_LOOPBACK', $loopback, $str), 1),
+            $siteConf
         );
     }
 

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -75,11 +75,13 @@ class Nginx
     {
         $this->files->ensureDirExists(BREW_PREFIX.'/etc/nginx/valet');
 
+        $loopback = $this->configuration->read()['loopback'];
+
         $this->files->putAsUser(
             BREW_PREFIX.'/etc/nginx/valet/valet.conf',
             str_replace(
-                ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX'],
-                [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX],
+                ['VALET_LOOPBACK', 'VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX'],
+                [$loopback, VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX],
                 $this->files->get(__DIR__.'/../stubs/valet.conf')
             )
         );
@@ -131,8 +133,10 @@ class Nginx
     function rewriteSecureNginxFiles()
     {
         $tld = $this->configuration->read()['tld'];
+        $loopback = $this->configuration->read()['loopback'];
 
         $this->site->resecureForNewTld($tld, $tld);
+        $this->site->resecureForNewLoopback($loopback, $loopback);
     }
 
     /**

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -150,6 +150,10 @@ class Nginx
         $tld = $this->configuration->read()['tld'];
         $loopback = $this->configuration->read()['loopback'];
 
+        if ($loopback !== VALET_LOOPBACK) {
+            $this->site->aliasLoopback(VALET_LOOPBACK, $loopback);
+        }
+
         $config = compact('tld', 'loopback');
 
         $this->site->resecureForNewConfiguration($config, $config);

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -98,7 +98,7 @@ class Nginx
             return $siteConf;
         }
 
-        $str = '#listen VALET_LOOPBACK:80 default_server; # valet loopback';
+        $str = '#listen VALET_LOOPBACK:80; # valet loopback';
 
         return str_replace(
             $str,
@@ -150,8 +150,9 @@ class Nginx
         $tld = $this->configuration->read()['tld'];
         $loopback = $this->configuration->read()['loopback'];
 
-        $this->site->resecureForNewTld($tld, $tld);
-        $this->site->resecureForNewLoopback($loopback, $loopback);
+        $config = compact('tld', 'loopback');
+
+        $this->site->resecureForNewConfiguration($config, $config);
     }
 
     /**

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -756,7 +756,7 @@ class Site
     }
 
     /**
-     * Remove old loopback interface alias and new one if necessary.
+     * Remove old loopback interface alias and add a new one if necessary.
      *
      * @param  string  $oldLoopback
      * @param  string  $loopback

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -795,7 +795,7 @@ class Site
     }
 
     /**
-     * Remove loopback interface alias.
+     * Add loopback interface alias.
      *
      * @param  string  $loopback
      * @return void

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -343,12 +343,12 @@ class Site
         $secured = $this->secured();
 
         $defaultTld = $this->config->read()['tld'];
-        $oldTld = isset($old['tld']) && ! empty($old['tld']) ? $old['tld'] : $defaultTld;
-        $tld = isset($new['tld']) && ! empty($new['tld']) ? $new['tld'] : $defaultTld;
+        $oldTld = !empty($old['tld']) ? $old['tld'] : $defaultTld;
+        $tld = !empty($new['tld']) ? $new['tld'] : $defaultTld;
 
         $defaultLoopback = $this->config->read()['loopback'];
-        $oldLoopback = isset($old['loopback']) && ! empty($old['loopback']) ? $old['loopback'] : $defaultLoopback;
-        $loopback = isset($new['loopback']) && ! empty($new['loopback']) ? $new['loopback'] : $defaultLoopback;
+        $oldLoopback = !empty($old['loopback']) ? $old['loopback'] : $defaultLoopback;
+        $loopback = !empty($new['loopback']) ? $new['loopback'] : $defaultLoopback;
 
         foreach ($secured as $url) {
             $newUrl = str_replace('.'.$oldTld, '.'.$tld, $url);
@@ -824,11 +824,8 @@ class Site
     /**
      * Get the path to loopback LaunchDaemon.
      *
-     * @return string
-     */
-    function plistPath()
-    {
-        return '/Library/LaunchDaemons/com.laravel.valet.loopback.plist';
+     * @return
+        return '/Library/LaunchDaemons.plist';
     }
 
     /**

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Helper\Table;
 /**
  * Define the ~/.config/valet path as a constant.
  */
+define('VALET_LOOPBACK', '127.0.0.1');
 define('VALET_HOME_PATH', $_SERVER['HOME'].'/.config/valet');
 define('VALET_SERVER_PATH', realpath(__DIR__ . '/../../server.php'));
 define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');

--- a/cli/stubs/ifconfig.plist
+++ b/cli/stubs/ifconfig.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.laravel.valet.ifconfig</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/sbin/ifconfig</string>
+      <string>lo0</string>
+      <string>alias</string>
+      <string>VALET_LOOPBACK</string>
+    </array>
+  </dict>
+</plist>

--- a/cli/stubs/loopback.plist
+++ b/cli/stubs/loopback.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>Label</key>
-    <string>com.laravel.valet.ifconfig</string>
+    <string>com.laravel.valet.loopback</string>
     <key>RunAtLoad</key>
     <true/>
     <key>ProgramArguments</key>

--- a/cli/stubs/proxy.valet.conf
+++ b/cli/stubs/proxy.valet.conf
@@ -1,13 +1,15 @@
 # valet stub: proxy.valet.conf
 
 server {
-    listen VALET_LOOPBACK:80;
+    listen 127.0.0.1:80;
+    #listen VALET_LOOPBACK:80; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
 }
 
 server {
-    listen VALET_LOOPBACK:443 ssl http2;
+    listen 127.0.0.1:443 ssl http2;
+    #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
@@ -55,7 +57,8 @@ server {
 }
 
 server {
-    listen VALET_LOOPBACK:60;
+    listen 127.0.0.1:60;
+    #listen VALET_LOOPBACK:60; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/stubs/proxy.valet.conf
+++ b/cli/stubs/proxy.valet.conf
@@ -1,13 +1,13 @@
 # valet stub: proxy.valet.conf
 
 server {
-    listen 127.0.0.1:80;
+    listen VALET_LOOPBACK:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
 }
 
 server {
-    listen 127.0.0.1:443 ssl http2;
+    listen VALET_LOOPBACK:443 ssl http2;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
@@ -55,7 +55,7 @@ server {
 }
 
 server {
-    listen 127.0.0.1:60;
+    listen VALET_LOOPBACK:60;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,11 +1,13 @@
 server {
-    listen VALET_LOOPBACK:80;
+    listen 127.0.0.1:80;
+    #listen VALET_LOOPBACK:80; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
 }
 
 server {
-    listen VALET_LOOPBACK:443 ssl http2;
+    listen 127.0.0.1:443 ssl http2;
+    #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
@@ -48,7 +50,8 @@ server {
 }
 
 server {
-    listen VALET_LOOPBACK:60;
+    listen 127.0.0.1:60;
+    #listen VALET_LOOPBACK:60; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,11 +1,11 @@
 server {
-    listen 127.0.0.1:80;
+    listen VALET_LOOPBACK:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
 }
 
 server {
-    listen 127.0.0.1:443 ssl http2;
+    listen VALET_LOOPBACK:443 ssl http2;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen 127.0.0.1:60;
+    listen VALET_LOOPBACK:60;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -1,6 +1,6 @@
 server {
     listen 127.0.0.1:80 default_server;
-    #listen VALET_LOOPBACK:80 default_server; # valet loopback
+    #listen VALET_LOOPBACK:80; # valet loopback
     root /;
     charset utf-8;
     client_max_body_size 128M;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -1,5 +1,5 @@
 server {
-    listen 127.0.0.1:80 default_server;
+    listen VALET_LOOPBACK:80 default_server;
     root /;
     charset utf-8;
     client_max_body_size 128M;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -1,5 +1,6 @@
 server {
-    listen VALET_LOOPBACK:80 default_server;
+    listen 127.0.0.1:80 default_server;
+    #listen VALET_LOOPBACK:80 default_server; # valet loopback
     root /;
     charset utf-8;
     client_max_body_size 128M;

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -102,8 +102,7 @@ if (is_dir(VALET_HOME_PATH)) {
         }
 
         if (filter_var($loopback, FILTER_VALIDATE_IP) === false) {
-            warning('['.$loopback.'] is not a valid IP address');
-            return 1;
+            return warning('['.$loopback.'] is not a valid IP address');
         }
 
         $oldLoopback = Configuration::read()['loopback'];
@@ -383,6 +382,8 @@ if (is_dir(VALET_HOME_PATH)) {
             Nginx::uninstall();
             info('Removing Dnsmasq and configs...');
             DnsMasq::uninstall();
+            info('Removing loopback customization...');
+            Site::uninstallLoopback();
             info('Removing Valet configs and customizations...');
             Configuration::uninstall();
             info('Removing PHP versions and configs...');

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -120,7 +120,7 @@ if (is_dir(VALET_HOME_PATH)) {
 
         info('Your valet loopback address has been updated to ['.$loopback.']');
 
-    }, ['address'])->descriptions('Get or set the loopback address used for Valet sites');
+    })->descriptions('Get or set the loopback address used for Valet sites');
 
     /**
      * Add the current working directory to the paths configuration.

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -113,6 +113,7 @@ if (is_dir(VALET_HOME_PATH)) {
         Configuration::updateKey('loopback', $loopback = trim($loopback, '.'));
 
         DnsMasq::refreshConfiguration();
+        Site::aliasLoopback($oldLoopback, $loopback);
         Site::resecureForNewLoopback($oldLoopback, $loopback);
         Nginx::installServer();
         PhpFpm::restart();

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -101,9 +101,14 @@ if (is_dir(VALET_HOME_PATH)) {
             return output(Configuration::read()['loopback']);
         }
 
+        if (filter_var($loopback, FILTER_VALIDATE_IP) === false) {
+            warning('['.$loopback.'] is not a valid IP address');
+            return 1;
+        }
+
         $oldLoopback = Configuration::read()['loopback'];
 
-        Configuration::updateKey('loopback', $loopback = trim($loopback, '.'));
+        Configuration::updateKey('loopback', $loopback);
 
         DnsMasq::refreshConfiguration();
         Site::aliasLoopback($oldLoopback, $loopback);

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -66,16 +66,9 @@ $app->command('install', function () {
  */
 if (is_dir(VALET_HOME_PATH)) {
     /**
-     * Upgrade helper: ensure the tld config exists
+     * Upgrade helper: ensure the tld config exists or the loopback config exists
      */
-    if (empty(Configuration::read()['tld'])) {
-        Configuration::writeBaseConfiguration();
-    }
-
-    /**
-     * Upgrade helper: ensure the loopback config exists
-     */
-    if (empty(Configuration::read()['loopback'])) {
+    if (empty(Configuration::read()['tld']) || empty(Configuration::read()['loopback'])) {
         Configuration::writeBaseConfiguration();
     }
 
@@ -93,7 +86,7 @@ if (is_dir(VALET_HOME_PATH)) {
 
         Configuration::updateKey('tld', $tld);
 
-        Site::resecureForNewTld($oldTld, $tld);
+        Site::resecureForNewConfiguration(['tld' => $oldTld], ['tld' => $tld]);
         PhpFpm::restart();
         Nginx::restart();
 
@@ -114,9 +107,9 @@ if (is_dir(VALET_HOME_PATH)) {
 
         DnsMasq::refreshConfiguration();
         Site::aliasLoopback($oldLoopback, $loopback);
-        Site::resecureForNewLoopback($oldLoopback, $loopback);
-        Nginx::installServer();
+        Site::resecureForNewConfiguration(['loopback' => $oldLoopback], ['loopback' => $loopback]);
         PhpFpm::restart();
+        Nginx::installServer();
         Nginx::restart();
 
         info('Your valet loopback address has been updated to ['.$loopback.']');

--- a/tests/DnsMasqTest.php
+++ b/tests/DnsMasqTest.php
@@ -34,6 +34,7 @@ class DnsMasqTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brew->shouldReceive('ensureInstalled')->once()->with('dnsmasq');
         $brew->shouldReceive('restartService')->once()->with('dnsmasq');
         swap(Brew::class, $brew);
+        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['tld' => 'test', 'loopback' => VALET_LOOPBACK]]));
 
         $dnsMasq = resolve(StubForCreatingCustomDnsMasqConfigFiles::class);
 
@@ -46,10 +47,8 @@ class DnsMasqTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $dnsMasq->install('test');
 
-        $loopback = \Configuration::read()['loopback'];
-
-        $this->assertSame('nameserver '.$loopback.PHP_EOL, file_get_contents(__DIR__.'/output/resolver/test'));
-        $this->assertSame('address=/.test/'.$loopback.PHP_EOL.'listen-address='.$loopback.PHP_EOL, file_get_contents(__DIR__.'/output/tld-test.conf'));
+        $this->assertSame('nameserver '.VALET_LOOPBACK.PHP_EOL, file_get_contents(__DIR__.'/output/resolver/test'));
+        $this->assertSame('address=/.test/'.VALET_LOOPBACK.PHP_EOL.'listen-address='.VALET_LOOPBACK.PHP_EOL, file_get_contents(__DIR__.'/output/tld-test.conf'));
         $this->assertSame('test-contents
 ' . PHP_EOL . 'conf-dir='.BREW_PREFIX.'/etc/dnsmasq.d/,*.conf' . PHP_EOL,
             file_get_contents($dnsMasq->dnsmasqMasterConfigFile)

--- a/tests/DnsMasqTest.php
+++ b/tests/DnsMasqTest.php
@@ -46,8 +46,10 @@ class DnsMasqTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $dnsMasq->install('test');
 
-        $this->assertSame('nameserver 127.0.0.1'.PHP_EOL, file_get_contents(__DIR__.'/output/resolver/test'));
-        $this->assertSame('address=/.test/127.0.0.1'.PHP_EOL.'listen-address=127.0.0.1'.PHP_EOL, file_get_contents(__DIR__.'/output/tld-test.conf'));
+        $loopback = \Configuration::read()['loopback'];
+
+        $this->assertSame('nameserver '.$loopback.PHP_EOL, file_get_contents(__DIR__.'/output/resolver/test'));
+        $this->assertSame('address=/.test/'.$loopback.PHP_EOL.'listen-address='.$loopback.PHP_EOL, file_get_contents(__DIR__.'/output/tld-test.conf'));
         $this->assertSame('test-contents
 ' . PHP_EOL . 'conf-dir='.BREW_PREFIX.'/etc/dnsmasq.d/,*.conf' . PHP_EOL,
             file_get_contents($dnsMasq->dnsmasqMasterConfigFile)

--- a/tests/NginxTest.php
+++ b/tests/NginxTest.php
@@ -46,7 +46,7 @@ class NginxTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('putAsUser')->with(VALET_HOME_PATH.'/Nginx/.keep', "\n")->once();
 
         swap(Filesystem::class, $files);
-        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['tld' => 'test']]));
+        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['tld' => 'test', 'loopback' => VALET_LOOPBACK]]));
         swap(Site::class, Mockery::spy(Site::class));
 
         $nginx = resolve(Nginx::class);
@@ -61,7 +61,7 @@ class NginxTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('putAsUser')->with(VALET_HOME_PATH.'/Nginx/.keep', "\n")->once();
 
         swap(Filesystem::class, $files);
-        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['tld' => 'test']]));
+        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['tld' => 'test', 'loopback' => VALET_LOOPBACK]]));
         swap(Site::class, Mockery::spy(Site::class));
 
         $nginx = resolve(Nginx::class);
@@ -76,7 +76,7 @@ class NginxTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('putAsUser')->with(VALET_HOME_PATH.'/Nginx/.keep', "\n")->once();
 
         swap(Filesystem::class, $files);
-        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['tld' => 'test']]));
+        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['tld' => 'test', 'loopback' => VALET_LOOPBACK]]));
         swap(Site::class, $site = Mockery::spy(Site::class));
 
         $nginx = resolve(Nginx::class);

--- a/tests/NginxTest.php
+++ b/tests/NginxTest.php
@@ -82,6 +82,8 @@ class NginxTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $nginx = resolve(Nginx::class);
         $nginx->installNginxDirectory();
 
-        $site->shouldHaveReceived('resecureForNewTld', ['test', 'test']);
+        $data = ['tld' => 'test', 'loopback' => '127.0.0.1'];
+
+        $site->shouldHaveReceived('resecureForNewConfiguration', [$data, $data]);
     }
 }

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -339,7 +339,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     {
         $config = Mockery::mock(Configuration::class);
         $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
+            ->andReturn(['tld' => 'test', 'loopback' => VALET_LOOPBACK]);
 
         swap(Configuration::class, $config);
 
@@ -372,7 +372,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     {
         $config = Mockery::mock(Configuration::class);
         $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
+            ->andReturn(['tld' => 'test', 'loopback' => VALET_LOOPBACK]);
 
         swap(Configuration::class, $config);
 
@@ -416,7 +416,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     {
         $config = Mockery::mock(Configuration::class);
         $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
+            ->andReturn(['tld' => 'test', 'loopback' => VALET_LOOPBACK]);
 
         swap(Configuration::class, $config);
 
@@ -456,7 +456,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     {
         $config = Mockery::mock(Configuration::class);
         $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
+            ->andReturn(['tld' => 'test', 'loopback' => VALET_LOOPBACK]);
 
         swap(Configuration::class, $config);
 


### PR DESCRIPTION
Provides helper to change the loopback address used by Nginx and Dnsmasq.
Useful for `docker`, use a custom loopback address gives the ability to resolve hosts from both host side and container side. You may alias your loopback interface using a [private ip address](https://en.wikipedia.org/wiki/Private_network).

Adds one new command:
`valet loopback [address]` -- get or set the loopback address

eg:
`valet loopback` results in 127.0.0.1 (default value)
`valet loopback 10.254.254.254 && valet loopback` results in 10.254.254.254

--

Docker DNS explanation : [https://williamhayes.medium.com/local-dev-on-docker-fun-with-dns-85ca7d701f0a](https://williamhayes.medium.com/local-dev-on-docker-fun-with-dns-85ca7d701f0a)

--

Get it working:

- create a loopback alias using `sudo ifconfig lo0 alias 10.254.254.254` or any other private ip address, the alias will removed in next startup
- you may want to create a permanent loopback alias : see [https://medium.com/@david.limkys/permanently-create-an-ifconfig-loopback-alias-macos-b7c93a8b0db](https://medium.com/@david.limkys/permanently-create-an-ifconfig-loopback-alias-macos-b7c93a8b0db)
- restart docker deamon (docker for mac)
- `valet loopback 10.254.254.254`

Now any Valet host will be reachable from both host side and container side.