### PR TITLE
Fix subdomains pointing to root path

### DIFF
--- a/server.php
+++ b/server.php
@@ -125,10 +125,10 @@ if (strpos($siteName, 'www.') === 0) {
  * Determine the fully qualified path to the site.
  * Inspects registered path directories, case-sensitive.
  */
-function get_valet_site_path($valtetConfig, $domain, $siteName)
+function get_valet_site_path($valetConfig, $siteName, $domain)
 {
     $valetSitePath = null;
-    foreach ($valtetConfig['paths'] as $path) {
+    foreach ($valetConfig['paths'] as $path) {
         if ($handle = opendir($path)) {
             while (false !== ($file = readdir($handle))) {
                 if (! is_dir($path.'/'.$file)) continue;

--- a/server.php
+++ b/server.php
@@ -141,14 +141,9 @@ foreach ($valetConfig['paths'] as $path) {
             }
             if (strtolower($file) === $domain) {
                 $valetSitePath = $path.'/'.$file;
-                break;
             }
         }
         closedir($handle);
-        
-        if ($valetSitePath) {
-            break;
-        }
     }
 }
 

--- a/server.php
+++ b/server.php
@@ -135,15 +135,15 @@ foreach ($valetConfig['paths'] as $path) {
             if (in_array($file, ['.', '..', '.DS_Store'])) continue;
 
             // match dir for lowercase, because Nginx only tells us lowercase names
-            if (strtolower($file) === $siteName) {
-                $valetSitePath = $path.'/'.$file;
-                break;
-            }
-            if (strtolower($file) === $domain) {
+            if (strtolower($file) === $siteName || strtolower($file) === $domain) {
                 $valetSitePath = $path.'/'.$file;
             }
         }
         closedir($handle);
+
+        if ($valetSitePath) {
+            break;
+        }
     }
 }
 

--- a/server.php
+++ b/server.php
@@ -125,27 +125,31 @@ if (strpos($siteName, 'www.') === 0) {
  * Determine the fully qualified path to the site.
  * Inspects registered path directories, case-sensitive.
  */
-$valetSitePath = null;
-$domain = array_slice(explode('.', $siteName), -1)[0];
+function get_valet_site_path($valtetConfig, $domain, $siteName)
+{
+    $valetSitePath = null;
+    foreach ($valtetConfig['paths'] as $path) {
+        if ($handle = opendir($path)) {
+            while (false !== ($file = readdir($handle))) {
+                if (! is_dir($path.'/'.$file)) continue;
+                if (in_array($file, ['.', '..', '.DS_Store'])) continue;
 
-foreach ($valetConfig['paths'] as $path) {
-    if ($handle = opendir($path)) {
-        while (false !== ($file = readdir($handle))) {
-            if (! is_dir($path.'/'.$file)) continue;
-            if (in_array($file, ['.', '..', '.DS_Store'])) continue;
-
-            // match dir for lowercase, because Nginx only tells us lowercase names
-            if (strtolower($file) === $siteName || strtolower($file) === $domain) {
-                $valetSitePath = $path.'/'.$file;
+                // match dir for lowercase, because Nginx only tells us lowercase names
+                if (strtolower($file) === $siteName || strtolower($file) === $domain) {
+                    $valetSitePath = $path.'/'.$file;
+                }
             }
-        }
-        closedir($handle);
-
-        if ($valetSitePath) {
-            break;
+            closedir($handle);
+            
+            if ($valetSitePath) {
+                return $valetSitePath;
+            }
         }
     }
 }
+
+$domain = array_slice(explode('.', $siteName), -1)[0];
+$valetSitePath = get_valet_site_path($valetConfig, $siteName, $domain);
 
 if (is_null($valetSitePath) && is_null($valetSitePath = valet_default_site_path($valetConfig))) {
     show_valet_404();


### PR DESCRIPTION
Closes #1032

This PR reverts the changes from #1018 and fixes the problem with subdomains described in #1032.

The "breaking" change was in [server.php#L144](https://github.com/laravel/valet/blob/master/server.php#L144)
```php
            if (strtolower($file) === $domain) {
                $valetSitePath = $path.'/'.$file;
                break;
            }
```

The `break` statement stopped the execution of the loop too early, as `$domain` is not what we are looking for at this very moment, when using a linked subdomain.

I actually was able to reproduce the problem @mrk-j described in #1018 too and solved this by re-adding his outer break statement, but removing the early breaks. 

So, this should fix both problems described in #1018 and #1032. 