### PR TITLE
Add `-diff` for binary file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 .gitignore export-ignore
 .travis.yml export-ignore
 phpunit.xml export-ignore
+
+/bin/ngrok -diff


### PR DESCRIPTION
https://git-scm.com/docs/gitattributes#_marking_files_as_binary

> Git usually guesses correctly whether a blob contains text or binary data by examining the beginning of the contents. However, sometimes you may want to override its decision, either because a blob contains binary data later in the file, or because the content, while technically composed of text characters, is opaque to a human reader.