### PR TITLE
Fix subdomain using root domain link

### DIFF
--- a/server.php
+++ b/server.php
@@ -139,7 +139,7 @@ function get_valet_site_path($valetConfig, $siteName, $domain)
         $dirs = [];
 
         while (false !== ($file = readdir($handle))) {
-            if (is_dir($path.'/'.$file) && ! in_array($file, ['.', '..', '.DS_Store'])) {
+            if (is_dir($path.'/'.$file) && ! in_array($file, ['.', '..'])) {
                 $dirs[] = $file;
             }
         }

--- a/server.php
+++ b/server.php
@@ -135,7 +135,12 @@ function get_valet_site_path($valetConfig, $siteName, $domain)
                 if (in_array($file, ['.', '..', '.DS_Store'])) continue;
 
                 // match dir for lowercase, because Nginx only tells us lowercase names
-                if (strtolower($file) === $siteName || strtolower($file) === $domain) {
+                if (strtolower($file) === $siteName) {
+                    $valetSitePath = $path.'/'.$file;
+                    break;
+                }
+
+                if (strtolower($file) === $domain) {
                     $valetSitePath = $path.'/'.$file;
                 }
             }

--- a/server.php
+++ b/server.php
@@ -128,32 +128,39 @@ if (strpos($siteName, 'www.') === 0) {
 function get_valet_site_path($valetConfig, $siteName, $domain)
 {
     $valetSitePath = null;
+
     foreach ($valetConfig['paths'] as $path) {
-        if ($handle = opendir($path)) {
-            $dirs = [];
-            while (false !== ($file = readdir($handle))) {
-                if (! is_dir($path.'/'.$file)) continue;
-                if (in_array($file, ['.', '..', '.DS_Store'])) continue;
+        $handle = opendir($path);
+
+        if ($handle === false) {
+            continue;
+        }
+
+        $dirs = [];
+
+        while (false !== ($file = readdir($handle))) {
+            if (is_dir($path.'/'.$file) && ! in_array($file, ['.', '..', '.DS_Store'])) {
                 $dirs[] = $file;
             }
-            closedir($handle);
+        }
 
-            // Note: strtolower used below because Nginx only tells us lowercase names
-            foreach ($dirs as $dir) {
-                if (strtolower($dir) === $siteName) {
-                    // early return when exact match for linked subdomain
-                    return $path.'/'.$dir;
-                }
+        closedir($handle);
 
-                if (strtolower($dir) === $domain) {
-                    // no early return here because the foreach may still have some subdomains to process with higher priority
-                    $valetSitePath = $path.'/'.$dir;
-                }
+        // Note: strtolower used below because Nginx only tells us lowercase names
+        foreach ($dirs as $dir) {
+            if (strtolower($dir) === $siteName) {
+                // early return when exact match for linked subdomain
+                return $path.'/'.$dir;
             }
 
-            if ($valetSitePath) {
-                return $valetSitePath;
+            if (strtolower($dir) === $domain) {
+                // no early return here because the foreach may still have some subdomains to process with higher priority
+                $valetSitePath = $path.'/'.$dir;
             }
+        }
+
+        if ($valetSitePath) {
+            return $valetSitePath;
         }
     }
 }


### PR DESCRIPTION
I just updated my local Valet installation, and it looks like the fix implemented in #1040 does not work for me. After putting some debug `var_dump`s in the `server.php` file in the `get_valet_site_path` function - in the loop and right before the return statement - it gave me the following output when trying to access `a.domain.test`:

```
// -> /Users/stidges/.config/valet/Sites/a.domain
// -> /Users/stidges/.config/valet/Sites/domain

// -> RESULT: /Users/stidges/.config/valet/Sites/domain
```

I think this is caused by the root domain coming _after_ the subdomain, so it overwrites the `$valetSitePath`. 

This PR breaks out of the loop as soon as the `strtolower($file) === $siteName` statement passes, as you're sure to have an exact match at that point. This would still allow for a fallback to the root domain.