### PR TITLE
Stop non-root homebrew services during restarts

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -197,7 +197,11 @@ class Brew
             if ($this->installed($service)) {
                 info("Restarting {$service}...");
 
+                // first we ensure that the service is not incorrectly running as non-root
+                $this->cli->quietly('brew services stop '.$service);
+                // stop the actual/correct sudo version
                 $this->cli->quietly('sudo brew services stop '.$service);
+                // start correctly as root
                 $this->cli->quietly('sudo brew services start '.$service);
             }
         }
@@ -216,6 +220,10 @@ class Brew
             if ($this->installed($service)) {
                 info("Stopping {$service}...");
 
+                // first we ensure that the service is not incorrectly running as non-root
+                $this->cli->quietly('brew services stop '.$service);
+
+                // stop the sudo version
                 $this->cli->quietly('sudo brew services stop '.$service);
             }
         }

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -117,6 +117,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     {
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('runAsUser')->once()->with('brew info dnsmasq --json')->andReturn('[{"name":"dnsmasq","full_name":"dnsmasq","aliases":[],"versioned_formulae":[],"versions":{"stable":"1"},"installed":[{"version":"1"}]}]');
+        $cli->shouldReceive('quietly')->once()->with('brew services stop dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services start dnsmasq');
         swap(CommandLine::class, $cli);
@@ -127,6 +128,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     {
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('runAsUser')->once()->with('brew info dnsmasq --json')->andReturn('[{"name":"dnsmasq","full_name":"dnsmasq","aliases":[],"versioned_formulae":[],"versions":{"stable":"1"},"installed":[{"version":"1"}]}]');
+        $cli->shouldReceive('quietly')->once()->with('brew services stop dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
         swap(CommandLine::class, $cli);
         resolve(Brew::class)->stopService('dnsmasq');


### PR DESCRIPTION
This is intended to assist with avoiding having competing non-root instances of valet dependency services running due to userland use of brew CLI commands.

Now, when running `valet stop` or `valet restart` it will (silently) attempt to stop the non-root instance (ignoring any errors thrown), before stopping (and/or starting) the sudo/root instance which is normally used.

(Though obvious, I'll point out that this only applies to services Valet manages.)

Fixes #1057