### PR TITLE
Set the $_SERVER['SCRIPT_FILENAME'] to the front controller path

### DIFF
--- a/cli/drivers/SymfonyValetDriver.php
+++ b/cli/drivers/SymfonyValetDriver.php
@@ -47,12 +47,17 @@ class SymfonyValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        if (file_exists($frontControllerPath = $sitePath.'/web/app_dev.php')) {
-            return $frontControllerPath;
-        } elseif (file_exists($frontControllerPath = $sitePath.'/web/app.php')) {
-            return $frontControllerPath;
-        } elseif (file_exists($frontControllerPath = $sitePath.'/public/index.php')) {
-            return $frontControllerPath;
+        $frontControllerPath = null;
+
+        if (file_exists($path = $sitePath.'/web/app_dev.php')) {
+            $frontControllerPath = $path;
+        } elseif (file_exists($path = $sitePath.'/web/app.php')) {
+            $frontControllerPath = $path;
+        } elseif (file_exists($path = $sitePath.'/public/index.php')) {
+            $frontControllerPath = $path;
         }
+
+        $_SERVER['SCRIPT_FILENAME'] = $frontControllerPath;
+        return $frontControllerPath;
     }
 }

--- a/server.php
+++ b/server.php
@@ -21,12 +21,12 @@ function show_valet_404()
  * Show directory listing or 404 if directory doesn't exist.
  */
 function show_directory_listing($valetSitePath, $uri)
-{ 
+{
     $is_root = ($uri == '/');
     $directory = ($is_root) ? $valetSitePath : $valetSitePath.$uri;
 
-    if (!file_exists($directory)) { 
-        show_valet_404(); 
+    if (!file_exists($directory)) {
+        show_valet_404();
     }
 
     // Sort directories at the top
@@ -232,4 +232,5 @@ if (! $frontControllerPath) {
 
 chdir(dirname($frontControllerPath));
 
+$_SERVER['SCRIPT_FILENAME'] = $frontControllerPath;
 require $frontControllerPath;

--- a/server.php
+++ b/server.php
@@ -232,5 +232,4 @@ if (! $frontControllerPath) {
 
 chdir(dirname($frontControllerPath));
 
-$_SERVER['SCRIPT_FILENAME'] = $frontControllerPath;
 require $frontControllerPath;


### PR DESCRIPTION
This PR fixes this issue #1071. (Closes #1071)

The problem was with the clear Symfony 5 project. Symfony in the `index.php` file requires `autoload_runtime.php`.  Going further the `autoload_runtime.php` contains the following line:
`$app = require $_SERVER['SCRIPT_FILENAME'];`. Currently this variable points to the `server.php` file from valet what causes the problems with the Symfony 5 projects.

I've set the "correct" SCRIPT_FILENAME path manually just before requiring the front controller in the `server.php`.

I've performed some tests and it seems it won't break non-Symfony projects.