### PR TITLE
Prevent 502 errors when using AJAX

### DIFF
--- a/cli/stubs/fastcgi_params
+++ b/cli/stubs/fastcgi_params
@@ -18,3 +18,5 @@ fastcgi_param SERVER_NAME  $server_name;
 fastcgi_param HTTPS   $https if_not_empty;
 fastcgi_param REDIRECT_STATUS  200;
 fastcgi_param HTTP_PROXY  "";
+fastcgi_buffer_size 512k;
+fastcgi_buffers 16 512k;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -27,6 +27,10 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass "unix:VALET_HOME_PATH/valet.sock";
         fastcgi_index "VALET_SERVER_PATH";
+        fastcgi_temp_file_write_size 10m;
+        fastcgi_busy_buffers_size 512k;
+        fastcgi_buffer_size 512k;
+        fastcgi_buffers 16 512k;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
         fastcgi_param PATH_INFO $fastcgi_path_info;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -27,10 +27,6 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass "unix:VALET_HOME_PATH/valet.sock";
         fastcgi_index "VALET_SERVER_PATH";
-        fastcgi_temp_file_write_size 10m;
-        fastcgi_busy_buffers_size 512k;
-        fastcgi_buffer_size 512k;
-        fastcgi_buffers 16 512k;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
         fastcgi_param PATH_INFO $fastcgi_path_info;


### PR DESCRIPTION
When using the Laravel DebugBar with the `capture_ajax` flag set to `true`, developers may encounter 502 Bad Gateway errors. This is due to DebugBar's AJAX request monitoring exceeding the FastCGI buffer limit.

This PR increases the size of the buffer. While it is not guaranteed to fix the problem, the increased buffer size should solve the issue for most developers. Further discussion on this subject can be [found in this issue on the DebugBar repo](https://github.com/barryvdh/laravel-debugbar/issues/251).