### PR TITLE
Added ability to use a `.valetphprc` file with `valet use` in a project to define the required PHP version

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -495,7 +495,15 @@ You might also want to investigate your global Composer configs. Helpful command
      */
     $app->command('use [phpVersion] [--force]', function ($phpVersion, $force) {
         if (!$phpVersion) {
-            return info('Valet is using ' . Brew::linkedPhp());
+            if (file_exists($path = getcwd() . '/.valetrc')) {
+                if ($phpVersion = trim(file_get_contents($path))) {
+                    info('Found \'' . $path . '/.valetrc\' with version <' . $phpVersion . '>');
+                } else {
+                    return info('.valetrc does not contain a valid PHP version' . $phpVersion);
+                }
+            } else {
+                return info('Valet is using ' . Brew::linkedPhp());
+            }
         }
 
         PhpFpm::validateRequestedVersion($phpVersion);

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -495,14 +495,14 @@ You might also want to investigate your global Composer configs. Helpful command
      */
     $app->command('use [phpVersion] [--force]', function ($phpVersion, $force) {
         if (!$phpVersion) {
-            $path = getcwd() . '/.valetrc';
+            $path = getcwd() . '/.valetphprc';
             $linkedVersion = Brew::linkedPhp();
             if (!file_exists($path)) {
                 return info(sprintf('Valet is using %s.', $linkedVersion));
             }
 
             $phpVersion = trim(file_get_contents($path));
-            info('Found \'' . $path . '\' with version: ' . $phpVersion);
+            info('Found \'' . $path . '\' specifying version: ' . $phpVersion);
 
             if ($linkedVersion == $phpVersion) {
                 return info(sprintf('Valet is already using %s.', $linkedVersion));

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -495,14 +495,17 @@ You might also want to investigate your global Composer configs. Helpful command
      */
     $app->command('use [phpVersion] [--force]', function ($phpVersion, $force) {
         if (!$phpVersion) {
-            if (file_exists($path = getcwd() . '/.valetrc')) {
-                if ($phpVersion = trim(file_get_contents($path))) {
-                    info('Found \'' . $path . '/.valetrc\' with version <' . $phpVersion . '>');
-                } else {
-                    return info('.valetrc does not contain a valid PHP version' . $phpVersion);
-                }
-            } else {
-                return info('Valet is using ' . Brew::linkedPhp());
+            $path = getcwd() . '/.valetrc';
+            $linkedVersion = Brew::linkedPhp();
+            if (!file_exists($path)) {
+                return info(sprintf('Valet is using %s.', $linkedVersion));
+            }
+
+            $phpVersion = trim(file_get_contents($path));
+            info('Found \'' . $path . '\' with version: ' . $phpVersion);
+
+            if ($linkedVersion == $phpVersion) {
+                return info(sprintf('Valet is already using %s.', $linkedVersion));
             }
         }
 


### PR DESCRIPTION
This extension to the functionality of the `valet use` command adds a check for a `.valetrc` file when no version is passed as an argument, which contains the PHP version for the project and works in a similar manner to the `nvm use` command in Node Version Manager to save developers time and avoid mistakes when working across projects that have different PHP version requirements.

e.g. `.valetrc` in a project root could contain:
```
php@7.3
```

When `valet use` is run without specifying a PHP version you could expect one of the following outputs:

**Unlinking the current version for the specified version**
```bash
Found '/Users/johnnyappleseed/Sites/example/.valetrc' with version: php@7.3
Unlinking current version: php@7.4
Linking new version: php@7.3
Updating PHP configuration...
Restarting php@7.3...
Restarting nginx...
Valet is now using php@7.3.

Note that you might need to run composer global update if your PHP version change affects the dependencies of global packages required by Composer.
```

**Specified version is already linked**
```bash
Found '/Users/johnnyappleseed/Sites/example/.valetrc' with version: php@7.3
Valet is already using php@7.3.
```