### PR TITLE
Add support for parked domains to some commands

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -948,4 +948,22 @@ class Site
 
         return $this->valetHomePath().'/Certificates'.$url.$extension;
     }
+
+    /**
+     * Make the domain name based on parked domains or the internal TLD.
+     *
+     * @return string
+     */
+    public function domain($domain)
+    {
+        if ($this->parked()->pluck('site')->contains($domain)) {
+            return $domain;
+        }
+
+        if ($parked = $this->parked()->where('path', getcwd())->first()) {
+            return $parked['site'];
+        }
+
+        return $domain ?: $this->host(getcwd()).'.'.$this->config->read()['tld'];
+    }
 }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -180,7 +180,7 @@ if (is_dir(VALET_HOME_PATH)) {
      * Secure the given domain with a trusted TLS certificate.
      */
     $app->command('secure [domain]', function ($domain = null) {
-        $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
+        $url = Site::domain($domain);
 
         Site::secure($url);
 
@@ -198,7 +198,7 @@ if (is_dir(VALET_HOME_PATH)) {
             return;
         }
 
-        $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
+        $url = Site::domain($domain);
 
         Site::unsecure($url);
 
@@ -270,7 +270,7 @@ if (is_dir(VALET_HOME_PATH)) {
      * Open the current or given directory in the browser.
      */
     $app->command('open [domain]', function ($domain = null) {
-        $url = "http://".($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
+        $url = "http://".Site::domain($domain);
         CommandLine::runAsUser("open ".escapeshellarg($url));
     })->descriptions('Open the site for the current (or specified) directory in your browser');
 
@@ -285,7 +285,7 @@ if (is_dir(VALET_HOME_PATH)) {
      * Echo the currently tunneled URL.
      */
     $app->command('fetch-share-url [domain]', function ($domain = null) {
-        output(Ngrok::currentTunnelUrl($domain ?: Site::host(getcwd()).'.'.Configuration::read()['tld']));
+        output(Ngrok::currentTunnelUrl(Site::domain($domain)));
     })->descriptions('Get the URL to the current Ngrok tunnel');
 
     /**


### PR DESCRIPTION
Some commands doesn't support parked domains today:

- secure
- unsecure
- open

This PR will do sucessfully secure a parked domain:

```
> valet secure sitename.dev.a17.io
Restarting nginx...
The [sitename.dev.a17.io] site has been secured with a fresh TLS certificate.
```

Instead of adding the .test TLD to it and securing an inexistent domain:

```
The [sitename.dev.a17.io.test] site has been secured with a fresh TLS certificate.
```