### PR TITLE
Allow execution of custom PHP files in Bedrock projects

### DIFF
--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -55,6 +55,10 @@ class BedrockValetDriver extends BasicValetDriver
                             ? $sitePath.'/web'.$this->forceTrailingSlash($uri).'/index.php'
                             : $sitePath.'/web'.$uri;
         }
+        
+        if($uri !== '/' && file_exists($sitePath.'/web'.$uri)) {
+            return $sitePath.'/web'.$uri;
+        }
 
         return $sitePath.'/web/index.php';
     }


### PR DESCRIPTION
All request to PHP files are directed trough index.php which results in a 404 when you try to access a php file directly. This is not always the desired behaviour.

Also described in #539 