### PR TITLE
Set Brew PHP latest version to 8.1

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -23,7 +23,7 @@ class Brew
         'php56'
     ];
 
-    const LATEST_PHP_VERSION = 'php@8.0';
+    const LATEST_PHP_VERSION = 'php@8.1';
 
     var $cli, $files;
 


### PR DESCRIPTION
Set Brew PHP latest version to 8.1 as PHP 8.1 is released and command `valet use php@8.0` now sets 8.1 and it is impossible to set 8.0.