### PR TITLE
Switch to Illuminate Collections

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [5.6, '7.0', 7.1, 7.2, 7.3, 7.4, '8.0', '8.1']
+        php: [7.3, 7.4, '8.0', '8.1']
 
     name: PHP ${{ matrix.php }}
 

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -12,15 +12,7 @@ class Brew
         'php@8.0',
         'php@7.4',
         'php@7.3',
-        'php@7.2',
-        'php@7.1',
-        'php@7.0',
-        'php@5.6',
         'php73',
-        'php72',
-        'php71',
-        'php70',
-        'php56',
     ];
 
     const LATEST_PHP_VERSION = 'php@8.1';

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -79,20 +79,9 @@ class PhpFpm
             rename($oldFile, $oldFile.'-backup');
         }
 
-        if (false === strpos($fpmConfigFile, '5.6')) {
-            // since PHP 7 we can simply drop in a valet-specific fpm pool config, and not touch the default config
-            $contents = $this->files->get(__DIR__.'/../stubs/etc-phpfpm-valet.conf');
-            $contents = str_replace(['VALET_USER', 'VALET_HOME_PATH'], [user(), VALET_HOME_PATH], $contents);
-        } else {
-            // for PHP 5 we must do a direct edit of the fpm pool config to switch it to Valet's needs
-            $contents = $this->files->get($fpmConfigFile);
-            $contents = preg_replace('/^user = .+$/m', 'user = '.user(), $contents);
-            $contents = preg_replace('/^group = .+$/m', 'group = staff', $contents);
-            $contents = preg_replace('/^listen = .+$/m', 'listen = '.VALET_HOME_PATH.'/valet.sock', $contents);
-            $contents = preg_replace('/^;?listen\.owner = .+$/m', 'listen.owner = '.user(), $contents);
-            $contents = preg_replace('/^;?listen\.group = .+$/m', 'listen.group = staff', $contents);
-            $contents = preg_replace('/^;?listen\.mode = .+$/m', 'listen.mode = 0777', $contents);
-        }
+        $contents = $this->files->get(__DIR__.'/../stubs/etc-phpfpm-valet.conf');
+        $contents = str_replace(['VALET_USER', 'VALET_HOME_PATH'], [user(), VALET_HOME_PATH], $contents);
+
         $this->files->put($fpmConfigFile, $contents);
 
         $contents = $this->files->get(__DIR__.'/../stubs/php-memory-limits.ini');
@@ -148,9 +137,7 @@ class PhpFpm
         $versionNormalized = $this->normalizePhpVersion($version === 'php' ? Brew::LATEST_PHP_VERSION : $version);
         $versionNormalized = preg_replace('~[^\d\.]~', '', $versionNormalized);
 
-        return $versionNormalized === '5.6'
-            ? BREW_PREFIX.'/etc/php/5.6/php-fpm.conf'
-            : BREW_PREFIX."/etc/php/${versionNormalized}/php-fpm.d/valet-fpm.conf";
+        return BREW_PREFIX."/etc/php/${versionNormalized}/php-fpm.d/valet-fpm.conf";
     }
 
     /**

--- a/cli/includes/compatibility.php
+++ b/cli/includes/compatibility.php
@@ -16,8 +16,8 @@ if (PHP_OS !== 'Darwin' && ! $inTestingEnvironment) {
     exit(1);
 }
 
-if (version_compare(PHP_VERSION, '5.6.0', '<')) {
-    echo 'Valet requires PHP 5.6 or later.';
+if (version_compare(PHP_VERSION, '7.3.0', '<')) {
+    echo "Valet requires PHP 7.3 or later.";
 
     exit(1);
 }

--- a/cli/includes/compatibility.php
+++ b/cli/includes/compatibility.php
@@ -17,7 +17,7 @@ if (PHP_OS !== 'Darwin' && ! $inTestingEnvironment) {
 }
 
 if (version_compare(PHP_VERSION, '7.3.0', '<')) {
-    echo "Valet requires PHP 7.3 or later.";
+    echo 'Valet requires PHP 7.3 or later.';
 
     exit(1);
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "illuminate/collections": "^8.0",
         "mnapoli/silly": "^1.0",
         "symfony/process": "^5.1.4",
-        "nategood/httpful": "^0.2",
+        "nategood/httpful": "^0.2"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
         }
     },
     "require": {
-        "php": "^5.6|^7.0|^8.0",
-        "illuminate/container": "~5.1|^6.0|^7.0|^8.0",
+        "php": "^7.3|^8.0",
+        "illuminate/container": "^8.0",
         "mnapoli/silly": "^1.0",
-        "symfony/process": "^3.0|^4.0|^5.0",
+        "symfony/process": "^5.1.4",
         "nategood/httpful": "^0.2",
-        "tightenco/collect": "^5.3|^6.0|^7.0|^8.0"
+        "tightenco/collect": "^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     "require": {
         "php": "^7.3|^8.0",
         "illuminate/container": "^8.0",
+        "illuminate/collections": "^8.0",
         "mnapoli/silly": "^1.0",
         "symfony/process": "^5.1.4",
         "nategood/httpful": "^0.2",
-        "tightenco/collect": "^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -59,7 +59,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     public function test_has_installed_php_indicates_if_php_is_installed_via_brew()
     {
         $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@5.5']));
+        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@7.2']));
         $this->assertFalse($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
@@ -81,36 +81,16 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
         $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php73']));
         $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@7.2', 'php72']));
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php71', 'php@7.1']));
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@7.0']));
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php@5.6']));
-        $this->assertTrue($brew->hasInstalledPhp());
-
-        $brew = Mockery::mock(Brew::class.'[installedPhpFormulae]', [new CommandLine, new Filesystem]);
-        $brew->shouldReceive('installedPhpFormulae')->andReturn(collect(['php56']));
-        $this->assertTrue($brew->hasInstalledPhp());
     }
 
     public function test_tap_taps_the_given_homebrew_repository()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('passthru')->once()->with('sudo -u "'.user().'" brew tap php@7.1');
-        $cli->shouldReceive('passthru')->once()->with('sudo -u "'.user().'" brew tap php@7.0');
-        $cli->shouldReceive('passthru')->once()->with('sudo -u "'.user().'" brew tap php@5.6');
+        $cli->shouldReceive('passthru')->once()->with('sudo -u "'.user().'" brew tap php@8.1');
+        $cli->shouldReceive('passthru')->once()->with('sudo -u "'.user().'" brew tap php@8.0');
+        $cli->shouldReceive('passthru')->once()->with('sudo -u "'.user().'" brew tap php@7.4');
         swap(CommandLine::class, $cli);
-        resolve(Brew::class)->tap('php@7.1', 'php@7.0', 'php@5.6');
+        resolve(Brew::class)->tap('php@8.1', 'php@8.0', 'php@7.4');
     }
 
     public function test_restart_restarts_the_service_using_homebrew_services()
@@ -152,20 +132,20 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $this->assertSame('php@7.3', $getBrewMock($files)->linkedPhp());
 
         $files = Mockery::mock(Filesystem::class);
-        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn('/test/path/php@7.2/7.2.13/test');
-        $this->assertSame('php@7.2', $getBrewMock($files)->linkedPhp());
+        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn('/test/path/php@8.0/8.0.13/test');
+        $this->assertSame('php@8.0', $getBrewMock($files)->linkedPhp());
 
         $files = Mockery::mock(Filesystem::class);
-        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn('/test/path/php/7.2.9_2/test');
-        $this->assertSame('php@7.2', $getBrewMock($files)->linkedPhp());
+        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn('/test/path/php/8.0.13_2/test');
+        $this->assertSame('php@8.0', $getBrewMock($files)->linkedPhp());
 
         $files = Mockery::mock(Filesystem::class);
-        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn('/test/path/php72/7.2.9_2/test');
-        $this->assertSame('php@7.2', $getBrewMock($files)->linkedPhp());
+        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn('/test/path/php80/8.0.13_2/test');
+        $this->assertSame('php@8.0', $getBrewMock($files)->linkedPhp());
 
         $files = Mockery::mock(Filesystem::class);
-        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn('/test/path/php56/test');
-        $this->assertSame('php@5.6', $getBrewMock($files)->linkedPhp());
+        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/php')->andReturn('/test/path/php80/test');
+        $this->assertSame('php@8.0', $getBrewMock($files)->linkedPhp());
     }
 
     public function test_linked_php_throws_exception_if_no_php_link()


### PR DESCRIPTION
This PR switches Valet to use the new Illuminate Collections instead. This will require a new major release. You might want to split off the current master branch into a `2.x` branch before merging this.

Because we're switching to a new Illuminate component introduced in Laravel 8, we'll have to drop old PHP and Laravel versions.

Valet 2.x can still be maintained simultaneously if needed for people on lower Laravel/PHP versions.

Closes https://github.com/laravel/valet/issues/1011