### PR TITLE
Update constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
         }
     },
     "require": {
-        "php": ">=5.6",
+        "php": "^5.6|^7.0|^8.0",
         "illuminate/container": "~5.1|^6.0|^7.0|^8.0",
-        "mnapoli/silly": "~1.0",
-        "symfony/process": "~3.0|~4.0|~5.0",
-        "nategood/httpful": "~0.2",
+        "mnapoli/silly": "^1.0",
+        "symfony/process": "^3.0|^4.0|^5.0",
+        "nategood/httpful": "^0.2",
         "tightenco/collect": "^5.3|^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR updates the versions in the composer.json file to use the proper caret symbol like we do in all of our other libraries. This will ensure SemVer updates are properly handled. Further more, I've limited the allowed PHP versions to only the ones we support at the time. The current constraint allowed Valet to be installed on any PHP version that will be released in the future.
