### PR TITLE
Add 'expireIn=' option and use in the openssl command

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -179,15 +179,17 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Secure the given domain with a trusted TLS certificate.
      */
-    $app->command('secure [domain]', function ($domain = null) {
+    $app->command('secure [domain] [--expireIn=]', function ($domain = null, $expireIn = null) {
         $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
 
-        Site::secure($url);
+        Site::secure($url, null, $expireIn);
 
         Nginx::restart();
 
         info('The ['.$url.'] site has been secured with a fresh TLS certificate.');
-    })->descriptions('Secure the given domain with a trusted TLS certificate');
+    })->descriptions('Secure the given domain with a trusted TLS certificate', [
+        '--expireIn' => 'The amount of days the self signed certificate is valid for. Default is set to "368"',
+    ]);
 
     /**
      * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -574,7 +574,7 @@ class FixturesSiteFake extends Site
         $this->valetHomePath = __DIR__.'/output';
     }
 
-    public function createCa()
+    public function createCa($caExpireInDays)
     {
         // noop
         //
@@ -583,7 +583,7 @@ class FixturesSiteFake extends Site
         // CA for our faked Site.
     }
 
-    public function createCertificate($urlWithTld)
+    public function createCertificate($urlWithTld, $caExpireInDays)
     {
         // We're not actually going to generate a real certificate
         // here. We are going to do something basic to include
@@ -607,7 +607,7 @@ class FixturesSiteFake extends Site
         // forcing a fake creation of a URL (including .tld) and passes
         // through to createCertificate() directly.
         $this->files->ensureDirExists($this->certificatesPath(), user());
-        $this->createCertificate($urlWithTld);
+        $this->createCertificate($urlWithTld, 368);
     }
 
     public function assertNginxExists($urlWithTld)


### PR DESCRIPTION
This pr is meant to overcome an issue in concerning Chrome v58 and up.

### The tests I've conducted are:

**Test the default setting**
1. Clean linked directories, `$ valet unpark`
2. Run without `expireIn` should go to default. `$ valet secure <my_laravel_project>`
3. See if Chrome is happy - yes it is - validity is set default to 368 days now.

**Test with a too high `expireIn`**

1. Clean linked directories, `$ valet unpark`
2. Run without secure, `$ valet secure --expireIn=730 <my_laravel_project>`
3. See if Chrome is not happy, throws same error `net::ERR_CERT_VALIDITY_TOO_LONG`

**Test with a lower `expireIn`**
1. Clean linked directories, `$ valet unpark`
2. Run with shorter `expireIn`, `$ valet secure --expireIn=120 <my_laravel_project>`
3. See if Chrome is happy.

**Extra test is done by checking Mac's Keychain Access for default option, 368 days counting from December 13 2021**
![image](https://user-images.githubusercontent.com/681775/145826377-66763d0f-a2b5-408b-9b0a-f90fe8d2e196.png)


The expireIn option that can be passed to `$ valet secure <domain> --expireIn=<nDays>` can be used to overcome the aforementioned issue.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
