### PR TITLE
Fix certificate generation

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -179,7 +179,7 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Secure the given domain with a trusted TLS certificate.
      */
-    $app->command('secure [domain] [--expireIn=]', function ($domain = null, $expireIn = null) {
+    $app->command('secure [domain] [--expireIn=]', function ($domain = null, $expireIn = 368) {
         $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
 
         Site::secure($url, null, $expireIn);


### PR DESCRIPTION
Fixes issue described in https://github.com/laravel/valet/pull/1154#issuecomment-992900342

I just tested this multiple times and can confirm that making it `null` makes `valet secure` break nginx config, but making it `368` in the source code makes `valet secure` work as expected.