### PR TITLE
Replace HTTPFul with Guzzle

### DIFF
--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -3,7 +3,8 @@
 namespace Valet;
 
 use DomainException;
-use Httpful\Request;
+use GuzzleHttp\Client;
+use GuzzleHttp\Utils;
 
 class Ngrok
 {
@@ -24,7 +25,7 @@ class Ngrok
 
         foreach ($this->tunnelsEndpoints as $endpoint) {
             $response = retry(20, function () use ($endpoint, $domain) {
-                $body = Request::get($endpoint)->send()->body;
+                $body = Utils::jsonDecode((new Client())->get($endpoint)->getBody());
 
                 if (isset($body->tunnels) && count($body->tunnels) > 0) {
                     return $this->findHttpTunnelUrl($body->tunnels, $domain);

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -2,7 +2,8 @@
 
 namespace Valet;
 
-use Httpful\Request;
+use GuzzleHttp\Client;
+use GuzzleHttp\Utils;
 
 class Valet
 {
@@ -72,11 +73,12 @@ class Valet
      * @param  string  $currentVersion
      * @return bool
      *
-     * @throws \Httpful\Exception\ConnectionErrorException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function onLatestVersion($currentVersion)
     {
-        $response = Request::get('https://api.github.com/repos/laravel/valet/releases/latest')->send();
+        $url = 'https://api.github.com/repos/laravel/valet/releases/latest';
+        $response = Utils::jsonDecode((new Client())->get($url)->getBody());
 
         return version_compare($currentVersion, trim($response->body->tag_name, 'v'), '>=');
     }

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "illuminate/container": "~5.1|^6.0|^7.0|^8.0",
         "mnapoli/silly": "^1.0",
         "symfony/process": "^3.0|^4.0|^5.0",
-        "nategood/httpful": "^0.2",
-        "tightenco/collect": "^5.3|^6.0|^7.0|^8.0"
+        "tightenco/collect": "^5.3|^6.0|^7.0|^8.0",
+        "guzzlehttp/guzzle": "^7.4"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "mnapoli/silly": "^1.0",
         "symfony/process": "^3.0|^4.0|^5.0",
         "tightenco/collect": "^5.3|^6.0|^7.0|^8.0",
-        "guzzlehttp/guzzle": "^7.4"
+        "guzzlehttp/guzzle": "^6.0|^7.4"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As commented on #1157, HTTPful contains some deprecated calls and replacing it with Guzzle is better.
