### PR TITLE
Fix warnings when using Valet in non-CLI context

### DIFF
--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -10,16 +10,18 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 /**
  * Define constants.
  */
-if (! defined('VALET_LOOPBACK')) {
-    define('VALET_LOOPBACK', '127.0.0.1');
-    define('VALET_HOME_PATH', $_SERVER['HOME'].'/.config/valet');
-    define('VALET_SERVER_PATH', realpath(__DIR__.'/../../server.php'));
-    define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
-
-    define('VALET_LEGACY_HOME_PATH', $_SERVER['HOME'].'/.valet');
-
-    define('BREW_PREFIX', (new CommandLine())->runAsUser('printf $(brew --prefix)'));
+if (! defined('VALET_HOME_PATH')) {
+    define('VALET_HOME_PATH', $_SERVER['HOME'] . '/.config/valet');
 }
+if (! defined('VALET_STATIC_PREFIX')) {
+    define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
+}
+
+define('VALET_LOOPBACK', '127.0.0.1');
+define('VALET_SERVER_PATH', realpath(__DIR__.'/../../server.php'));
+define('VALET_LEGACY_HOME_PATH', $_SERVER['HOME'].'/.valet');
+
+define('BREW_PREFIX', (new CommandLine())->runAsUser('printf $(brew --prefix)'));
 
 /**
  * Output the given text to the console.

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
  * Define constants.
  */
 if (! defined('VALET_HOME_PATH')) {
-    define('VALET_HOME_PATH', $_SERVER['HOME'] . '/.config/valet');
+    define('VALET_HOME_PATH', $_SERVER['HOME'].'/.config/valet');
 }
 if (! defined('VALET_STATIC_PREFIX')) {
     define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');


### PR DESCRIPTION
#1050 introduced some small changes to allow Valet to be used in a non-CLI context.

One of the changes was to only define the constants used by Valet if they hadn't already been defined. Rather than checking each constant individually and defining it if required, it only checks if one of the constants has been defined and then defines them all if it hasn't been. That chosen constant was `VALET_LOOPBACK`.

Despite that PR being merged, when including Valet as a package within a Laravel application that is being served by Valet, I still see the following warnings about constants already being defined: 

![147251151-da5c5dea-4b2f-4931-94f4-786fc88554f4](https://user-images.githubusercontent.com/1455253/147650195-7827837d-699b-4847-9d23-b9bf14504058.png)

I'm relatively new to Valet, but diving into the source, it looks like when a site is served through `/server.php`, the only two constants that get set are `VALET_HOME_PATH `and `VALET_STATIC_PREFIX` - the `VALET_LOOPBACK` constant is never set - hence the warnings I saw above. 

Therefore, this PR simply proposes to remove the check for `VALET_LOOPBACK` being defined, and instead individually check if `VALET_HOME_PATH` and `VALET_STATIC_PREFIX` are defined before attempting to define them. 

This fixes the warnings and doesn't appear to break any existing functionality.

_You may notice that I slightly changed the order of the definitions - this was to make it easier to read with the additional `if` statements._

_I understand including Valet as a package isn't really a documented use-case, however it feels right to try and fix it as some of the work has already been done in that original merged PR._
