### PR TITLE
Stop root homebrew services on php version switch

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -384,7 +384,7 @@ class Brew
 
     /**
      * Get the currently running brew services as root.
-     * i.e. /Library/LaunchDaemons (started at boot)
+     * i.e. /Library/LaunchDaemons (started at boot).
      *
      * @return \Illuminate\Support\Collection
      */
@@ -395,7 +395,7 @@ class Brew
 
     /**
      * Get the currently running brew services.
-     * i.e. ~/Library/LaunchAgents (started at login)
+     * i.e. ~/Library/LaunchAgents (started at login).
      *
      * @return \Illuminate\Support\Collection
      */
@@ -410,7 +410,7 @@ class Brew
      * @param  bool  $asUser
      * @return \Illuminate\Support\Collection
      */
-    public function getRunningServices(bool $asUser = false)
+    public function getRunningServices($asUser = false)
     {
         $command = 'brew services list | grep started | awk \'{ print $1; }\'';
         $onError = function ($exitCode, $errorOutput) {
@@ -421,7 +421,7 @@ class Brew
 
         return collect(array_filter(explode(PHP_EOL, $asUser
             ? $this->cli->runAsUser($command, $onError)
-            : $this->cli->run('sudo ' . $command, $onError)
+            : $this->cli->run('sudo '.$command, $onError)
         )));
     }
 

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -371,20 +371,58 @@ class Brew
     }
 
     /**
-     * Get the currently running brew services.
+     * Get all the currently running brew services.
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getRunningServices()
+    public function getAllRunningServices()
     {
-        return collect(array_filter(explode(PHP_EOL, $this->cli->runAsUser(
-            'brew services list | grep started | awk \'{ print $1; }\'',
-            function ($exitCode, $errorOutput) {
-                output($errorOutput);
+        return $this->getRunningServicesAsRoot()
+            ->concat($this->getRunningServicesAsUser())
+            ->unique();
+    }
 
-                throw new DomainException('Brew was unable to check which services are running.');
-            }
-        ))));
+    /**
+     * Get the currently running brew services as root.
+     * i.e. /Library/LaunchDaemons (started at boot)
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getRunningServicesAsRoot()
+    {
+        return $this->getRunningServices();
+    }
+
+    /**
+     * Get the currently running brew services.
+     * i.e. ~/Library/LaunchAgents (started at login)
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getRunningServicesAsUser()
+    {
+        return $this->getRunningServices(true);
+    }
+
+    /**
+     * Get the currently running brew services.
+     *
+     * @param  bool  $asUser
+     * @return \Illuminate\Support\Collection
+     */
+    public function getRunningServices(bool $asUser = false)
+    {
+        $command = 'brew services list | grep started | awk \'{ print $1; }\'';
+        $onError = function ($exitCode, $errorOutput) {
+            output($errorOutput);
+
+            throw new DomainException('Brew was unable to check which services are running.');
+        };
+
+        return collect(array_filter(explode(PHP_EOL, $asUser
+            ? $this->cli->runAsUser($command, $onError)
+            : $this->cli->run('sudo ' . $command, $onError)
+        )));
     }
 
     /**

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -159,7 +159,7 @@ class PhpFpm
     public function stopRunning()
     {
         $this->brew->stopService(
-            $this->brew->getRunningServices()
+            $this->brew->getAllRunningServices()
                 ->filter(function ($service) {
                     return substr($service, 0, 3) === 'php';
                 })

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -348,7 +348,6 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         ], array_values($result->all()));
     }
 
-
     public function test_getAllRunningServices_will_return_unique_services()
     {
         $cli = Mockery::mock(CommandLine::class);
@@ -361,7 +360,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             'service1',
             'service2',
             'service3',
-            'service4'
+            'service4',
         ], array_values($result->all()));
     }
 

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -307,7 +307,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             $onError(1, 'test error output');
         });
         swap(CommandLine::class, $cli);
-        resolve(Brew::class)->getRunningServices();
+        resolve(Brew::class)->getRunningServices(true);
     }
 
     public function test_getRunningServices_will_pass_to_brew_services_list_and_return_array()
@@ -319,12 +319,49 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         ])->andReturn('service1'.PHP_EOL.'service2'.PHP_EOL.PHP_EOL.'service3'.PHP_EOL);
 
         swap(CommandLine::class, $cli);
-        $result = resolve(Brew::class)->getRunningServices('term');
+        $result = resolve(Brew::class)->getRunningServices(true);
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertSame([
             'service1',
             'service2',
             'service3',
+        ], array_values($result->all()));
+    }
+
+    public function test_getAllRunningServices_will_return_both_root_and_user_services()
+    {
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('run')->once()->withArgs([
+            'sudo brew services list | grep started | awk \'{ print $1; }\'',
+            Mockery::type('callable'),
+        ])->andReturn('sudo_ran_service');
+        $cli->shouldReceive('runAsUser')->once()->withArgs([
+            'brew services list | grep started | awk \'{ print $1; }\'',
+            Mockery::type('callable'),
+        ])->andReturn('user_ran_service');
+
+        swap(CommandLine::class, $cli);
+        $result = resolve(Brew::class)->getAllRunningServices();
+        $this->assertSame([
+            'sudo_ran_service',
+            'user_ran_service',
+        ], array_values($result->all()));
+    }
+
+
+    public function test_getAllRunningServices_will_return_unique_services()
+    {
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('run')->once()->andReturn('service1'.PHP_EOL.'service2'.PHP_EOL.'service1'.PHP_EOL);
+        $cli->shouldReceive('runAsUser')->once()->andReturn('service3'.PHP_EOL.'service4'.PHP_EOL.'service2'.PHP_EOL);
+
+        swap(CommandLine::class, $cli);
+        $result = resolve(Brew::class)->getAllRunningServices();
+        $this->assertSame([
+            'service1',
+            'service2',
+            'service3',
+            'service4'
         ], array_values($result->all()));
     }
 

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -42,7 +42,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     public function test_stopRunning_will_pass_filtered_result_of_getRunningServices_to_stopService()
     {
         $brewMock = Mockery::mock(Brew::class);
-        $brewMock->shouldReceive('getRunningServices')->once()
+        $brewMock->shouldReceive('getAllRunningServices')->once()
             ->andReturn(collect([
                 'php7.2',
                 'php@7.3',
@@ -83,7 +83,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock->shouldReceive('link')->withArgs(['php@7.2', true]);
         $brewMock->shouldReceive('linkedPhp');
         $brewMock->shouldReceive('installed');
-        $brewMock->shouldReceive('getRunningServices')->andReturn(collect());
+        $brewMock->shouldReceive('getAllRunningServices')->andReturn(collect());
         $brewMock->shouldReceive('stopService');
 
         // Test both non prefixed and prefixed
@@ -128,7 +128,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock->shouldReceive('link')->withArgs(['php@7.2', true]);
         $brewMock->shouldReceive('linkedPhp');
         $brewMock->shouldReceive('installed');
-        $brewMock->shouldReceive('getRunningServices')->andReturn(collect());
+        $brewMock->shouldReceive('getAllRunningServices')->andReturn(collect());
         $brewMock->shouldReceive('stopService');
 
         // Test both non prefixed and prefixed


### PR DESCRIPTION
Before the change, when running `valet use` the code intended to stop currently running PHP services. But the `getRunningServices` method only returned non-root running services. As PHP services started by Valet are run using `sudo` (so running as root), they were not returned and subsequently not stopped.

This change is intended to fix the above and stop PHP services that are started by Valet on a PHP version switch.

Described the actual issue I was facing in https://github.com/laravel/valet/issues/1177 

A few notes on the implementation:
- I initially tried to make the change as small as possible, and tried to update the current command to be something like `{ sudo brew services list && sudo -u "cristian" brew services list } | grep started | awk '{ print $1; }'` i.e. basically to get the output of both root and non-root services at once. While the command above worked on my command line, it throws an error `"sh: {sudo brew services list && sudo -u "cristian" brew services list }: command not found"` when run via the code. I didn't investigate this further, as I thought that using "advanced" features like the "&&" and "{}" was not worth it. I considered that the readability of this approach was also not that great, so I scraped this implementation.
- On this new implementation, I was not sure of how to name the two new methods. Ended up with `getRunningServicesAsRoot` and `getRunningServicesAsUser`. I considered using `LaunchDaemons` and `LaunchAgents` as this is how they are called in Homebrew https://share.getcloudapp.com/nOu9NlWJ - but decided against as I think the "average" brew user (like myself) would probably not know this. So went with "AsRoot" and "AsUser". Would welcome any thoughts on this.


PS. Noticed that the Diagnose command is also using `brew services list`. Was thinking that maybe it would be a good idea to also add `sudo brew services list`? As Valet runs most of the services using sudo, so they won't be on the `brew services list` command output.
