### PR TITLE
Laravel 9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [5.6, '7.0', 7.1, 7.2, 7.3, 7.4, '8.0', 8.1]
+        php: ['8.0', 8.1]
 
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [5.6, '7.0', 7.1, 7.2, 7.3, 7.4, '8.0', '8.1']
+        php: [5.6, '7.0', 7.1, 7.2, 7.3, 7.4, '8.0', 8.1]
 
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1]
+        php: [5.6, '7.0', 7.1, 7.2, 7.3, 7.4, '8.0', 8.1]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "require": {
         "php": "^5.6|^7.0|^8.0",
-        "illuminate/container": "^9.0",
+        "illuminate/container": "~5.1|^6.0|^7.0|^8.0|^9.0",
         "mnapoli/silly": "^1.0",
-        "symfony/process": "^6.0",
+        "symfony/process": "^3.0|^4.0|^5.0|^6.0",
         "tightenco/collect": "^5.3|^6.0|^7.0|^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,5 @@
         "branch-alias": {
             "dev-master": "2.x-dev"
         }
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "require": {
         "php": "^5.6|^7.0|^8.0",
-        "illuminate/container": "~5.1|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/container": "^9.0",
         "mnapoli/silly": "^1.0",
-        "symfony/process": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/process": "^6.0",
         "tightenco/collect": "^5.3|^6.0|^7.0|^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,10 @@
         "branch-alias": {
             "dev-master": "2.x-dev"
         }
-    }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "require": {
         "php": "^5.6|^7.0|^8.0",
-        "illuminate/container": "~5.1|^6.0|^7.0|^8.0",
+        "illuminate/container": "~5.1|^6.0|^7.0|^8.0|^9.0",
         "mnapoli/silly": "^1.0",
-        "symfony/process": "^3.0|^4.0|^5.0",
+        "symfony/process": "^3.0|^4.0|^5.0|^6.0",
         "tightenco/collect": "^5.3|^6.0|^7.0|^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.4"
     },


### PR DESCRIPTION
Since the CI suite doesn't actually tests different Laravel versions, there's no way to know if this PR will support Laravel 9 until we either try out everything manually or wait until Laravel 9 has been released and we can let the CI run the latest builds of PHP 8 & 8.1 with Laravel 9. I'll keep this PR in draft until the latter has happened.