### PR TITLE
Add ARM support for ngrok

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,4 @@ phpunit.xml.dist export-ignore
 UPGRADE.md export-ignore
 
 /bin/ngrok -diff
+/bin/ngrok-arm -diff

--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -28,6 +28,7 @@ class Diagnose
         'curl --version',
         'php --ri curl',
         '~/.composer/vendor/laravel/valet/bin/ngrok version',
+        '~/.composer/vendor/laravel/valet/bin/ngrok-arm version',
         'ls -al ~/.ngrok2',
         'brew info nginx',
         'brew info php',

--- a/valet
+++ b/valet
@@ -77,8 +77,15 @@ then
 
 	# Fetch Ngrok URL In Background...
 	bash "$DIR/cli/scripts/fetch-share-url.sh" "$HOST" &
-    
-	sudo -u "$USER" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
+
+    arch = $(uname -m)
+
+    if [[ $arch == 'arm64' ]]; then
+        sudo -u "$USER" "$DIR/bin/ngrok-arm" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
+    else
+        sudo -u "$USER" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS"
+    fi
+
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
This PR adds an ARM binary for ngrok to support Apple Silicon MacBooks. Unfortunately this will add around 30MB to the repo so not entirely sure this is wanted...

For Dusk where we do something similar with the chrome driver binaries, [we opted to remove them in the next major version](https://github.com/laravel/dusk/pull/873) and to let the user explicitly install them during the install process. That way the repos stay small. I'm not sure if there's any interest in taking that approach? If so I can look into it maybe.

Closes https://github.com/laravel/valet/issues/1171