### PR TITLE
Fix syntax error in ./valet

### DIFF
--- a/valet
+++ b/valet
@@ -83,7 +83,7 @@ then
     if [[ $arch == 'arm64' ]]; then
         sudo -u "$USER" "$DIR/bin/ngrok-arm" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
     else
-        sudo -u "$USER" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS"
+        sudo -u "$USER" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
     fi
 
     exit


### PR DESCRIPTION
The extra " in line 86 breaks the installer and valet commands

FIXES:

```
/usr/local/bin/valet: line 95: unexpected EOF while looking for matching `"'
/usr/local/bin/valet: line 97: syntax error: unexpected end of file
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
