### PR TITLE
Multiple/Parallel PHP Version Support for Valet

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -80,30 +80,13 @@ class Nginx
             str_replace(
                 ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX'],
                 [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX],
-                $this->replaceLoopback($this->files->get(__DIR__.'/../stubs/valet.conf'))
+                $this->site->replaceLoopback($this->files->get(__DIR__.'/../stubs/valet.conf'))
             )
         );
 
         $this->files->putAsUser(
             BREW_PREFIX.'/etc/nginx/fastcgi_params',
             $this->files->get(__DIR__.'/../stubs/fastcgi_params')
-        );
-    }
-
-    public function replaceLoopback($siteConf)
-    {
-        $loopback = $this->configuration->read()['loopback'];
-
-        if ($loopback === VALET_LOOPBACK) {
-            return $siteConf;
-        }
-
-        $str = '#listen VALET_LOOPBACK:80; # valet loopback';
-
-        return str_replace(
-            $str,
-            substr(str_replace('VALET_LOOPBACK', $loopback, $str), 1),
-            $siteConf
         );
     }
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -396,8 +396,8 @@ class PhpFpm
     }
 
     /**
-     * Get a list of all PHP versions currently serving "isolated sites" (sites with custom Nginx
-     * configs pointing them to a specific PHP version).
+     * Get a list including the global PHP version and allPHP versions currently serving "isolated sites" (sites with
+     * custom Nginx configs pointing them to a specific PHP version).
      *
      * @return array
      */

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -179,6 +179,21 @@ class PhpFpm
     }
 
     /**
+     * Stop PHP, if a specific version isn't being used globally or by any sites.
+     *
+     * @param  string  $phpVersion
+     * @return void
+     */
+    public function maybeStop($phpVersion)
+    {
+        $phpVersion = $this->normalizePhpVersion($phpVersion);
+
+        if(! in_array($phpVersion, $this->utilizedPhpVersions())) {
+            $this->brew->stopService($phpVersion);
+        }
+    }
+
+    /**
      * Use a specific version of php.
      *
      * @param $version
@@ -305,8 +320,8 @@ class PhpFpm
      * If a given file is pointing the custom sock file for the new global version, that new
      * version will now be hosted at `valet.sock`, so update the config file to point to that instead.
      *
-     * @param $newPhpVersion
-     * @param $oldPhpVersion
+     * @param  string  $newPhpVersion
+     * @param  string  $oldPhpVersion
      * @return void
      */
     public function updateConfigurationForGlobalUpdate($newPhpVersion, $oldPhpVersion)

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -223,8 +223,12 @@ class PhpFpm
             $site = $this->site->getSiteUrl($directory);
 
             if (! $site) {
-                warning(sprintf("The [%s] site could not be found in Valet's site list.", $directory));
-                return;
+                throw new DomainException(
+                    sprintf(
+                        "The [%s] site could not be found in Valet's site list.",
+                        $directory
+                    )
+                );
             }
 
             if ($version == 'default') { // Remove isolation for this site
@@ -233,6 +237,7 @@ class PhpFpm
                 $this->stopIfUnused($oldCustomPhpVersion);
                 $this->nginx->restart();
                 info(sprintf('The site [%s] is now using the default PHP version.', $site));
+
                 return;
             }
         }
@@ -263,6 +268,7 @@ class PhpFpm
             $this->restart($version);
             $this->nginx->restart();
             info(sprintf('The site [%s] is now using %s.', $site, $version));
+
             return;
         }
 
@@ -424,6 +430,6 @@ class PhpFpm
                         return $this->normalizePhpVersion($phpVersion); // Example output php@7.4
                     }
                 }
-            })->merge([$this->brew->getLinkedPhpFormula()])->filter()->unique()->toArray();
+            })->merge([$this->brew->getLinkedPhpFormula()])->filter()->unique()->values()->toArray();
     }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -212,7 +212,7 @@ class PhpFpm
     /**
      * Use a specific version of php.
      *
-     * @param $version
+     * @param  string  $version
      * @param  bool  $force
      * @param  string|null  $directory
      * @return string|void
@@ -223,8 +223,8 @@ class PhpFpm
             $site = $this->site->getSiteUrl($directory);
 
             if (! $site) {
-                warning(sprintf('The [%s] site could not be found in valet site list.', $directory));
-                exit();
+                warning(sprintf("The [%s] site could not be found in Valet's site list.", $directory));
+                return;
             }
 
             if ($version == 'default') { // Remove isolation for this site
@@ -232,8 +232,8 @@ class PhpFpm
                 $this->site->removeIsolation($site);
                 $this->maybeStop($customPhpVersion);
                 $this->nginx->restart();
-                info(sprintf('The [%s] site is now using default php version.', $site));
-                exit();
+                info(sprintf('The site [%s] is now using the default PHP version.', $site));
+                return;
             }
         }
 
@@ -253,8 +253,7 @@ class PhpFpm
             $this->brew->ensureInstalled($version, [], $this->taps);
         }
 
-        // Delete old Valet sock files, install the new version, and, if this is a global change, unlink and link PHP
-        if ($directory && $site) {
+        if ($directory) {
             $customPhpVersion = $this->site->customPhpVersion($site); // Example output: "74"
             $this->cli->quietly('sudo rm '.VALET_HOME_PATH.'/'.$this->fpmSockName($version));
             $this->updateConfiguration($version);
@@ -264,7 +263,7 @@ class PhpFpm
             $this->restart($version);
             $this->nginx->restart();
             info(sprintf('The [%s] site is now using %s.', $site, $version));
-            exit();
+            return;
         }
 
         // Unlink the current global PHP if there is one installed

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -192,7 +192,7 @@ class PhpFpm
      * @param  string|null  $phpVersion
      * @return void
      */
-    public function maybeStop($phpVersion)
+    public function stopIfUnused($phpVersion)
     {
         if (! $phpVersion) {
             return;
@@ -228,9 +228,9 @@ class PhpFpm
             }
 
             if ($version == 'default') { // Remove isolation for this site
-                $customPhpVersion = $this->site->customPhpVersion($site); // Example output: "74"
+                $oldCustomPhpVersion = $this->site->customPhpVersion($site); // Example output: "74"
                 $this->site->removeIsolation($site);
-                $this->maybeStop($customPhpVersion);
+                $this->stopIfUnused($oldCustomPhpVersion);
                 $this->nginx->restart();
                 info(sprintf('The site [%s] is now using the default PHP version.', $site));
                 return;
@@ -254,15 +254,15 @@ class PhpFpm
         }
 
         if ($directory) {
-            $customPhpVersion = $this->site->customPhpVersion($site); // Example output: "74"
+            $oldCustomPhpVersion = $this->site->customPhpVersion($site); // Example output: "74"
             $this->cli->quietly('sudo rm '.VALET_HOME_PATH.'/'.$this->fpmSockName($version));
             $this->updateConfiguration($version);
             $this->site->installSiteConfig($site, $this->fpmSockName($version), $version);
 
-            $this->maybeStop($customPhpVersion);
+            $this->stopIfUnused($oldCustomPhpVersion);
             $this->restart($version);
             $this->nginx->restart();
-            info(sprintf('The [%s] site is now using %s.', $site, $version));
+            info(sprintf('The site [%s] is now using %s.', $site, $version));
             return;
         }
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -123,11 +123,12 @@ class PhpFpm
     /**
      * Restart the PHP FPM process.
      *
+     * @param  string|null  $phpVersion
      * @return void
      */
     public function restart($phpVersion = null)
     {
-        $this->brew->restartService($phpVersion ?: $this->getPhpVersionsToPerformRestart());
+        $this->brew->restartService($phpVersion ?: $this->utilizedPhpVersions());
     }
 
     /**
@@ -146,6 +147,7 @@ class PhpFpm
     /**
      * Get the path to the FPM configuration file for the current PHP version.
      *
+     * @param  string|null  $phpVersion
      * @return string
      */
     public function fpmConfigPath($phpVersion = null)
@@ -298,7 +300,7 @@ class PhpFpm
 
     /**
      * Update all existing Nginx files when running a global PHP version update.
-     * If a given file is pointing to `valet.sock`, it's targeting the old global PHP version; 
+     * If a given file is pointing to `valet.sock`, it's targeting the old global PHP version;
      * update it to point to the new custom sock file for that version.
      * If a given file is pointing the custom sock file for the new global version, that new
      * version will now be hosted at `valet.sock`, so update the config file to point to that instead.
@@ -336,7 +338,7 @@ class PhpFpm
      *
      * @return array
      */
-    public function getPhpVersionsToPerformRestart()
+    public function utilizedPhpVersions()
     {
         $fpmSockFiles = $this->brew->supportedPhpVersions()->map(function ($version) {
             return $this->fpmSockName($this->normalizePhpVersion($version));
@@ -356,7 +358,7 @@ class PhpFpm
                         // for example, "valet74.sock" will output "php74"
                         $phpVersion = 'php'.str_replace(['valet', '.sock'], '', $sock);
 
-                        return $this->normalizePhpVersion($phpVersion); // example output php@7.4
+                        return $this->normalizePhpVersion($phpVersion); // Example output php@7.4
                     }
                 }
             })->merge([$this->brew->getLinkedPhpFormula()])->filter()->unique()->toArray();

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -188,7 +188,7 @@ class PhpFpm
     {
         $phpVersion = $this->normalizePhpVersion($phpVersion);
 
-        if(! in_array($phpVersion, $this->utilizedPhpVersions())) {
+        if (! in_array($phpVersion, $this->utilizedPhpVersions())) {
             $this->brew->stopService($phpVersion);
         }
     }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -191,14 +191,14 @@ class Site
     }
 
     /**
-     * Determine if the provided site is parked.
+     * Determine if the provided site is a valid site, whether parked or linked.
      *
-     * @param $valetSite
+     * @param string $valetSite
      * @return bool
      */
     public function isValidSite($valetSite)
     {
-        // remove .tld to make the search a bit easier
+        // Remove .tld from sitename if it was provided
         $siteName = str_replace('.'.$this->config->read()['tld'], '', $valetSite);
 
         return $this->parked()->merge($this->links())->where('site', $siteName)->count() > 0;
@@ -488,7 +488,8 @@ class Site
      */
     public function secure($url, $siteConf = null, $certificateExpireInDays = 396, $caExpireInYears = 20)
     {
-        $phpVersion = $this->extractPhpVersion($url); // let's try to preserve the isolated php version here. Example output: 74
+        // Extract in order to later preserve custom PHP version config when securing
+        $phpVersion = $this->extractPhpVersion($url);
 
         $this->unsecure($url);
 
@@ -505,8 +506,7 @@ class Site
 
         $siteConf = $this->buildSecureNginxServer($url, $siteConf);
 
-        // if user had any isolated php version, let's swap the .sock file,
-        // so it still uses the old php version
+        // If they user had isolated the PHP version for this site, swap out .sock file
         if ($phpVersion) {
             $siteConf = $this->replaceSockFile($siteConf, "valet{$phpVersion}.sock", $phpVersion);
         }
@@ -1020,7 +1020,7 @@ class Site
     }
 
     /**
-     * Replace Loopback.
+     * Replace Loopback configuration line in Valet site configuration file contents.
      *
      * @param  string  $siteConf
      * @return string
@@ -1062,11 +1062,11 @@ class Site
     }
 
     /**
-     * Replace .sock file form a Nginx site conf.
+     * Replace .sock file in an Nginx site configuration file contents.
      *
-     * @param $siteConf
-     * @param $sockFile
-     * @param $phpVersion
+     * @param string $siteConf
+     * @param string $sockFile
+     * @param string $phpVersion
      * @return string
      */
     public function replaceSockFile($siteConf, $sockFile, $phpVersion)

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -712,12 +712,12 @@ class Site
     }
 
     /**
-     * Remove PHP Version isolation from a specific site
+     * Remove PHP Version isolation from a specific site.
      *
      * @param  string  $valetSite
      * @return void
      */
-    function removeIsolation($valetSite)
+    public function removeIsolation($valetSite)
     {
         // When site has SSL certificate, just re-generate the nginx config.
         // It will be using the `valet.sock` by default from now
@@ -1064,7 +1064,7 @@ class Site
     /**
      * Extract PHP version of exising nginx conifg.
      *
-     * @param   string  $url
+     * @param  string  $url
      * @return string|void
      */
     public function customPhpVersion($url)
@@ -1075,7 +1075,7 @@ class Site
             if (starts_with($siteConf, '# Valet isolated PHP version')) {
                 $firstLine = explode(PHP_EOL, $siteConf)[0];
 
-                return preg_replace("/[^\d]*/", '', $firstLine);
+                return preg_replace("/[^\d]*/", '', $firstLine); // Example output: "74" or "81"
             }
         }
     }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -191,17 +191,26 @@ class Site
     }
 
     /**
-     * Determine if the provided site is a valid site, whether parked or linked.
+     * Determine if the provided site is a valid site, whether parked or linked and get the site url.
      *
-     * @param  string  $valetSite
-     * @return bool
+     * @param  string  $directory
+     * @return string|false
      */
-    public function isValidSite($valetSite)
+    public function getSiteUrl($directory)
     {
-        // Remove .tld from sitename if it was provided
-        $siteName = str_replace('.'.$this->config->read()['tld'], '', $valetSite);
+        $tld = $this->config->read()['tld'];
 
-        return $this->parked()->merge($this->links())->where('site', $siteName)->count() > 0;
+        if ($directory == '.') { // Allow user to use dot as current dir's site `--site=.`
+            $directory = $this->host(getcwd());
+        }
+
+        $directory = str_replace('.'.$tld, '', $directory); // Remove .tld from sitename if it was provided
+
+        if ($this->parked()->merge($this->links())->where('site', $directory)->count() > 0) {
+            return $directory.'.'.$tld;
+        }
+
+        return false; // Invalid directory provided
     }
 
     /**
@@ -692,7 +701,7 @@ class Site
      *
      * @param  string  $valetSite
      * @param  string  $fpmSockName
-     * @param $phpVersion
+     * @param  string  $phpVersion
      * @return void
      */
     public function installSiteConfig($valetSite, $fpmSockName, $phpVersion)
@@ -1091,11 +1100,8 @@ class Site
     public function replaceSockFile($siteConf, $sockFile, $phpVersion)
     {
         $siteConf = preg_replace('/valet[0-9]*.sock/', $sockFile, $siteConf);
+        $siteConf = preg_replace('/# Valet isolated PHP version.*\n/', '', $siteConf); // Remove `Valet isolated PHP version` line from config
 
-        if (! starts_with($siteConf, '# Valet isolated PHP version')) {
-            $siteConf = '# Valet isolated PHP version : '.$phpVersion.PHP_EOL.$siteConf;
-        }
-
-        return $siteConf;
+        return '# Valet isolated PHP version : '.$phpVersion.PHP_EOL.$siteConf;
     }
 }

--- a/cli/stubs/site.valet.conf
+++ b/cli/stubs/site.valet.conf
@@ -1,0 +1,40 @@
+# Valet isolated PHP version : VALET_ISOLATED_PHP_VERSION
+server {
+    listen 127.0.0.1:80;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    #listen VALET_LOOPBACK:80; # valet loopback
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location / {
+        rewrite ^ "VALET_SERVER_PATH" last;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/nginx-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass "unix:VALET_HOME_PATH/VALET_PHP_FPM_SOCKET";
+        fastcgi_index "VALET_SERVER_PATH";
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -525,7 +525,12 @@ You might also want to investigate your global Composer configs. Helpful command
             }
 
             if ($phpVersion == 'default') {
+                $customPhpVersion = Site::customPhpVersion($site); // Example output: "74"
                 Site::removeIsolation($site);
+                if ($customPhpVersion) {
+                    PhpFpm::maybeStop('php' .$customPhpVersion);
+                }
+
                 Nginx::restart();
 
                 info(sprintf('The [%s] site is now using default php version.', $site));

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -509,45 +509,7 @@ You might also want to investigate your global Composer configs. Helpful command
             }
         }
 
-        if ($site) {
-            $tld = Configuration::read()['tld'];
-
-            if ($site == '.') { // Allow user to use dot as current dir's site `--site=.`
-                $site = Site::host(getcwd()).'.'.$tld;
-            }
-
-            if (false === strpos($site, '.'.$tld)) {
-                $site = $site.'.'.$tld; // Allow user to pass just the site's directory name
-            }
-
-            if (! Site::isValidSite($site)) {
-                return warning(sprintf('Site %s could not be found in valet site list.', $site));
-            }
-
-            if ($phpVersion == 'default') {
-                $customPhpVersion = Site::customPhpVersion($site); // Example output: "74"
-                Site::removeIsolation($site);
-                if ($customPhpVersion) {
-                    PhpFpm::maybeStop('php'.$customPhpVersion);
-                }
-
-                Nginx::restart();
-
-                info(sprintf('The [%s] site is now using default php version.', $site));
-            } else {
-                $newVersion = PhpFpm::useVersion($phpVersion, $force, $site);
-
-                Site::installSiteConfig($site, PhpFpm::fpmSockName($phpVersion), $phpVersion);
-                Nginx::restart();
-
-                info(sprintf('The [%s] site is now using %s.', $site, $newVersion));
-            }
-        } else {
-            $newVersion = PhpFpm::useVersion($phpVersion, $force);
-            Nginx::restart();
-            info(sprintf('Valet is now using %s.', $newVersion).PHP_EOL);
-            info('Note that you might need to run <comment>composer global update</comment> if your PHP version change affects the dependencies of global packages required by Composer.');
-        }
+        PhpFpm::useVersion($phpVersion, $force, $site);
     })->descriptions('Change the version of PHP used by valet', [
         'phpVersion' => 'The PHP version you want to use, e.g php@7.3',
         '--site' => 'Isolate PHP version of a specific valet site. e.g: --site=site.test',

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -528,7 +528,7 @@ You might also want to investigate your global Composer configs. Helpful command
                 $customPhpVersion = Site::customPhpVersion($site); // Example output: "74"
                 Site::removeIsolation($site);
                 if ($customPhpVersion) {
-                    PhpFpm::maybeStop('php' .$customPhpVersion);
+                    PhpFpm::maybeStop('php'.$customPhpVersion);
                 }
 
                 Nginx::restart();

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -3,9 +3,12 @@
 use Illuminate\Container\Container;
 use Valet\Brew;
 use Valet\CommandLine;
+use Valet\Configuration;
 use Valet\Filesystem;
+use Valet\Nginx;
 use Valet\PhpFpm;
 use function Valet\resolve;
+use Valet\Site;
 use function Valet\swap;
 use function Valet\user;
 
@@ -65,10 +68,16 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     public function test_use_version_will_convert_passed_php_version()
     {
         $brewMock = Mockery::mock(Brew::class);
+        $nginxMock = Mockery::mock(Nginx::class);
+        $siteMock = Mockery::mock(Site::class);
+
         $phpFpmMock = Mockery::mock(PhpFpm::class, [
             $brewMock,
             resolve(CommandLine::class),
             resolve(Filesystem::class),
+            resolve(Configuration::class),
+            $siteMock,
+            $nginxMock,
         ])->makePartial();
 
         $phpFpmMock->shouldReceive('install');
@@ -85,6 +94,8 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock->shouldReceive('installed');
         $brewMock->shouldReceive('getAllRunningServices')->andReturn(collect());
         $brewMock->shouldReceive('stopService');
+
+        $nginxMock->shouldReceive('restart');
 
         // Test both non prefixed and prefixed
         $this->assertSame('php@7.2', $phpFpmMock->useVersion('php7.2'));
@@ -109,11 +120,18 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     public function test_use_version_if_already_linked_php_will_unlink_before_installing()
     {
         $brewMock = Mockery::mock(Brew::class);
+        $nginxMock = Mockery::mock(Nginx::class);
+        $siteMock = Mockery::mock(Site::class);
+
         $phpFpmMock = Mockery::mock(PhpFpm::class, [
             $brewMock,
             resolve(CommandLine::class),
             resolve(Filesystem::class),
+            resolve(Configuration::class),
+            $siteMock,
+            $nginxMock,
         ])->makePartial();
+
         $phpFpmMock->shouldReceive('install');
         $phpFpmMock->shouldReceive('updateConfigurationForGlobalUpdate');
 
@@ -131,6 +149,8 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock->shouldReceive('installed');
         $brewMock->shouldReceive('getAllRunningServices')->andReturn(collect());
         $brewMock->shouldReceive('stopService');
+
+        $nginxMock->shouldReceive('restart');
 
         // Test both non prefixed and prefixed
         $this->assertSame('php@7.2', $phpFpmMock->useVersion('php@7.2'));

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -40,6 +40,186 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $this->assertStringContainsString(sprintf("\nuser = %s", user()), $contents);
         $this->assertStringContainsString("\ngroup = staff", $contents);
         $this->assertStringContainsString("\nlisten = ".VALET_HOME_PATH.'/valet.sock', $contents);
+
+        // Passing speicifc version will change the .sock file
+        resolve(StubForUpdatingFpmConfigFiles::class)->updateConfiguration('php@7.2');
+        $contents = file_get_contents(__DIR__.'/output/fpm.conf');
+        $this->assertStringContainsString(sprintf("\nuser = %s", user()), $contents);
+        $this->assertStringContainsString("\ngroup = staff", $contents);
+        $this->assertStringContainsString("\nlisten = ".VALET_HOME_PATH.'/valet72.sock', $contents);
+    }
+
+    public function test_it_can_generate_sock_file_name_from_php_version()
+    {
+        $this->assertEquals('valet72.sock', resolve(PhpFpm::class)->fpmSockName('php@7.2'));
+        $this->assertEquals('valet72.sock', resolve(PhpFpm::class)->fpmSockName('php@72'));
+        $this->assertEquals('valet72.sock', resolve(PhpFpm::class)->fpmSockName('php72'));
+        $this->assertEquals('valet72.sock', resolve(PhpFpm::class)->fpmSockName('72'));
+    }
+
+    public function test_utilized_php_versions()
+    {
+        $fileSystemMock = Mockery::mock(Filesystem::class);
+        $brewMock = Mockery::mock(Brew::class);
+
+        $phpFpmMock = Mockery::mock(PhpFpm::class, [
+            $brewMock,
+            Mockery::mock(CommandLine::class),
+            $fileSystemMock,
+            resolve(Configuration::class),
+            Mockery::mock(Site::class),
+            Mockery::mock(Nginx::class),
+        ])->makePartial();
+
+        swap(PhpFpm::class, $phpFpmMock);
+
+        $brewMock->shouldReceive('supportedPhpVersions')->andReturn(collect([
+            'php@7.1',
+            'php@7.2',
+            'php@7.3',
+            'php@7.4',
+        ]));
+
+        $brewMock->shouldReceive('getLinkedPhpFormula')->andReturn('php@7.3');
+
+        $fileSystemMock->shouldReceive('scandir')
+            ->once()
+            ->with(VALET_HOME_PATH.'/Nginx')
+            ->andReturn(['.gitkeep', 'isolated-site-71.test', 'isolated-site-72.test', 'isolated-site-73.test']);
+
+        $fileSystemMock->shouldNotReceive('get')->with(VALET_HOME_PATH.'/Nginx/.gitkeep');
+
+        $sites = [
+            [
+                'site' => 'isolated-site-71.test',
+                'conf' => '# Valet isolated PHP version : 71'.PHP_EOL.'valet71.sock',
+            ],
+            [
+                'site' => 'isolated-site-72.test',
+                'conf' => '# Valet isolated PHP version : php@7.2'.PHP_EOL.'valet72.sock',
+            ],
+            [
+                'site' => 'isolated-site-73.test',
+                'conf' => '# Valet isolated PHP version : 73'.PHP_EOL.'valet.sock',
+            ],
+        ];
+
+        foreach ($sites as $site) {
+            $fileSystemMock->shouldReceive('get')->once()->with(VALET_HOME_PATH.'/Nginx/'.$site['site'])->andReturn($site['conf']);
+        }
+
+        $this->assertEquals(['php@7.1', 'php@7.2', 'php@7.3'], resolve(PhpFpm::class)->utilizedPhpVersions());
+    }
+
+    public function test_global_php_version_update_will_swap_socks()
+    {
+        $fileSystemMock = Mockery::mock(Filesystem::class);
+
+        $phpFpmMock = Mockery::mock(PhpFpm::class, [
+            Mockery::mock(Brew::class),
+            Mockery::mock(CommandLine::class),
+            $fileSystemMock,
+            resolve(Configuration::class),
+            Mockery::mock(Site::class),
+            Mockery::mock(Nginx::class),
+        ])->makePartial();
+
+        swap(PhpFpm::class, $phpFpmMock);
+
+        $fileSystemMock->shouldReceive('scandir')
+            ->once()
+            ->with(VALET_HOME_PATH.'/Nginx')
+            ->andReturn([
+                '.gitkeep',
+                'isolated-site-71.test',
+                'isolated-site-72.test',
+                'isolated-site-73.test',
+                'non-isolated-site.test',
+            ]);
+
+        // Skip dotfiles
+        $fileSystemMock->shouldNotReceive('get')->with(VALET_HOME_PATH.'/Nginx/.gitkeep');
+
+        // Any isolated site running on php72 would be replaced with default valet.sock,
+        // as 72 will be the default version after the global PHP version switch
+        $fileSystemMock->shouldReceive('get')
+            ->once()
+            ->with(VALET_HOME_PATH.'/Nginx/isolated-site-72.test')
+            ->andReturn('# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }');
+
+        $fileSystemMock->shouldReceive('put')->once()->withArgs([
+            VALET_HOME_PATH.'/Nginx/isolated-site-72.test',
+            '# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet.sock }',
+        ]);
+
+        // Any isolated site running on current PHP version (with valet.sock),
+        // should be still be running on the same version after the global version update
+        $fileSystemMock->shouldReceive('get')
+            ->once()
+            ->with(VALET_HOME_PATH.'/Nginx/isolated-site-71.test')
+            ->andReturn('# Valet isolated PHP version : 71'.PHP_EOL.'server { fastcgi_pass: valet.sock }');
+
+        $fileSystemMock->shouldReceive('put')->once()->withArgs([
+            VALET_HOME_PATH.'/Nginx/isolated-site-71.test',
+            '# Valet isolated PHP version : 71'.PHP_EOL.'server { fastcgi_pass: valet71.sock }',
+        ]);
+
+        // PHP 7.3 sites won't be affected here
+        $fileSystemMock->shouldReceive('get')
+            ->once()
+            ->with(VALET_HOME_PATH.'/Nginx/isolated-site-73.test')
+            ->andReturn('# Valet isolated PHP version : 73'.PHP_EOL.'server { fastcgi_pass: valet73.sock }');
+
+        $fileSystemMock->shouldNotReceive('put')->withArgs([
+            VALET_HOME_PATH.'/Nginx/isolated-site-73.test',
+            Mockery::any(),
+        ]);
+
+        // Nginx config that doesn't have the isolation header, It would not swap .sock files
+        $fileSystemMock->shouldReceive('get')->once()->with(VALET_HOME_PATH.'/Nginx/non-isolated-site.test')->andReturn('valet.sock');
+        $fileSystemMock->shouldNotReceive('put')->withArgs([
+            VALET_HOME_PATH.'/Nginx/non-isolated-site.test',
+            'valet71.sock',
+        ]);
+
+        // Switching from php7.1 to php7.2
+        resolve(PhpFpm::class)->updateConfigurationForGlobalUpdate('php@7.2', 'php@7.1');
+    }
+
+    public function test_stop_unused_php_versions()
+    {
+        $brewMock = Mockery::mock(Brew::class);
+
+        $phpFpmMock = Mockery::mock(PhpFpm::class, [
+            $brewMock,
+            Mockery::mock(CommandLine::class),
+            Mockery::mock(Filesystem::class),
+            resolve(Configuration::class),
+            Mockery::mock(Site::class),
+            Mockery::mock(Nginx::class),
+        ])->makePartial();
+
+        swap(PhpFpm::class, $phpFpmMock);
+
+        $phpFpmMock->shouldReceive('utilizedPhpVersions')->andReturn([
+            'php@7.1',
+            'php@7.2',
+        ]);
+
+        // Would do nothing
+        resolve(PhpFpm::class)->stopIfUnused(null);
+
+        // Currently, not utilizeing this PHP version, should be stopped
+        $brewMock->shouldReceive('stopService')->times(3)->with('php@7.3');
+        resolve(PhpFpm::class)->stopIfUnused('73');
+        resolve(PhpFpm::class)->stopIfUnused('php73');
+        resolve(PhpFpm::class)->stopIfUnused('php@7.3');
+
+        // Utilizeing PHP Versions, should not receive stop command
+        $brewMock->shouldNotReceive('stopService')->with('php@7.1');
+        $brewMock->shouldNotReceive('stopService')->with('php@7.2');
+        resolve(PhpFpm::class)->stopIfUnused('php@7.1');
+        resolve(PhpFpm::class)->stopIfUnused('php@7.2');
     }
 
     public function test_stopRunning_will_pass_filtered_result_of_getRunningServices_to_stopService()
@@ -122,24 +302,32 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock = Mockery::mock(Brew::class);
         $nginxMock = Mockery::mock(Nginx::class);
         $siteMock = Mockery::mock(Site::class);
+        $cliMock = Mockery::mock(CommandLine::class);
+        $fileSystemMock = Mockery::mock(Filesystem::class);
 
         $phpFpmMock = Mockery::mock(PhpFpm::class, [
             $brewMock,
-            resolve(CommandLine::class),
-            resolve(Filesystem::class),
+            $cliMock,
+            $fileSystemMock,
             resolve(Configuration::class),
             $siteMock,
             $nginxMock,
         ])->makePartial();
 
         $phpFpmMock->shouldReceive('install');
-        $phpFpmMock->shouldReceive('updateConfigurationForGlobalUpdate');
+        $cliMock->shouldReceive('quietly')->with('sudo rm '.VALET_HOME_PATH.'/valet*.sock')->once();
+        $fileSystemMock->shouldReceive('unlink')->with(VALET_HOME_PATH.'/valet.sock')->once();
+
+        $phpFpmMock->shouldReceive('updateConfiguration')->with('php@7.1')->once();
+        $phpFpmMock->shouldReceive('updateConfigurationForGlobalUpdate')->withArgs(['php@7.2', 'php@7.1'])->once();
 
         $brewMock->shouldReceive('supportedPhpVersions')->andReturn(collect([
             'php@7.2',
             'php@5.6',
         ]));
+
         $brewMock->shouldReceive('hasLinkedPhp')->andReturn(true);
+        $brewMock->shouldReceive('linkedPhp')->andReturn('php@7.1');
         $brewMock->shouldReceive('getLinkedPhpFormula')->andReturn('php@7.1');
         $brewMock->shouldReceive('unlink')->with('php@7.1');
         $brewMock->shouldReceive('ensureInstalled')->with('php@7.2', [], $phpFpmMock->taps);
@@ -152,8 +340,97 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $nginxMock->shouldReceive('restart');
 
-        // Test both non prefixed and prefixed
         $this->assertSame('php@7.2', $phpFpmMock->useVersion('php@7.2'));
+    }
+
+    public function test_use_version_with_site_paramter_will_isolate_a_site()
+    {
+        $brewMock = Mockery::mock(Brew::class);
+        $nginxMock = Mockery::mock(Nginx::class);
+        $siteMock = Mockery::mock(Site::class);
+
+        $phpFpmMock = Mockery::mock(PhpFpm::class, [
+            $brewMock,
+            resolve(CommandLine::class),
+            resolve(Filesystem::class),
+            resolve(Configuration::class),
+            $siteMock,
+            $nginxMock,
+        ])->makePartial();
+
+        $brewMock->shouldReceive('supportedPhpVersions')->andReturn(collect([
+            'php@7.2',
+            'php@5.6',
+        ]));
+
+        $brewMock->shouldReceive('ensureInstalled')->with('php@7.2', [], $phpFpmMock->taps);
+        $brewMock->shouldReceive('installed')->with('php@7.2');
+        $brewMock->shouldReceive('determineAliasedVersion')->with('php@7.2')->andReturn('php@7.2');
+        $brewMock->shouldReceive('linkedPhp')->once();
+
+        $siteMock->shouldReceive('getSiteUrl')->with('test')->andReturn('test.test');
+        $siteMock->shouldReceive('installSiteConfig')->withArgs(['test.test', 'valet72.sock', 'php@7.2']);
+        $siteMock->shouldReceive('customPhpVersion')->with('test.test')->andReturn('72');
+
+        $phpFpmMock->shouldReceive('stopIfUnused')->with('72')->once();
+        $phpFpmMock->shouldReceive('updateConfiguration')->with('php@7.2')->once();
+        $phpFpmMock->shouldReceive('restart')->with('php@7.2')->once();
+
+        $nginxMock->shouldReceive('restart');
+
+        // These should only run when doing global PHP switches
+        $brewMock->shouldNotReceive('stopService');
+        $brewMock->shouldNotReceive('link');
+        $brewMock->shouldNotReceive('unlink');
+        $phpFpmMock->shouldNotReceive('stopRunning');
+        $phpFpmMock->shouldNotReceive('install');
+        $phpFpmMock->shouldNotReceive('updateConfigurationForGlobalUpdate');
+
+        $this->assertSame(null, $phpFpmMock->useVersion('php@7.2', false, 'test'));
+    }
+
+    public function test_use_version_can_remove_isolation_for_a_site()
+    {
+        $nginxMock = Mockery::mock(Nginx::class);
+        $siteMock = Mockery::mock(Site::class);
+
+        $phpFpmMock = Mockery::mock(PhpFpm::class, [
+            Mockery::mock(Brew::class),
+            resolve(CommandLine::class),
+            resolve(Filesystem::class),
+            resolve(Configuration::class),
+            $siteMock,
+            $nginxMock,
+        ])->makePartial();
+
+        $siteMock->shouldReceive('getSiteUrl')->with('test')->andReturn('test.test');
+        $siteMock->shouldReceive('customPhpVersion')->with('test.test')->andReturn('74');
+        $siteMock->shouldReceive('removeIsolation')->with('test.test')->once();
+        $phpFpmMock->shouldReceive('stopIfUnused')->with('74');
+        $nginxMock->shouldReceive('restart');
+
+        $this->assertSame(null, $phpFpmMock->useVersion('default', false, 'test'));
+    }
+
+    public function test_use_version_will_throw_if_site_is_not_parked_or_linked()
+    {
+        $siteMock = Mockery::mock(Site::class);
+
+        $phpFpmMock = Mockery::mock(PhpFpm::class, [
+            Mockery::mock(Brew::class),
+            resolve(CommandLine::class),
+            resolve(Filesystem::class),
+            resolve(Configuration::class),
+            $siteMock,
+            Mockery::mock(Nginx::class),
+        ])->makePartial();
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage("The [test] site could not be found in Valet's site list.");
+
+        $siteMock->shouldReceive('getSiteUrl');
+
+        $this->assertSame(null, $phpFpmMock->useVersion('default', false, 'test'));
     }
 }
 

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -115,6 +115,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             resolve(Filesystem::class),
         ])->makePartial();
         $phpFpmMock->shouldReceive('install');
+        $phpFpmMock->shouldReceive('updateConfigurationForGlobalUpdate');
 
         $brewMock->shouldReceive('supportedPhpVersions')->andReturn(collect([
             'php@7.2',
@@ -138,7 +139,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
 class StubForUpdatingFpmConfigFiles extends PhpFpm
 {
-    public function fpmConfigPath()
+    public function fpmConfigPath($phpVersion = null)
     {
         return __DIR__.'/output/fpm.conf';
     }

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -41,7 +41,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $this->assertStringContainsString("\ngroup = staff", $contents);
         $this->assertStringContainsString("\nlisten = ".VALET_HOME_PATH.'/valet.sock', $contents);
 
-        // Passing speicifc version will change the .sock file
+        // Passing specific version will change the .sock file
         resolve(StubForUpdatingFpmConfigFiles::class)->updateConfiguration('php@7.2');
         $contents = file_get_contents(__DIR__.'/output/fpm.conf');
         $this->assertStringContainsString(sprintf("\nuser = %s", user()), $contents);
@@ -209,13 +209,13 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         // Would do nothing
         resolve(PhpFpm::class)->stopIfUnused(null);
 
-        // Currently, not utilizeing this PHP version, should be stopped
+        // This currently-un-used PHP version should be stopped
         $brewMock->shouldReceive('stopService')->times(3)->with('php@7.3');
         resolve(PhpFpm::class)->stopIfUnused('73');
         resolve(PhpFpm::class)->stopIfUnused('php73');
         resolve(PhpFpm::class)->stopIfUnused('php@7.3');
 
-        // Utilizeing PHP Versions, should not receive stop command
+        // These currently-used PHP versions should not be stopped
         $brewMock->shouldNotReceive('stopService')->with('php@7.1');
         $brewMock->shouldNotReceive('stopService')->with('php@7.2');
         resolve(PhpFpm::class)->stopIfUnused('php@7.1');
@@ -343,7 +343,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $this->assertSame('php@7.2', $phpFpmMock->useVersion('php@7.2'));
     }
 
-    public function test_use_version_with_site_paramter_will_isolate_a_site()
+    public function test_use_version_with_site_parameter_will_isolate_a_site()
     {
         $brewMock = Mockery::mock(Brew::class);
         $nginxMock = Mockery::mock(Nginx::class);

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -526,6 +526,261 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals([], $site->proxies()->all());
     }
+
+    public function test_get_site_url_from_directory()
+    {
+        $config = Mockery::mock(Configuration::class);
+
+        swap(Configuration::class, $config);
+
+        $siteMock = Mockery::mock(Site::class, [
+            resolve(Configuration::class),
+            resolve(CommandLine::class),
+            resolve(Filesystem::class),
+        ])->makePartial();
+
+        swap(Site::class, $siteMock);
+
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test', 'loopback' => VALET_LOOPBACK, 'paths' => []]);
+
+        $siteMock->shouldReceive('parked')
+            ->andReturn(collect([
+                'site1' => [
+                    'site' => 'site1',
+                    'secured' => '',
+                    'url' => 'http://site1.test',
+                    'path' => '/Users/name/code/site1',
+                ],
+            ]));
+
+        $siteMock->shouldReceive('links')->andReturn(collect([
+            'site2' => [
+                'site' => 'site2',
+                'secured' => 'X',
+                'url' => 'http://site2.test',
+                'path' => '/Users/name/code/site2',
+            ],
+        ]));
+
+        $siteMock->shouldReceive('host')->andReturn('site1');
+
+        $site = resolve(Site::class);
+
+        $this->assertEquals('site1.test', $site->getSiteUrl('.'));
+        $this->assertEquals('site1.test', $site->getSiteUrl('./'));
+
+        $this->assertEquals('site1.test', $site->getSiteUrl('site1'));
+        $this->assertEquals('site1.test', $site->getSiteUrl('site1.test'));
+
+        $this->assertEquals('site2.test', $site->getSiteUrl('site2'));
+        $this->assertEquals('site2.test', $site->getSiteUrl('site2.test'));
+
+        $this->assertEquals(false, $site->getSiteUrl('site3'));
+        $this->assertEquals(false, $site->getSiteUrl('site3.test'));
+    }
+
+    public function test_adding_ssl_certificate_would_preserve_isolation()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $config = Mockery::mock(Configuration::class);
+
+        $siteMock = Mockery::mock(Site::class, [
+            $config,
+            Mockery::mock(CommandLine::class),
+            $files,
+        ])->makePartial();
+
+        swap(Site::class, $siteMock);
+
+        $siteMock->shouldReceive('unsecure');
+        $files->shouldReceive('ensureDirExists');
+        $files->shouldReceive('putAsUser');
+        $siteMock->shouldReceive('createCa');
+        $siteMock->shouldReceive('createCertificate');
+        $siteMock->shouldReceive('buildSecureNginxServer');
+
+        // If site has an isolated PHP version for the site, it would replace .sock file
+        $siteMock->shouldReceive('customPhpVersion')->with('site1.test')->andReturn('73')->once();
+        $siteMock->shouldReceive('replaceSockFile')->withArgs([Mockery::any(), 'valet73.sock', '73'])->once();
+        resolve(Site::class)->secure('site1.test');
+
+        // Sites without isolated PHP version, should not replace anything
+        $siteMock->shouldReceive('customPhpVersion')->with('site2.test')->andReturn(null)->once();
+        $siteMock->shouldNotReceive('replaceSockFile');
+        resolve(Site::class)->secure('site2.test');
+    }
+
+    public function test_removing_ssl_certificate_would_preserve_isolation()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $config = Mockery::mock(Configuration::class);
+        $cli = Mockery::mock(CommandLine::class);
+
+        $siteMock = Mockery::mock(Site::class, [
+            $config,
+            $cli,
+            $files,
+        ])->makePartial();
+
+        swap(Site::class, $siteMock);
+
+        $cli->shouldReceive('run');
+        $files->shouldReceive('exists')->andReturn(false);
+
+        // If site has an isolated PHP version, it would install nginx site config
+        $siteMock->shouldReceive('customPhpVersion')->with('site1.test')->andReturn('73')->once();
+        $siteMock->shouldReceive('installSiteConfig')->withArgs(['site1.test', 'valet73.sock', '73'])->once();
+        resolve(Site::class)->unsecure('site1.test');
+
+        // Site without a custom PHP version, should not install site config
+        $siteMock->shouldReceive('customPhpVersion')->with('site2.test')->andReturn(null)->once();
+        $siteMock->shouldNotReceive('installSiteConfig');
+        resolve(Site::class)->unsecure('site2.test');
+    }
+
+    public function test_can_install_nginx_site_config_for_specific_php_version()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $config = Mockery::mock(Configuration::class);
+
+        $siteMock = Mockery::mock(Site::class, [
+            $config,
+            resolve(CommandLine::class),
+            $files,
+        ])->makePartial();
+
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test', 'loopback' => VALET_LOOPBACK]);
+
+        // If Nginx config exists for the site, modify exising config
+        $files->shouldReceive('exists')->once()->with($siteMock->nginxPath('site1.test'))->andReturn(true);
+
+        $files->shouldReceive('get')
+            ->once()
+            ->with($siteMock->nginxPath('site1.test'))
+            ->andReturn('# Valet isolated PHP version : php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }');
+
+        $files->shouldReceive('putAsUser')
+            ->once()
+            ->withArgs([
+                $siteMock->nginxPath('site1.test'),
+                '# Valet isolated PHP version : php@8.0'.PHP_EOL.'server { fastcgi_pass: valet80.sock }',
+            ]);
+
+        $siteMock->installSiteConfig('site1.test', 'valet80.sock', 'php@8.0');
+
+        // When there's no Nginx file exists, create new config from the template
+        $files->shouldReceive('exists')->once()->with($siteMock->nginxPath('site2.test'))->andReturn(false);
+        $files->shouldReceive('get')
+            ->once()
+            ->with(dirname(__DIR__).'/cli/Valet/../stubs/site.valet.conf')
+            ->andReturn(file_get_contents(__DIR__.'/../cli/stubs/site.valet.conf'));
+
+        $files->shouldReceive('putAsUser')
+            ->once()
+            ->withArgs([
+                $siteMock->nginxPath('site2.test'),
+                Mockery::on(function ($argument) {
+                    return preg_match('/^# Valet isolated PHP version : php@8.0/', $argument)
+                        && preg_match('#fastcgi_pass "unix:.*/valet80.sock#', $argument)
+                        && strpos($argument, 'server_name site2.test www.site2.test *.site2.test;') !== false;
+                }),
+            ]);
+
+        $siteMock->installSiteConfig('site2.test', 'valet80.sock', 'php@8.0');
+    }
+
+    public function test_removeing_isolation()
+    {
+        $files = Mockery::mock(Filesystem::class);
+
+        $siteMock = Mockery::mock(Site::class, [
+            resolve(Configuration::class),
+            resolve(CommandLine::class),
+            $files,
+        ])->makePartial();
+
+        swap(Site::class, $siteMock);
+
+        // SSL Site
+        $files->shouldReceive('exists')->once()->with($siteMock->certificatesPath('site1.test', 'crt'))->andReturn(true);
+        $files->shouldReceive('putAsUser')->withArgs([$siteMock->nginxPath('site1.test'), Mockery::any()])->once();
+        $siteMock->shouldReceive('buildSecureNginxServer')->once()->with('site1.test');
+        resolve(Site::class)->removeIsolation('site1.test');
+
+        // Non-SSL Site
+        $files->shouldReceive('exists')->once()->with($siteMock->certificatesPath('site2.test', 'crt'))->andReturn(false);
+        $files->shouldReceive('unlink')->with($siteMock->nginxPath('site2.test'))->once();
+        $siteMock->shouldNotReceive('buildSecureNginxServer')->with('site2.test');
+        resolve(Site::class)->removeIsolation('site2.test');
+    }
+
+    public function test_retrive_custom_php_version_from_nginx_config()
+    {
+        $files = Mockery::mock(Filesystem::class);
+
+        $siteMock = Mockery::mock(Site::class, [
+            resolve(Configuration::class),
+            resolve(CommandLine::class),
+            $files,
+        ])->makePartial();
+
+        swap(Site::class, $siteMock);
+
+        // Site with isolated PHP version
+        $files->shouldReceive('exists')->once()->with($siteMock->nginxPath('site1.test'))->andReturn(true);
+        $files->shouldReceive('get')
+            ->once()
+            ->with($siteMock->nginxPath('site1.test'))
+            ->andReturn('# Valet isolated PHP version : php@7.4');
+        $this->assertEquals('74', resolve(Site::class)->customPhpVersion('site1.test'));
+
+        // Site without any custom nginx config
+        $files->shouldReceive('exists')->once()->with($siteMock->nginxPath('site2.test'))->andReturn(false);
+        $files->shouldNotReceive('get')->with($siteMock->nginxPath('site2.test'));
+        $this->assertEquals(null, resolve(Site::class)->customPhpVersion('site2.test'));
+
+        // Site with a custom nginx config, but doesn't have the header
+        $files->shouldReceive('exists')->once()->with($siteMock->nginxPath('site3.test'))->andReturn(true);
+        $files->shouldReceive('get')
+            ->once()
+            ->with($siteMock->nginxPath('site3.test'))
+            ->andReturn('server { }');
+        $this->assertEquals(null, resolve(Site::class)->customPhpVersion('site3.test'));
+    }
+
+    public function test_replace_sock_file_in_nginx_config()
+    {
+        $site = resolve(Site::class);
+
+        // Switiching to php71, valet71.sock should be replaced with valet.sock
+        // It would prepend isolation header
+        $this->assertEquals(
+            '# Valet isolated PHP version : 71'.PHP_EOL.'server { fastcgi_pass: valet.sock }',
+            $site->replaceSockFile('server { fastcgi_pass: valet71.sock }', 'valet.sock', '71')
+        );
+
+        // Switiching to php72, valet.sock should be replaced with valet72.sock
+        $this->assertEquals(
+            '# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }',
+            $site->replaceSockFile('server { fastcgi_pass: valet.sock }', 'valet72.sock', '72')
+        );
+
+        // Switiching to php73 from php72, valet72.sock should be replaced with valet73.sock
+        // Isolation header should be updated to 73
+        $this->assertEquals(
+            '# Valet isolated PHP version : 73'.PHP_EOL.'server { fastcgi_pass: valet73.sock }',
+            $site->replaceSockFile('# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }', 'valet73.sock', '73')
+        );
+
+        // Switiching to php72 from php74, valet72.sock should be replaced with valet74.sock
+        // Isolation header should be updated to php@7.4
+        $this->assertEquals(
+            '# Valet isolated PHP version : php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }',
+            $site->replaceSockFile('# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet.sock }', 'valet74.sock', 'php@7.4')
+        );
+    }
 }
 
 class CommandLineFake extends CommandLine


### PR DESCRIPTION
This pull request introduces an optional `--site` flag on the `valet use` command, that allows users to run multiple versions of PHP in parallel on different sites. 

Btw, I build this feature to solve my very own problem. I need to constantly switch between PHP versions, as I need to switch between old and new projects. This is being very handy for me. 

### To isolate a site's PHP version, run: 

```bash
valet use php@8.0 --site=site.test
```


or pass the site directory's name
```bash
valet use php@8.1 --site=site2 
```


or `cd` into the site's directory then use `.` to use current directory:
```bash
valet use php@8.1 --site .
```

### Remove isolation for a site: 
```bash
valet use default --site .
```

<details>
<summary>Here's a video showing this feature up and running</summary>

https://user-images.githubusercontent.com/13833460/152670301-d479a21e-c82c-443e-b732-f46afc67a2a9.mp4
</details>


### Behind the scene:
- Updates the FPM config file `/etc/php/8.0/php-fpm.d/valet-fpm.conf` and updates the listen parameter to something like: `valet80.sock`
- Publishes an Nginx config file on the `~/.config/valet/Nginx` location for that site.
- Updates that specific Nginx config file and replaces the `fastcgi_pass` param with `valet80.sock`

### Few other notes: 
- System default linked PHP will keep running on `valet.sock` as expected. 
- Global PHP switching commands like `valet use php@7.4` would still work as expected. Alongside, it will perform some operations on the isolated site's Nginx config to make sure those isolated sites still work as expected. 
- Running `valet install` or `valet restart` would do a scan on isolated sites to determine what versions of PHP are being used.  So it can restart each version of PHP correctly. 
- SSL-enabled sites could be isolated with the usual command. (or isolated site can obtain SSL, as well)
- Running `valet unsecure` on an isolated site will still keep the isolation and will remove the SSL.

### Future todos: 
- Need to have another command to list all the isolated sites and their PHP versions. (would be handy to have that)
- ~~Ideally, we would need to have a way to remove isolation for a site (valet use default --site .)~~


This modification doesn't seem to break any existing test cases or any existing flows.

I tried to add tests for the new methods that were introduced in this PR. 