### PR TITLE
Update `valet.sock` to be a symlink to an existing `valet{version}.sock` file

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -179,13 +179,13 @@ class Nginx
     }
 
     /**
-     * Return a list of all sites with explicit Nginx configurations
+     * Return a list of all sites with explicit Nginx configurations.
      *
      * @return \Illuminate\Support\Collection
      */
     public function configuredSites()
     {
-       return collect($this->files->scandir(VALET_HOME_PATH.'/Nginx'))
+        return collect($this->files->scandir(VALET_HOME_PATH.'/Nginx'))
             ->reject(function ($file) {
                 return starts_with($file, '.');
             });

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -177,4 +177,17 @@ class Nginx
         $this->brew->uninstallFormula('nginx nginx-full');
         $this->cli->quietly('rm -rf '.BREW_PREFIX.'/etc/nginx '.BREW_PREFIX.'/var/log/nginx');
     }
+
+    /**
+     * Return a list of all sites with explicit Nginx configurations
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function configuredSites()
+    {
+       return collect($this->files->scandir(VALET_HOME_PATH.'/Nginx'))
+            ->reject(function ($file) {
+                return starts_with($file, '.');
+            });
+    }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -253,7 +253,7 @@ class PhpFpm
         $configuredSites = $this->nginx->configuredSites();
 
         return $configuredSites->filter(function ($item) {
-            return str_contains($this->files->get(VALET_HOME_PATH.'/Nginx/'.$item), 'Valet isolated PHP version');
+            return strpos($this->files->get(VALET_HOME_PATH.'/Nginx/'.$item), 'Valet isolated PHP version') !== false;
         })->map(function ($item) {
             return ['url' => $item];
         });

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -258,7 +258,7 @@ class PhpFpm
         $configuredSites = $this->nginx->configuredSites();
 
         return $configuredSites->filter(function ($item) {
-            return strpos($this->files->get(VALET_HOME_PATH.'/Nginx/'.$item), 'Valet isolated PHP version') !== false;
+            return strpos($this->files->get(VALET_HOME_PATH.'/Nginx/'.$item), ISOLATED_PHP_VERSION) !== false;
         })->map(function ($item) {
             return ['url' => $item, 'version' => $this->normalizePhpVersion($this->site->customPhpVersion($item))];
         });

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -303,7 +303,7 @@ class PhpFpm
      */
     public function symlinkPrimaryValetSock($phpVersion)
     {
-        $this->files->symlink($this->fpmSockName($phpVersion), VALET_HOME_PATH.'/valet.sock');
+        $this->files->symlinkAsUser(VALET_HOME_PATH . '/' . $this->fpmSockName($phpVersion), VALET_HOME_PATH.'/valet.sock');
     }
 
     /**

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -311,11 +311,7 @@ class PhpFpm
      */
     public function normalizePhpVersion($version)
     {
-        if (strpos($version, 'php') === false) {
-            $version = 'php'.$version;
-        }
-
-        return preg_replace('/(php)([0-9+])(?:.)?([0-9+])/i', '$1@$2.$3', $version);
+        return preg_replace('/(?:php@?)?([0-9+])(?:.)?([0-9+])/i', 'php@$1.$2', $version);
     }
 
     /**

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -54,6 +54,11 @@ class PhpFpm
 
         $phpVersion = $this->brew->linkedPhp();
         $this->createConfigurationFiles($phpVersion);
+
+        // Remove old valet.sock
+        $this->files->unlink(VALET_HOME_PATH.'/valet.sock');
+        $this->cli->quietly('sudo rm '.VALET_HOME_PATH.'/valet.sock');
+
         $this->symlinkPrimaryValetSock($phpVersion);
 
         $this->restart();
@@ -292,10 +297,6 @@ class PhpFpm
         $this->brew->link($version, true);
 
         $this->stopRunning();
-
-        // Remove valet.sock
-        $this->files->unlink(VALET_HOME_PATH.'/valet.sock');
-        $this->cli->quietly('sudo rm '.VALET_HOME_PATH.'/valet.sock');
 
         $this->install();
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -303,7 +303,7 @@ class PhpFpm
      */
     public function symlinkPrimaryValetSock($phpVersion)
     {
-        $this->files->symlinkAsUser(VALET_HOME_PATH . '/' . $this->fpmSockName($phpVersion), VALET_HOME_PATH.'/valet.sock');
+        $this->files->symlinkAsUser(VALET_HOME_PATH.'/'.$this->fpmSockName($phpVersion), VALET_HOME_PATH.'/valet.sock');
     }
 
     /**

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -312,8 +312,6 @@ class PhpFpm
     /**
      * Symlink (Capistrano-style) a given Valet.sock file to be the primary valet.sock.
      *
-     * @todo write tests
-     *
      * @param  string  $phpVersion
      * @return void
      */

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -244,6 +244,22 @@ class PhpFpm
     }
 
     /**
+     * List all directories with PHP isolation configured.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function isolatedDirectories()
+    {
+        $configuredSites = $this->nginx->configuredSites();
+
+        return $configuredSites->filter(function ($item) {
+            return str_contains($this->files->get(VALET_HOME_PATH.'/Nginx/'.$item), 'Valet isolated PHP version');
+        })->map(function ($item) {
+            return ['url' => $item];
+        });
+    }
+
+    /**
      * Use a specific version of PHP globally.
      *
      * @param  string  $version
@@ -366,11 +382,7 @@ class PhpFpm
             return self::fpmSockName($this->normalizePhpVersion($version));
         })->unique();
 
-        return collect($this->files->scandir(VALET_HOME_PATH.'/Nginx'))
-            ->reject(function ($file) {
-                return starts_with($file, '.');
-            })
-            ->map(function ($file) use ($fpmSockFiles) {
+        return $this->nginx->configuredSites()->map(function ($file) use ($fpmSockFiles) {
                 $content = $this->files->get(VALET_HOME_PATH.'/Nginx/'.$file);
 
                 // Get the normalized PHP version for this config file, if it's defined

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -59,9 +59,9 @@ class PhpFpm
         $this->files->unlink(VALET_HOME_PATH.'/valet.sock');
         $this->cli->quietly('sudo rm '.VALET_HOME_PATH.'/valet.sock');
 
-        $this->symlinkPrimaryValetSock($phpVersion);
-
         $this->restart();
+
+        $this->symlinkPrimaryValetSock($phpVersion);
     }
 
     /**

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -383,18 +383,18 @@ class PhpFpm
         })->unique();
 
         return $this->nginx->configuredSites()->map(function ($file) use ($fpmSockFiles) {
-                $content = $this->files->get(VALET_HOME_PATH.'/Nginx/'.$file);
+            $content = $this->files->get(VALET_HOME_PATH.'/Nginx/'.$file);
 
-                // Get the normalized PHP version for this config file, if it's defined
-                foreach ($fpmSockFiles as $sock) {
-                    if (strpos($content, $sock) !== false) {
-                        // Extract the PHP version number from a custom .sock path;
-                        // for example, "valet74.sock" will output "php74"
-                        $phpVersion = 'php'.str_replace(['valet', '.sock'], '', $sock);
+            // Get the normalized PHP version for this config file, if it's defined
+            foreach ($fpmSockFiles as $sock) {
+                if (strpos($content, $sock) !== false) {
+                    // Extract the PHP version number from a custom .sock path;
+                    // for example, "valet74.sock" will output "php74"
+                    $phpVersion = 'php'.str_replace(['valet', '.sock'], '', $sock);
 
-                        return $this->normalizePhpVersion($phpVersion); // Example output php@7.4
-                    }
+                    return $this->normalizePhpVersion($phpVersion); // Example output php@7.4
                 }
-            })->merge([$this->brew->getLinkedPhpFormula()])->filter()->unique()->values()->toArray();
+            }
+        })->merge([$this->brew->getLinkedPhpFormula()])->filter()->unique()->values()->toArray();
     }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -255,7 +255,7 @@ class PhpFpm
         return $configuredSites->filter(function ($item) {
             return strpos($this->files->get(VALET_HOME_PATH.'/Nginx/'.$item), 'Valet isolated PHP version') !== false;
         })->map(function ($item) {
-            return ['url' => $item];
+            return ['url' => $item, 'version' => $this->normalizePhpVersion($this->site->customPhpVersion($item))];
         });
     }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1082,7 +1082,7 @@ class Site
         if ($this->files->exists($this->nginxPath($url))) {
             $siteConf = $this->files->get($this->nginxPath($url));
 
-            if (starts_with($siteConf, '# Valet isolated PHP version')) {
+            if (starts_with($siteConf, '# '.ISOLATED_PHP_VERSION)) {
                 $firstLine = explode(PHP_EOL, $siteConf)[0];
 
                 return preg_replace("/[^\d]*/", '', $firstLine); // Example output: "74" or "81"
@@ -1102,8 +1102,8 @@ class Site
         $sockFile = PhpFpm::fpmSockName($phpVersion);
 
         $siteConf = preg_replace('/valet[0-9]*.sock/', $sockFile, $siteConf);
-        $siteConf = preg_replace('/# Valet isolated PHP version.*\n/', '', $siteConf); // Remove `Valet isolated PHP version` line from config
+        $siteConf = preg_replace('/# '.ISOLATED_PHP_VERSION.'.*\n/', '', $siteConf); // Remove ISOLATED_PHP_VERSION line from config
 
-        return '# Valet isolated PHP version: '.$phpVersion.PHP_EOL.$siteConf;
+        return '# '.ISOLATED_PHP_VERSION.'='.$phpVersion.PHP_EOL.$siteConf;
     }
 }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1104,6 +1104,6 @@ class Site
         $siteConf = preg_replace('/valet[0-9]*.sock/', $sockFile, $siteConf);
         $siteConf = preg_replace('/# Valet isolated PHP version.*\n/', '', $siteConf); // Remove `Valet isolated PHP version` line from config
 
-        return '# Valet isolated PHP version : '.$phpVersion.PHP_EOL.$siteConf;
+        return '# Valet isolated PHP version: '.$phpVersion.PHP_EOL.$siteConf;
     }
 }

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -23,6 +23,8 @@ define('VALET_LEGACY_HOME_PATH', $_SERVER['HOME'].'/.valet');
 
 define('BREW_PREFIX', (new CommandLine())->runAsUser('printf $(brew --prefix)'));
 
+define('ISOLATED_PHP_VERSION', 'ISOLATED_PHP_VERSION');
+
 /**
  * Output the given text to the console.
  *

--- a/cli/stubs/site.valet.conf
+++ b/cli/stubs/site.valet.conf
@@ -1,4 +1,4 @@
-# Valet isolated PHP version: VALET_ISOLATED_PHP_VERSION
+# ISOLATED_PHP_VERSION=VALET_ISOLATED_PHP_VERSION
 server {
     listen 127.0.0.1:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;

--- a/cli/stubs/site.valet.conf
+++ b/cli/stubs/site.valet.conf
@@ -1,4 +1,4 @@
-# Valet isolated PHP version : VALET_ISOLATED_PHP_VERSION
+# Valet isolated PHP version: VALET_ISOLATED_PHP_VERSION
 server {
     listen 127.0.0.1:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -528,7 +528,16 @@ You might also want to investigate your global Composer configs. Helpful command
      */
     $app->command('unisolate', function () {
         PhpFpm::unIsolateDirectory(basename(getcwd()));
-    })->descriptions('Stop customizing the version of PHP used by valet to serve the current working directory');
+    })->descriptions('Stop customizing the version of PHP used by Valet to serve the current working directory');
+
+    /**
+     * List isolated sites
+     */
+    $app->command('isolated', function () {
+        $sites = PhpFpm::isolatedDirectories();
+
+        table(['Path'], $sites->all());
+    })->descriptions('List all sites using isolated versions of PHP.');
 
     /**
      * Tail log file.

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -547,7 +547,7 @@ You might also want to investigate your global Composer configs. Helpful command
     $app->command('isolated', function () {
         $sites = PhpFpm::isolatedDirectories();
 
-        table(['Path'], $sites->all());
+        table(['Path', 'PHP Version'], $sites->all());
     })->descriptions('List all sites using isolated versions of PHP.');
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -491,9 +491,9 @@ You might also want to investigate your global Composer configs. Helpful command
     ]);
 
     /**
-     * Allow the user to change the version of php valet uses.
+     * Allow the user to change the version of php Valet uses.
      */
-    $app->command('use [phpVersion] [--force] [--site=]', function ($phpVersion, $force, $site) {
+    $app->command('use [phpVersion] [--force]', function ($phpVersion, $force) {
         if (! $phpVersion) {
             $path = getcwd().'/.valetphprc';
             $linkedVersion = Brew::linkedPhp();
@@ -509,30 +509,26 @@ You might also want to investigate your global Composer configs. Helpful command
             }
         }
 
-        PhpFpm::useVersion($phpVersion, $force, $site);
-    })->descriptions('Change the version of PHP used by valet', [
-        'phpVersion' => 'The PHP version you want to use, e.g php@7.3',
-        '--site' => 'Isolate PHP version of a specific valet site. e.g: --site=site.test',
-    ]);
-
-    /**
-     * Allow the user to change the version of php valet uses to serve a given site.
-     */
-    $app->command('isolate [site] [phpVersion] ', function ($site, $phpVersion) {
-        PhpFpm::isolateDirectory($site, $phpVersion);
-    })->descriptions('Change the version of PHP used by valet to serve a given site', [
-        'site' => 'The valet site (e.g. site.test) you want to isolate to a given PHP version',
+        PhpFpm::useVersion($phpVersion, $force);
+    })->descriptions('Change the version of PHP used by Valet', [
         'phpVersion' => 'The PHP version you want to use, e.g php@7.3',
     ]);
 
     /**
-     * Allow the user to un-do specifying the version of php valet uses to serve a given site.
+     * Allow the user to change the version of PHP Valet uses to serve the current site.
      */
-    $app->command('unisolate [site] ', function ($site) {
-        PhpFpm::unIsolateDirectory($site);
-    })->descriptions('Stop customizing the version of PHP used by valet to serve a given site', [
-        'site' => 'The valet site (e.g. site.test) you want to un-isolate',
+    $app->command('isolate [phpVersion] ', function ($phpVersion) {
+        PhpFpm::isolateDirectory(basename(getcwd()), $phpVersion);
+    })->descriptions('Change the version of PHP used by Valet to serve the current working directory', [
+        'phpVersion' => 'The PHP version you want to use, e.g php@7.3',
     ]);
+
+    /**
+     * Allow the user to un-do specifying the version of PHP Valet uses to serve the current site.
+     */
+    $app->command('unisolate', function () {
+        PhpFpm::unIsolateDirectory(basename(getcwd()));
+    })->descriptions('Stop customizing the version of PHP used by valet to serve the current working directory');
 
     /**
      * Tail log file.

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -531,7 +531,7 @@ You might also want to investigate your global Composer configs. Helpful command
     })->descriptions('Stop customizing the version of PHP used by Valet to serve the current working directory');
 
     /**
-     * List isolated sites
+     * List isolated sites.
      */
     $app->command('isolated', function () {
         $sites = PhpFpm::isolatedDirectories();

--- a/tests/NginxTest.php
+++ b/tests/NginxTest.php
@@ -86,4 +86,26 @@ class NginxTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $site->shouldHaveReceived('resecureForNewConfiguration', [$data, $data]);
     }
+
+    public function test_it_gets_configured_sites()
+    {
+        $files = Mockery::mock(Filesystem::class);
+
+        $files->shouldReceive('scandir')
+            ->once()
+            ->with(VALET_HOME_PATH . '/Nginx')
+            ->andReturn(['.gitkeep', 'isolated-site-71.test', 'isolated-site-72.test', 'isolated-site-73.test']);
+
+        swap(Filesystem::class, $files);
+        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['tld' => 'test', 'loopback' => VALET_LOOPBACK]]));
+        swap(Site::class, Mockery::mock(Site::class));
+
+        $nginx = resolve(Nginx::class);
+        $output = $nginx->configuredSites();
+
+        $this->assertEquals(
+            ['isolated-site-71.test', 'isolated-site-72.test', 'isolated-site-73.test'],
+            $output->values()->all()
+        );
+    }
 }

--- a/tests/NginxTest.php
+++ b/tests/NginxTest.php
@@ -93,7 +93,7 @@ class NginxTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $files->shouldReceive('scandir')
             ->once()
-            ->with(VALET_HOME_PATH . '/Nginx')
+            ->with(VALET_HOME_PATH.'/Nginx')
             ->andReturn(['.gitkeep', 'isolated-site-71.test', 'isolated-site-72.test', 'isolated-site-73.test']);
 
         swap(Filesystem::class, $files);

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -60,6 +60,11 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $this->assertEquals('php@8.1', resolve(PhpFpm::class)->normalizePhpVersion('81'));
     }
 
+    public function test_it_installs()
+    {
+        $this->markTestIncomplete('todo');
+    }
+
     public function test_utilized_php_versions()
     {
         $fileSystemMock = Mockery::mock(Filesystem::class);
@@ -291,21 +296,17 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock = Mockery::mock(Brew::class);
         $nginxMock = Mockery::mock(Nginx::class);
         $siteMock = Mockery::mock(Site::class);
-        $cliMock = Mockery::mock(CommandLine::class);
-        $fileSystemMock = Mockery::mock(Filesystem::class);
 
         $phpFpmMock = Mockery::mock(PhpFpm::class, [
             $brewMock,
-            $cliMock,
-            $fileSystemMock,
+            resolve(CommandLine::class),
+            resolve(Filesystem::class),
             resolve(Configuration::class),
             $siteMock,
             $nginxMock,
         ])->makePartial();
 
         $phpFpmMock->shouldReceive('install');
-        $cliMock->shouldReceive('quietly')->with('sudo rm '.VALET_HOME_PATH.'/valet.sock')->once();
-        $fileSystemMock->shouldReceive('unlink')->with(VALET_HOME_PATH.'/valet.sock')->once();
 
         $brewMock->shouldReceive('supportedPhpVersions')->andReturn(collect([
             'php@7.2',

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -64,6 +64,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     {
         $fileSystemMock = Mockery::mock(Filesystem::class);
         $brewMock = Mockery::mock(Brew::class);
+        $nginxMock = Mockery::mock(Nginx::class);
 
         $phpFpmMock = Mockery::mock(PhpFpm::class, [
             $brewMock,
@@ -71,7 +72,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             $fileSystemMock,
             resolve(Configuration::class),
             Mockery::mock(Site::class),
-            Mockery::mock(Nginx::class),
+            $nginxMock,
         ])->makePartial();
 
         swap(PhpFpm::class, $phpFpmMock);
@@ -85,12 +86,9 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $brewMock->shouldReceive('getLinkedPhpFormula')->andReturn('php@7.3');
 
-        $fileSystemMock->shouldReceive('scandir')
+        $nginxMock->shouldReceive('configuredSites')
             ->once()
-            ->with(VALET_HOME_PATH.'/Nginx')
-            ->andReturn(['.gitkeep', 'isolated-site-71.test', 'isolated-site-72.test', 'isolated-site-73.test']);
-
-        $fileSystemMock->shouldNotReceive('get')->with(VALET_HOME_PATH.'/Nginx/.gitkeep');
+            ->andReturn(collect(['isolated-site-71.test', 'isolated-site-72.test', 'isolated-site-73.test']));
 
         $sites = [
             [
@@ -112,6 +110,11 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         }
 
         $this->assertEquals(['php@7.1', 'php@7.2', 'php@7.3'], resolve(PhpFpm::class)->utilizedPhpVersions());
+    }
+
+    public function test_it_lists_isolated_directories()
+    {
+        $this->markTestIncomplete('@todo');
     }
 
     public function test_stop_unused_php_versions()

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -230,7 +230,6 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
     public function test_use_version_will_convert_passed_php_version()
     {
-        // @todo mock CLI and filesystem so real valet.sock files aren't deleted
         $brewMock = Mockery::mock(Brew::class);
         $nginxMock = Mockery::mock(Nginx::class);
         $siteMock = Mockery::mock(Site::class);

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -35,13 +35,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         copy(__DIR__.'/files/fpm.conf', __DIR__.'/output/fpm.conf');
         mkdir(__DIR__.'/output/conf.d');
         copy(__DIR__.'/files/php-memory-limits.ini', __DIR__.'/output/conf.d/php-memory-limits.ini');
-        resolve(StubForUpdatingFpmConfigFiles::class)->createConfigurationFiles();
-        $contents = file_get_contents(__DIR__.'/output/fpm.conf');
-        $this->assertStringContainsString(sprintf("\nuser = %s", user()), $contents);
-        $this->assertStringContainsString("\ngroup = staff", $contents);
-        $this->assertStringContainsString("\nlisten = ".VALET_HOME_PATH.'/valet.sock', $contents);
 
-        // Passing specific version will change the .sock file
         resolve(StubForUpdatingFpmConfigFiles::class)->createConfigurationFiles('php@7.2');
         $contents = file_get_contents(__DIR__.'/output/fpm.conf');
         $this->assertStringContainsString(sprintf("\nuser = %s", user()), $contents);
@@ -113,6 +107,8 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
     public function test_global_php_version_update_will_swap_socks()
     {
+        $this->markTestIncomplete('Needs deleting or refactoring');
+
         $fileSystemMock = Mockery::mock(Filesystem::class);
 
         $phpFpmMock = Mockery::mock(PhpFpm::class, [
@@ -315,11 +311,11 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         ])->makePartial();
 
         $phpFpmMock->shouldReceive('install');
-        $cliMock->shouldReceive('quietly')->with('sudo rm '.VALET_HOME_PATH.'/valet*.sock')->once();
+        $cliMock->shouldReceive('quietly')->with('sudo rm '.VALET_HOME_PATH.'/valet.sock')->once();
         $fileSystemMock->shouldReceive('unlink')->with(VALET_HOME_PATH.'/valet.sock')->once();
 
-        $phpFpmMock->shouldReceive('createConfigurationFiles')->with('php@7.1')->once();
-        $phpFpmMock->shouldReceive('updateConfigurationForGlobalUpdate')->withArgs(['php@7.2', 'php@7.1'])->once();
+        // $phpFpmMock->shouldReceive('createConfigurationFiles')->with('php@7.1')->once();
+        // $phpFpmMock->shouldReceive('updateConfigurationForGlobalUpdate')->withArgs(['php@7.2', 'php@7.1'])->once();
 
         $brewMock->shouldReceive('supportedPhpVersions')->andReturn(collect([
             'php@7.2',
@@ -384,7 +380,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock->shouldNotReceive('unlink');
         $phpFpmMock->shouldNotReceive('stopRunning');
         $phpFpmMock->shouldNotReceive('install');
-        $phpFpmMock->shouldNotReceive('updateConfigurationForGlobalUpdate');
+        // $phpFpmMock->shouldNotReceive('updateConfigurationForGlobalUpdate');
 
         $this->assertSame(null, $phpFpmMock->isolateDirectory('test', 'php@7.2'));
     }

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -51,6 +51,15 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $this->assertEquals('valet72.sock', resolve(PhpFpm::class)->fpmSockName('72'));
     }
 
+    public function test_it_normalizes_php_versions()
+    {
+        $this->assertEquals('php@8.1', resolve(PhpFpm::class)->normalizePhpVersion('php@8.1'));
+        $this->assertEquals('php@8.1', resolve(PhpFpm::class)->normalizePhpVersion('php8.1'));
+        $this->assertEquals('php@8.1', resolve(PhpFpm::class)->normalizePhpVersion('php81'));
+        $this->assertEquals('php@8.1', resolve(PhpFpm::class)->normalizePhpVersion('8.1'));
+        $this->assertEquals('php@8.1', resolve(PhpFpm::class)->normalizePhpVersion('81'));
+    }
+
     public function test_utilized_php_versions()
     {
         $fileSystemMock = Mockery::mock(Filesystem::class);

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -93,15 +93,15 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $sites = [
             [
                 'site' => 'isolated-site-71.test',
-                'conf' => '# Valet isolated PHP version : 71'.PHP_EOL.'valet71.sock',
+                'conf' => '# Valet isolated PHP version: 71'.PHP_EOL.'valet71.sock',
             ],
             [
                 'site' => 'isolated-site-72.test',
-                'conf' => '# Valet isolated PHP version : php@7.2'.PHP_EOL.'valet72.sock',
+                'conf' => '# Valet isolated PHP version: php@7.2'.PHP_EOL.'valet72.sock',
             ],
             [
                 'site' => 'isolated-site-73.test',
-                'conf' => '# Valet isolated PHP version : 73'.PHP_EOL.'valet.sock',
+                'conf' => '# Valet isolated PHP version: 73'.PHP_EOL.'valet.sock',
             ],
         ];
 
@@ -135,11 +135,11 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $sites = [
             [
                 'site' => 'isolated-site-71.test',
-                'conf' => '# Valet isolated PHP version : 71' . PHP_EOL . 'valet71.sock',
+                'conf' => '# Valet isolated PHP version: 71' . PHP_EOL . 'valet71.sock',
             ],
             [
                 'site' => 'isolated-site-72.test',
-                'conf' => '# Valet isolated PHP version : php@7.2' . PHP_EOL . 'valet72.sock',
+                'conf' => '# Valet isolated PHP version: php@7.2' . PHP_EOL . 'valet72.sock',
             ],
             [
                 'site' => 'not-isolated-site.test',

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -98,15 +98,15 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $sites = [
             [
                 'site' => 'isolated-site-71.test',
-                'conf' => '# Valet isolated PHP version: 71'.PHP_EOL.'valet71.sock',
+                'conf' => '# '.ISOLATED_PHP_VERSION.'=71'.PHP_EOL.'valet71.sock',
             ],
             [
                 'site' => 'isolated-site-72.test',
-                'conf' => '# Valet isolated PHP version: php@7.2'.PHP_EOL.'valet72.sock',
+                'conf' => '# '.ISOLATED_PHP_VERSION.'=php@7.2'.PHP_EOL.'valet72.sock',
             ],
             [
                 'site' => 'isolated-site-73.test',
-                'conf' => '# Valet isolated PHP version: 73'.PHP_EOL.'valet.sock',
+                'conf' => '# '.ISOLATED_PHP_VERSION.'=73'.PHP_EOL.'valet.sock',
             ],
         ];
 
@@ -146,11 +146,11 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $sites = [
             [
                 'site' => 'isolated-site-71.test',
-                'conf' => '# Valet isolated PHP version: 71'.PHP_EOL.'valet71.sock',
+                'conf' => '# '.ISOLATED_PHP_VERSION.'=71'.PHP_EOL.'valet71.sock',
             ],
             [
                 'site' => 'isolated-site-72.test',
-                'conf' => '# Valet isolated PHP version: php@7.2'.PHP_EOL.'valet72.sock',
+                'conf' => '# '.ISOLATED_PHP_VERSION.'=php@7.2'.PHP_EOL.'valet72.sock',
             ],
             [
                 'site' => 'not-isolated-site.test',

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -659,13 +659,13 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('get')
             ->once()
             ->with($siteMock->nginxPath('site1.test'))
-            ->andReturn('# Valet isolated PHP version : php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }');
+            ->andReturn('# Valet isolated PHP version: php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }');
 
         $files->shouldReceive('putAsUser')
             ->once()
             ->withArgs([
                 $siteMock->nginxPath('site1.test'),
-                '# Valet isolated PHP version : php@8.0'.PHP_EOL.'server { fastcgi_pass: valet80.sock }',
+                '# Valet isolated PHP version: php@8.0'.PHP_EOL.'server { fastcgi_pass: valet80.sock }',
             ]);
 
         $siteMock->isolate('site1.test', 'php@8.0');
@@ -682,7 +682,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             ->withArgs([
                 $siteMock->nginxPath('site2.test'),
                 Mockery::on(function ($argument) {
-                    return preg_match('/^# Valet isolated PHP version : php@8.0/', $argument)
+                    return preg_match('/^# Valet isolated PHP version: php@8.0/', $argument)
                         && preg_match('#fastcgi_pass "unix:.*/valet80.sock#', $argument)
                         && strpos($argument, 'server_name site2.test www.site2.test *.site2.test;') !== false;
                 }),
@@ -733,7 +733,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('get')
             ->once()
             ->with($siteMock->nginxPath('site1.test'))
-            ->andReturn('# Valet isolated PHP version : php@7.4');
+            ->andReturn('# Valet isolated PHP version: php@7.4');
         $this->assertEquals('74', resolve(Site::class)->customPhpVersion('site1.test'));
 
         // Site without any custom nginx config
@@ -757,28 +757,28 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         // When switching to php71, valet71.sock should be replaced with valet.sock;
         // isolation header should be prepended
         $this->assertEquals(
-            '# Valet isolated PHP version : 71'.PHP_EOL.'server { fastcgi_pass: valet71.sock }',
+            '# Valet isolated PHP version: 71'.PHP_EOL.'server { fastcgi_pass: valet71.sock }',
             $site->replaceSockFile('server { fastcgi_pass: valet71.sock }', '71')
         );
 
         // When switching to php72, valet.sock should be replaced with valet72.sock
         $this->assertEquals(
-            '# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }',
+            '# Valet isolated PHP version: 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }',
             $site->replaceSockFile('server { fastcgi_pass: valet.sock }', '72')
         );
 
         // When switching to php73 from php72, valet72.sock should be replaced with valet73.sock;
         // isolation header should be updated to php@7.3
         $this->assertEquals(
-            '# Valet isolated PHP version : 73'.PHP_EOL.'server { fastcgi_pass: valet73.sock }',
-            $site->replaceSockFile('# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }', '73')
+            '# Valet isolated PHP version: 73'.PHP_EOL.'server { fastcgi_pass: valet73.sock }',
+            $site->replaceSockFile('# Valet isolated PHP version: 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }', '73')
         );
 
         // When switching to php72 from php74, valet72.sock should be replaced with valet74.sock;
         // isolation header should be updated to php@7.4
         $this->assertEquals(
-            '# Valet isolated PHP version : php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }',
-            $site->replaceSockFile('# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet.sock }', 'php@7.4')
+            '# Valet isolated PHP version: php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }',
+            $site->replaceSockFile('# Valet isolated PHP version: 72'.PHP_EOL.'server { fastcgi_pass: valet.sock }', 'php@7.4')
         );
     }
 

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -659,13 +659,13 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('get')
             ->once()
             ->with($siteMock->nginxPath('site1.test'))
-            ->andReturn('# Valet isolated PHP version: php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }');
+            ->andReturn('# '.ISOLATED_PHP_VERSION.'=php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }');
 
         $files->shouldReceive('putAsUser')
             ->once()
             ->withArgs([
                 $siteMock->nginxPath('site1.test'),
-                '# Valet isolated PHP version: php@8.0'.PHP_EOL.'server { fastcgi_pass: valet80.sock }',
+                '# '.ISOLATED_PHP_VERSION.'=php@8.0'.PHP_EOL.'server { fastcgi_pass: valet80.sock }',
             ]);
 
         $siteMock->isolate('site1.test', 'php@8.0');
@@ -682,7 +682,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             ->withArgs([
                 $siteMock->nginxPath('site2.test'),
                 Mockery::on(function ($argument) {
-                    return preg_match('/^# Valet isolated PHP version: php@8.0/', $argument)
+                    return preg_match('/^# '.ISOLATED_PHP_VERSION.'=php@8.0/', $argument)
                         && preg_match('#fastcgi_pass "unix:.*/valet80.sock#', $argument)
                         && strpos($argument, 'server_name site2.test www.site2.test *.site2.test;') !== false;
                 }),
@@ -733,7 +733,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('get')
             ->once()
             ->with($siteMock->nginxPath('site1.test'))
-            ->andReturn('# Valet isolated PHP version: php@7.4');
+            ->andReturn('# '.ISOLATED_PHP_VERSION.'=php@7.4');
         $this->assertEquals('74', resolve(Site::class)->customPhpVersion('site1.test'));
 
         // Site without any custom nginx config
@@ -757,28 +757,28 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         // When switching to php71, valet71.sock should be replaced with valet.sock;
         // isolation header should be prepended
         $this->assertEquals(
-            '# Valet isolated PHP version: 71'.PHP_EOL.'server { fastcgi_pass: valet71.sock }',
+            '# '.ISOLATED_PHP_VERSION.'=71'.PHP_EOL.'server { fastcgi_pass: valet71.sock }',
             $site->replaceSockFile('server { fastcgi_pass: valet71.sock }', '71')
         );
 
         // When switching to php72, valet.sock should be replaced with valet72.sock
         $this->assertEquals(
-            '# Valet isolated PHP version: 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }',
+            '# '.ISOLATED_PHP_VERSION.'=72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }',
             $site->replaceSockFile('server { fastcgi_pass: valet.sock }', '72')
         );
 
         // When switching to php73 from php72, valet72.sock should be replaced with valet73.sock;
         // isolation header should be updated to php@7.3
         $this->assertEquals(
-            '# Valet isolated PHP version: 73'.PHP_EOL.'server { fastcgi_pass: valet73.sock }',
-            $site->replaceSockFile('# Valet isolated PHP version: 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }', '73')
+            '# '.ISOLATED_PHP_VERSION.'=73'.PHP_EOL.'server { fastcgi_pass: valet73.sock }',
+            $site->replaceSockFile('# '.ISOLATED_PHP_VERSION.'=72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }', '73')
         );
 
         // When switching to php72 from php74, valet72.sock should be replaced with valet74.sock;
         // isolation header should be updated to php@7.4
         $this->assertEquals(
-            '# Valet isolated PHP version: php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }',
-            $site->replaceSockFile('# Valet isolated PHP version: 72'.PHP_EOL.'server { fastcgi_pass: valet.sock }', 'php@7.4')
+            '# '.ISOLATED_PHP_VERSION.'=php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }',
+            $site->replaceSockFile('# '.ISOLATED_PHP_VERSION.'=72'.PHP_EOL.'server { fastcgi_pass: valet.sock }', 'php@7.4')
         );
     }
 

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -602,7 +602,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         // If site has an isolated PHP version for the site, it would replace .sock file
         $siteMock->shouldReceive('customPhpVersion')->with('site1.test')->andReturn('73')->once();
-        $siteMock->shouldReceive('replaceSockFile')->withArgs([Mockery::any(), 'valet73.sock', '73'])->once();
+        $siteMock->shouldReceive('replaceSockFile')->withArgs([Mockery::any(), '73'])->once();
         resolve(Site::class)->secure('site1.test');
 
         // For sites without an isolated PHP version, nothing should be replaced
@@ -757,28 +757,28 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         // When switching to php71, valet71.sock should be replaced with valet.sock;
         // isolation header should be prepended
         $this->assertEquals(
-            '# Valet isolated PHP version : 71'.PHP_EOL.'server { fastcgi_pass: valet.sock }',
-            $site->replaceSockFile('server { fastcgi_pass: valet71.sock }', 'valet.sock', '71')
+            '# Valet isolated PHP version : 71'.PHP_EOL.'server { fastcgi_pass: valet71.sock }',
+            $site->replaceSockFile('server { fastcgi_pass: valet71.sock }', '71')
         );
 
         // When switching to php72, valet.sock should be replaced with valet72.sock
         $this->assertEquals(
             '# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }',
-            $site->replaceSockFile('server { fastcgi_pass: valet.sock }', 'valet72.sock', '72')
+            $site->replaceSockFile('server { fastcgi_pass: valet.sock }', '72')
         );
 
         // When switching to php73 from php72, valet72.sock should be replaced with valet73.sock;
         // isolation header should be updated to php@7.3
         $this->assertEquals(
             '# Valet isolated PHP version : 73'.PHP_EOL.'server { fastcgi_pass: valet73.sock }',
-            $site->replaceSockFile('# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }', 'valet73.sock', '73')
+            $site->replaceSockFile('# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet72.sock }', '73')
         );
 
         // When switching to php72 from php74, valet72.sock should be replaced with valet74.sock;
         // isolation header should be updated to php@7.4
         $this->assertEquals(
             '# Valet isolated PHP version : php@7.4'.PHP_EOL.'server { fastcgi_pass: valet74.sock }',
-            $site->replaceSockFile('# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet.sock }', 'valet74.sock', 'php@7.4')
+            $site->replaceSockFile('# Valet isolated PHP version : 72'.PHP_EOL.'server { fastcgi_pass: valet.sock }', 'php@7.4')
         );
     }
 }


### PR DESCRIPTION
This PR modifies #1198, which is an update of #1192.

In #1192/#1198, `valet.sock` is always used by the global Valet PHP version, and then Valet sets up `valet80.sock` etc. for versions of PHP that aren't used globally but are used by isolated sites.

This PR makes it so that every PHP version used by Valet, global or not, sets up a `valet{version}.sock` file, and the global version is set by simply symlink-ing `valet.sock` to the version-specific `.sock` file.

This PR:
- Makes that symlink change
- Catches some work I missed in #1192 to the syntax in valet.php
- Cleans up `normalizePhpVersion` with a regex from @fuelingtheweb; again should've just applied to #1192
- Drops the tests that were covering the old pre-symlink behavior

Bugs in testing:
- [x] Somehow I saw `valet.sock` disappear twice in the middle of my testing, which broke all sites. Re-running `valet install` fixed it but I'm not sure what deleted it in the first place. I'll try to keep testing.