### PR TITLE
Bump valet version for CLI

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -32,7 +32,7 @@ if (is_dir(VALET_LEGACY_HOME_PATH) && ! is_dir(VALET_HOME_PATH)) {
  */
 Container::setInstance(new Container);
 
-$version = '2.18.10';
+$version = '3.0.0-alpha';
 
 $app = new Application('Laravel Valet', $version);
 


### PR DESCRIPTION
As of the `3.0.0-alpha` release yesterday `valet -V` returns the wrong value. This PR updates the global version for Valet. **Not:** this will likely need to be updated before tagging the next release (probably either as `3.0.0-alpha-2` or something similar)