### PR TITLE
Fix Homebrew PHP default www pools issue on Valet 3.0 alpha

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -92,6 +92,12 @@ class PhpFpm
 
         $this->files->ensureDirExists(dirname($fpmConfigFile), user());
 
+        // rename (to disable) old FPM Pool configuration, regardless of whether it's a default config or one customized by an older Valet version
+        $oldFile = dirname($fpmConfigFile).'/www.conf';
+        if (file_exists($oldFile)) {
+            rename($oldFile, $oldFile.'-backup');
+        }
+
         // Create FPM Config File from stub
         $contents = str_replace(
             ['VALET_USER', 'VALET_HOME_PATH', 'valet.sock'],

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -33,6 +33,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     public function test_fpm_is_configured_with_the_correct_user_group_and_port()
     {
         copy(__DIR__.'/files/fpm.conf', __DIR__.'/output/fpm.conf');
+        copy(__DIR__.'/files/fpm.conf', __DIR__.'/output/www.conf');
         mkdir(__DIR__.'/output/conf.d');
         copy(__DIR__.'/files/php-memory-limits.ini', __DIR__.'/output/conf.d/php-memory-limits.ini');
 
@@ -41,6 +42,10 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $this->assertStringContainsString(sprintf("\nuser = %s", user()), $contents);
         $this->assertStringContainsString("\ngroup = staff", $contents);
         $this->assertStringContainsString("\nlisten = ".VALET_HOME_PATH.'/valet72.sock', $contents);
+
+        // It should disable old or default FPM Pool configuration
+        $this->assertFileDoesNotExist(__DIR__.'/output/www.conf');
+        $this->assertFileExists(__DIR__.'/output/www.conf-backup');
     }
 
     public function test_it_can_generate_sock_file_name_from_php_version()


### PR DESCRIPTION
Previously Valet was disabling `www.conf` during the PHP version installation process. 

But [these lines of codes](https://github.com/laravel/valet/commit/eefc06b07f8ee57186ce898cacaaf33f9504d679#diff-d8e7b9c98bc6a045292f784be0d98860c26b463a1dd29f36256fed1d2ad62752L89) was probably deleted accidentally. Or intentionally? I'm not sure. 

Either way, I think bringing these lines back should fix https://github.com/laravel/valet/issues/1205.

### Steps to reproduce this error
1. Install a PHP version using `brew install php@x.x` or `valet use php@x.x` that is not present on the machine.
2. Homebrew would create a `/etc/php/x.x/php-fpm.d/www.conf` file automatically during the installation process.
3. That should create a conflict and would result in a 502 error in valet sites. 