### PR TITLE
Isolation compatibility with .valetphprc

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -540,8 +540,7 @@ You might also want to investigate your global Composer configs. Helpful command
             $site = basename(getcwd());
         }
 
-        if (! $phpVersion) {
-            $phpVersion = Site::phpRcVersion($site);
+        if (is_null($phpVersion) && $phpVersion = Site::phpRcVersion($site)) {
             info("Found '{$site}/.valetphprc' specifying version: {$phpVersion}");
         }
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -508,7 +508,15 @@ You might also want to investigate your global Composer configs. Helpful command
         if (! $phpVersion) {
             $site = basename(getcwd());
             $linkedVersion = Brew::linkedPhp();
-            $phpVersion = Site::phpRcVersion($site);
+
+            if ($phpVersion = Site::phpRcVersion($site)) {
+                info("Found '{$site}/.valetphprc' specifying version: {$phpVersion}");
+            } else {
+                $domain = $site.'.'.data_get(Configuration::read(), 'tld');
+                if ($phpVersion = PhpFpm::normalizePhpVersion(Site::customPhpVersion($domain))) {
+                    info("Found isolated site '{$domain}' specifying version: {$phpVersion}");
+                }
+            }
 
             if (! $phpVersion) {
                 return info("Valet is using {$linkedVersion}.");
@@ -517,8 +525,6 @@ You might also want to investigate your global Composer configs. Helpful command
             if ($linkedVersion == $phpVersion && ! $force) {
                 return info("Valet is already using {$linkedVersion}.");
             }
-
-            info("Found '{$site}/.valetphprc' specifying version: {$phpVersion}");
         }
 
         PhpFpm::useVersion($phpVersion, $force);
@@ -532,6 +538,11 @@ You might also want to investigate your global Composer configs. Helpful command
     $app->command('isolate [phpVersion] [--site=]', function ($phpVersion, $site = null) {
         if (! $site) {
             $site = basename(getcwd());
+        }
+
+        if (! $phpVersion) {
+            $phpVersion = Site::phpRcVersion($site);
+            info("Found '{$site}/.valetphprc' specifying version: {$phpVersion}");
         }
 
         PhpFpm::isolateDirectory($site, $phpVersion);


### PR DESCRIPTION
This PR adds two enhancements: 

1. Running `valet isolate` (without specifying a PHP version) on a directory where there's a `.valetphprc` file is present, Valet would recognize that. 
2. Running `valet use` (without specifying a PHP version) on an isolated site directory would change global PHP version to that isolated version. 

Fixes #1209

Tests: I'm not sure how do we test codes from `cli/valet.php` yet. I would be happy to add tests if I can get some guidance. 