### PR TITLE
fix: Drupal JSON:API support for non-standard url

### DIFF
--- a/cli/drivers/DrupalValetDriver.php
+++ b/cli/drivers/DrupalValetDriver.php
@@ -57,8 +57,8 @@ class DrupalValetDriver extends ValetDriver
     {
         $sitePath = $this->addSubdirectory($sitePath);
 
-        if (! isset($_GET['q']) && ! empty($uri) && $uri !== '/' && strpos($uri, '/jsonapi/') === false) {
-            $_GET['q'] = $uri;
+        if (! isset($_GET['Q']) && ! empty($uri) && $uri !== '/' && strpos($uri, '/jsonapi/') === false) {
+            $_GET['Q'] = $uri;
         }
 
         $matches = [];


### PR DESCRIPTION
This is related to issue https://github.com/laravel/valet/issues/771 which was fixed by https://github.com/laravel/valet/pull/705

Unfortunately, as [this comment in the PR shows](https://github.com/laravel/valet/pull/705/files#r284138311), this will break for anyone not using the default path setting for [Drupal's JSON:API module](https://www.drupal.org/docs/core-modules-and-themes/core-modules/jsonapi-module/api-overview), like me. In Drupal I changed the default `/jsonapi` path to `/api` and this broke Valet's integration.

Specifically, when making any API call to a JSON:API endpoint, I got the same error as in the original issue:

```
The following query parameters violate the JSON:API spec: 'q'.
```

In the original issue there was already [a fix proposed](https://github.com/laravel/valet/issues/771#issuecomment-485533478), which is to change the following in `DrupalValetDriver.php`:

`if (!isset($_GET['q']) && !empty($uri) && $uri !== '/') { $_GET['q'] = $uri; }`
to:
`if (!isset($_GET['Q']) && !empty($uri) && $uri !== '/') { $_GET['Q'] = $uri; }`

That's all this current PR does. It doesn't break anything existing, as Drupal otherwise does not care about the case-sensitivity of the `q` querystring parameter.

### Alternative solutions

There are a few other possibilities mentioned in https://www.drupal.org/project/jsonapi/issues/2984044 but they require patching Drupal core, or having Nginx config specific to Drupal (which isn't applicable to Valet).

Out of interesting, here's the official [Nginx config for Drupal](https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/)