### PR TITLE
When stopping Homebrew services, restore original folder permissions

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -232,7 +232,6 @@ class Brew
                     BREW_PREFIX . "/var/homebrew/linked/$service",
                 ];
 
-                // if the services aren't running: we'll restore the original permissions
                 $whoami = get_current_user();
 
                 foreach ($directories as $directory) {

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -224,6 +224,20 @@ class Brew
 
                 // stop the sudo version
                 $this->cli->quietly('sudo brew services stop '.$service);
+
+                // restore folder permissions: for each brew formula, these directories are owned by root:admin
+                $directories = [
+                    BREW_PREFIX . "/Cellar/$service",
+                    BREW_PREFIX . "/opt/$service",
+                    BREW_PREFIX . "/var/homebrew/linked/$service",
+                ];
+
+                // if the services aren't running: we'll restore the original permissions
+                $whoami = get_current_user();
+
+                foreach ($directories as $directory) {
+                    $this->cli->quietly("sudo chown -R {$whoami}:admin '$directory'");
+                }
             }
         }
     }

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -227,9 +227,9 @@ class Brew
 
                 // restore folder permissions: for each brew formula, these directories are owned by root:admin
                 $directories = [
-                    BREW_PREFIX . "/Cellar/$service",
-                    BREW_PREFIX . "/opt/$service",
-                    BREW_PREFIX . "/var/homebrew/linked/$service",
+                    BREW_PREFIX."/Cellar/$service",
+                    BREW_PREFIX."/opt/$service",
+                    BREW_PREFIX."/var/homebrew/linked/$service",
                 ];
 
                 $whoami = get_current_user();

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -161,9 +161,7 @@ class Nginx
      */
     public function stop()
     {
-        info('Stopping nginx...');
-
-        $this->cli->quietly('sudo brew services stop '.$this->brew->nginxServiceName());
+        $this->brew->stopService(['nginx']);
     }
 
     /**

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -122,6 +122,9 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $cli->shouldReceive('runAsUser')->once()->with('brew info dnsmasq --json')->andReturn('[{"name":"dnsmasq","full_name":"dnsmasq","aliases":[],"versioned_formulae":[],"versions":{"stable":"1"},"installed":[{"version":"1"}]}]');
         $cli->shouldReceive('quietly')->once()->with('brew services stop dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
+        $cli->shouldReceive('quietly')->once()->with("sudo chown -R ".user().":admin '".BREW_PREFIX."/Cellar/dnsmasq'");
+        $cli->shouldReceive('quietly')->once()->with("sudo chown -R ".user().":admin '".BREW_PREFIX."/opt/dnsmasq'");
+        $cli->shouldReceive('quietly')->once()->with("sudo chown -R ".user().":admin '".BREW_PREFIX."/var/homebrew/linked/dnsmasq'");
         swap(CommandLine::class, $cli);
         resolve(Brew::class)->stopService('dnsmasq');
     }

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -122,9 +122,9 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $cli->shouldReceive('runAsUser')->once()->with('brew info dnsmasq --json')->andReturn('[{"name":"dnsmasq","full_name":"dnsmasq","aliases":[],"versioned_formulae":[],"versions":{"stable":"1"},"installed":[{"version":"1"}]}]');
         $cli->shouldReceive('quietly')->once()->with('brew services stop dnsmasq');
         $cli->shouldReceive('quietly')->once()->with('sudo brew services stop dnsmasq');
-        $cli->shouldReceive('quietly')->once()->with("sudo chown -R ".user().":admin '".BREW_PREFIX."/Cellar/dnsmasq'");
-        $cli->shouldReceive('quietly')->once()->with("sudo chown -R ".user().":admin '".BREW_PREFIX."/opt/dnsmasq'");
-        $cli->shouldReceive('quietly')->once()->with("sudo chown -R ".user().":admin '".BREW_PREFIX."/var/homebrew/linked/dnsmasq'");
+        $cli->shouldReceive('quietly')->once()->with('sudo chown -R '.user().":admin '".BREW_PREFIX."/Cellar/dnsmasq'");
+        $cli->shouldReceive('quietly')->once()->with('sudo chown -R '.user().":admin '".BREW_PREFIX."/opt/dnsmasq'");
+        $cli->shouldReceive('quietly')->once()->with('sudo chown -R '.user().":admin '".BREW_PREFIX."/var/homebrew/linked/dnsmasq'");
         swap(CommandLine::class, $cli);
         resolve(Brew::class)->stopService('dnsmasq');
     }


### PR DESCRIPTION
As discussed in #1220, cleaning up after stopping Homebrew services that run as `root` is probably the best solution for now. This PR now causes permissions to be reset whenever a Homebrew service is stopped.

What's changed:

- Stopping any Homebrew service now restores the appropriate permissions for the Homebrew directories
- Stopping nginx now also happens via $this->brew (to avoid code duplication)

The tests were updated to reflect this change.

There is one thing I'm uncertain of — whether the group owner needs to be `wheel` or `admin`. Either is fine, so in these commits I opted to go for `admin`, since that seems to be the default group ownership Homebrew assigns by default.