### PR TITLE
Add PHP version to `valet links` output table

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -364,7 +364,7 @@ class Site
     /**
      * Get the PHP version for the given site.
      *
-     * @param  string  $url Site URL including the TLD
+     * @param  string  $url  Site URL including the TLD
      * @return string
      */
     public function getPhpVersion($url)

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -374,6 +374,7 @@ class Site
         if (empty($phpVersion)) {
             $phpVersion = PhpFpm::normalizePhpVersion($defaultPhpVersion);
         }
+
         return $phpVersion;
     }
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -166,7 +166,7 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('links', function () {
         $links = Site::links();
 
-        table(['Site', 'SSL', 'URL', 'Path'], $links->all());
+        table(['Site', 'SSL', 'URL', 'Path', 'PHP Version'], $links->all());
     })->descriptions('Display all of the registered Valet links');
 
     /**

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -425,6 +425,8 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     public function test_isolate_will_throw_if_site_is_not_parked_or_linked()
     {
         $brewMock = Mockery::mock(Brew::class);
+        $brewMock->shouldReceive('linkedPhp')->andReturn('php@7.4');
+
         $configMock = Mockery::mock(Configuration::class);
         $configMock->shouldReceive('read')->andReturn(['tld' => 'jamble', 'paths' => []]);
 

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use Illuminate\Container\Container;
+use Valet\Brew;
 use Valet\CommandLine;
 use Valet\Configuration;
 use Valet\Filesystem;
 use function Valet\resolve;
-use Valet\Brew;
 use Valet\Site;
 use function Valet\swap;
 use function Valet\user;

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -5,6 +5,7 @@ use Valet\CommandLine;
 use Valet\Configuration;
 use Valet\Filesystem;
 use function Valet\resolve;
+use Valet\Brew;
 use Valet\Site;
 use function Valet\swap;
 use function Valet\user;
@@ -68,17 +69,24 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('ensureDirExists')
             ->once()
             ->with($dirPath, user());
+        $files->shouldReceive('exists')->andReturn(false);
 
         $config = Mockery::mock(Configuration::class);
         $config->shouldReceive('read')
             ->once()
             ->andReturn(['tld' => 'local']);
 
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')->andReturn('php@8.1');
+
         swap(Filesystem::class, $files);
         swap(Configuration::class, $config);
+        swap(Brew::class, $brew);
 
         /** @var Site $site */
         $site = resolve(Site::class);
+
+        $phpVersion = $site->brew->linkedPhp();
 
         $certs = Mockery::mock(\Illuminate\Support\Collection::class);
         $certs->shouldReceive('has')
@@ -96,12 +104,14 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             'secured' => '',
             'url' => 'http://sitetwo.local',
             'path' => $dirPath.'/sitetwo',
+            'phpVersion' => $phpVersion,
         ], $sites->first());
         $this->assertSame([
             'site' => 'sitethree',
             'secured' => ' X',
             'url' => 'https://sitethree.local',
             'path' => $dirPath.'/sitethree',
+            'phpVersion' => $phpVersion,
         ], $sites->last());
     }
 
@@ -125,17 +135,24 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('ensureDirExists')
             ->once()
             ->with($dirPath, user());
+        $files->shouldReceive('exists')->andReturn(false);
 
         $config = Mockery::mock(Configuration::class);
         $config->shouldReceive('read')
             ->once()
             ->andReturn(['tld' => 'local']);
 
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')->andReturn('php@8.1');
+
         swap(Filesystem::class, $files);
         swap(Configuration::class, $config);
+        swap(Brew::class, $brew);
 
         /** @var Site $site */
         $site = resolve(Site::class);
+
+        $phpVersion = $site->brew->linkedPhp();
 
         $sites = $site->getSites($dirPath, collect());
         $this->assertCount(1, $sites);
@@ -144,6 +161,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             'secured' => '',
             'url' => 'http://sitetwo.local',
             'path' => $dirPath.'/sitetwo',
+            'phpVersion' => $phpVersion,
         ], $sites->first());
     }
 
@@ -162,17 +180,24 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('ensureDirExists')
             ->once()
             ->with($dirPath, user());
+        $files->shouldReceive('exists')->andReturn(false);
 
         $config = Mockery::mock(Configuration::class);
         $config->shouldReceive('read')
             ->once()
             ->andReturn(['tld' => 'local']);
 
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')->andReturn('php@8.1');
+
         swap(Filesystem::class, $files);
         swap(Configuration::class, $config);
+        swap(Brew::class, $brew);
 
         /** @var Site $site */
         $site = resolve(Site::class);
+
+        $phpVersion = $site->brew->linkedPhp();
 
         $sites = $site->getSites($dirPath, collect());
         $this->assertCount(1, $sites);
@@ -181,6 +206,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             'secured' => '',
             'url' => 'http://siteone.local',
             'path' => $dirPath.'/siteone',
+            'phpVersion' => $phpVersion,
         ], $sites->first());
     }
 
@@ -204,17 +230,24 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files->shouldReceive('ensureDirExists')
             ->once()
             ->with($dirPath, user());
+        $files->shouldReceive('exists')->andReturn(false);
 
         $config = Mockery::mock(Configuration::class);
         $config->shouldReceive('read')
             ->once()
             ->andReturn(['tld' => 'local']);
 
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')->andReturn('php@8.1');
+
         swap(Filesystem::class, $files);
         swap(Configuration::class, $config);
+        swap(Brew::class, $brew);
 
         /** @var Site $site */
         $site = resolve(Site::class);
+
+        $phpVersion = $site->brew->linkedPhp();
 
         $sites = $site->getSites($dirPath, collect());
         $this->assertCount(1, $sites);
@@ -223,6 +256,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             'secured' => '',
             'url' => 'http://siteone.local',
             'path' => $linkedPath,
+            'phpVersion' => $phpVersion,
         ], $sites->first());
     }
 
@@ -534,6 +568,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         swap(Configuration::class, $config);
 
         $siteMock = Mockery::mock(Site::class, [
+            resolve(Brew::class),
             resolve(Configuration::class),
             resolve(CommandLine::class),
             resolve(Filesystem::class),
@@ -585,6 +620,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         swap(Configuration::class, $config);
 
         $siteMock = Mockery::mock(Site::class, [
+            resolve(Brew::class),
             resolve(Configuration::class),
             resolve(CommandLine::class),
             resolve(Filesystem::class),
@@ -609,6 +645,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $config = Mockery::mock(Configuration::class);
 
         $siteMock = Mockery::mock(Site::class, [
+            resolve(Brew::class),
             $config,
             Mockery::mock(CommandLine::class),
             $files,
@@ -641,6 +678,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $cli = Mockery::mock(CommandLine::class);
 
         $siteMock = Mockery::mock(Site::class, [
+            resolve(Brew::class),
             $config,
             $cli,
             $files,
@@ -662,12 +700,40 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         resolve(Site::class)->unsecure('site2.test');
     }
 
+    public function test_php_version_returns_correct_version_for_site()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')->andReturn(false);
+
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')->andReturn('php@8.1');
+
+        swap(Brew::class, $brew);
+
+        $site = Mockery::mock(Site::class, [
+            resolve(Brew::class),
+            Mockery::mock(Configuration::class),
+            Mockery::mock(CommandLine::class),
+            $files,
+        ])->makePartial();
+        $site->shouldReceive('customPhpVersion')->with('site1.test')->andReturn('73')->once();
+        $site->shouldReceive('customPhpVersion')->with('site2.test')->andReturn(null)->once();
+
+        swap(Site::class, $site);
+
+        $phpVersion = $site->brew->linkedPhp();
+
+        $this->assertEquals('php@7.3', $site->getPhpVersion('site1.test'));
+        $this->assertEquals($phpVersion, $site->getPhpVersion('site2.test'));
+    }
+
     public function test_can_install_nginx_site_config_for_specific_php_version()
     {
         $files = Mockery::mock(Filesystem::class);
         $config = Mockery::mock(Configuration::class);
 
         $siteMock = Mockery::mock(Site::class, [
+            resolve(Brew::class),
             $config,
             resolve(CommandLine::class),
             $files,
@@ -719,6 +785,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files = Mockery::mock(Filesystem::class);
 
         $siteMock = Mockery::mock(Site::class, [
+            resolve(Brew::class),
             resolve(Configuration::class),
             resolve(CommandLine::class),
             $files,
@@ -744,6 +811,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $files = Mockery::mock(Filesystem::class);
 
         $siteMock = Mockery::mock(Site::class, [
+            resolve(Brew::class),
             resolve(Configuration::class),
             resolve(CommandLine::class),
             $files,
@@ -829,6 +897,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         swap(Filesystem::class, $files);
 
         $siteMock = Mockery::mock(Site::class, [
+            resolve(Brew::class),
             resolve(Configuration::class),
             resolve(CommandLine::class),
             resolve(Filesystem::class),


### PR DESCRIPTION
Adds a new column to the `valet links` CLI command output to show which PHP is version running on each site. This gives users who run multiple sites with isolated PHP versions on each a quick view of which PHP version is running on each site.