### PR TITLE
Remove preg_replace deprecation warning

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -324,7 +324,7 @@ class PhpFpm
      */
     public function normalizePhpVersion($version)
     {
-        return preg_replace('/(?:php@?)?([0-9+])(?:.)?([0-9+])/i', 'php@$1.$2', $version);
+        return preg_replace('/(?:php@?)?([0-9+])(?:.)?([0-9+])/i', 'php@$1.$2', (string) $version);
     }
 
     /**

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -63,6 +63,8 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $this->assertEquals('php@8.1', resolve(PhpFpm::class)->normalizePhpVersion('php81'));
         $this->assertEquals('php@8.1', resolve(PhpFpm::class)->normalizePhpVersion('8.1'));
         $this->assertEquals('php@8.1', resolve(PhpFpm::class)->normalizePhpVersion('81'));
+        $this->assertEquals('', resolve(PhpFpm::class)->normalizePhpVersion(''));
+        $this->assertEquals('', resolve(PhpFpm::class)->normalizePhpVersion(null));
     }
 
     public function test_it_validates_php_versions_when_installed()


### PR DESCRIPTION
Resolves https://github.com/laravel/valet/issues/1241


`Site::getSites()` is now adding "PHP Version" output. Introduced in https://github.com/laravel/valet/pull/1229. On that process Site:getPhpVersion() is passing `null` to `PhpFpm::normalizePhpVersion()` that is breaking  commands like `valet which-php` This PR should fix that. 