### PR TITLE
Add support for custom site domains to valet php and valet composer

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -608,7 +608,7 @@ You might also want to investigate your global Composer configs. Helpful command
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
     })->descriptions("Proxy PHP commands with isolated site's PHP executable", [
         'command' => "Command to run with isolated site's PHP executable. If you wish to pass a --site flag to this command then encapsulate the entire command within a string",
-        '--site' => 'Specify the site (e.g. if the site isn\'t linked as its directory name)'
+        '--site' => 'Specify the site (e.g. if the site isn\'t linked as its directory name)',
     ]);
 
     /**
@@ -618,7 +618,7 @@ You might also want to investigate your global Composer configs. Helpful command
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
     })->descriptions("Proxy Composer commands with isolated site's PHP executable", [
         'command' => "Composer command to run with isolated site's PHP executable",
-        '--site' => 'Specify the site (e.g. if the site isn\'t linked as its directory name)'
+        '--site' => 'Specify the site (e.g. if the site isn\'t linked as its directory name)',
     ]);
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -604,19 +604,21 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * Proxy commands through to an isolated site's version of PHP.
      */
-    $app->command('php [command]', function ($command) {
+    $app->command('php [command] [--site=]', function ($command, $site = null) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
     })->descriptions("Proxy PHP commands with isolated site's PHP executable", [
-        'command' => "Command to run with isolated site's PHP executable",
+        'command' => "Command to run with isolated site's PHP executable. If you wish to pass a --site flag to this command then encapsulate the entire command within a string",
+        '--site' => 'Specify the site (e.g. if the site isn\'t linked as its directory name)'
     ]);
 
     /**
      * Proxy commands through to an isolated site's version of Composer.
      */
-    $app->command('composer [command]', function ($command) {
+    $app->command('composer [command] [--site=]', function ($command, $site = null) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
     })->descriptions("Proxy Composer commands with isolated site's PHP executable", [
         'command' => "Composer command to run with isolated site's PHP executable",
+        '--site' => 'Specify the site (e.g. if the site isn\'t linked as its directory name)'
     ]);
 
     /**

--- a/valet
+++ b/valet
@@ -82,14 +82,53 @@ then
 # Proxy PHP commands to the "php" executable on the isolated site
 elif [[ "$1" = "php" ]]
 then
-    $(php "$DIR/cli/valet.php" which-php) "${@:2}"
+
+    # Find and extract an optional flag "--site=foo" to cater for sites that use
+    # a custom domain. The "=" after the flag is mandatory "--site foo" will not work.
+    SITE=""
+    PARSED_ARGS=()
+    for i in "$@"; do
+        case $i in
+        --site=*)
+          SITE="${i#*=}"
+          shift
+          ;;
+        *)    # All other input / commands / options
+        PARSED_ARGS+=("$i") # save it in an array for later
+        shift
+        ;;
+        esac
+    done
+
+    echo "${PARSED_ARGS[@]}"
+    exit
+
+    $(php "$DIR/cli/valet.php" which-php $SITE) "${PARSED_ARGS[@]:1}"
 
     exit
 
 # Proxy Composer commands with the "php" executable on the isolated site
 elif [[ "$1" = "composer" ]]
 then
-    $(php "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
+
+    # Find and extract an optional flag "--site=foo" to cater for sites that use
+    # a custom domain. The "=" after the flag is mandatory "--site foo" will not work.
+    SITE=""
+    PARSED_ARGS=()
+    for i in "$@"; do
+        case $i in
+        --site=*)
+          SITE="${i#*=}"
+          shift
+          ;;
+        *)    # All other input / commands / options
+        PARSED_ARGS+=("$i") # save it in an array for later
+        shift
+        ;;
+        esac
+    done
+
+    $(php "$DIR/cli/valet.php" which-php $SITE) $(which composer) "${PARSED_ARGS[@]:1}"
 
     exit
 

--- a/valet
+++ b/valet
@@ -100,9 +100,6 @@ then
         esac
     done
 
-    echo "${PARSED_ARGS[@]}"
-    exit
-
     $(php "$DIR/cli/valet.php" which-php $SITE) "${PARSED_ARGS[@]:1}"
 
     exit


### PR DESCRIPTION
Fixes #1272

Adds support for passing in a custom sitename via the flag `--site=sitename`
- Could be more flexible, at this point the '=' is mandatory
- Command help updated, arguments added etc
- Code is repeated in two place, I thought it more likely that potential flags / checks diverge over time and didn't want to prematurely abstract

Potential issues
- someone calling a php command that requires a "--site" flag has to encapsulate the whole command as a string to pass it in - e.g `valet php 'cms_cli do:thing --site=radsite.test' --site=radsite.test`

Other considerations
- It would be better if the isolate function wasn't so tied to dir names - keeping a config file of isolated sites vs just parsing nginx configs seems better to me in the long run but is a larger and more serious refactor of valet.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
