### PR TITLE
Enable local network sharing

### DIFF
--- a/server.php
+++ b/server.php
@@ -104,6 +104,21 @@ $valetConfig = json_decode(
 );
 
 /**
+ * If the HTTP_HOST is an IP address, check the start of the REQUEST_URI for a
+ * valid hostname, extract and use it as the effective HTTP_HOST in place
+ * of the IP. It enables the use of Valet in a local network.
+ */
+if (preg_match('/^([0-9]+\.){3}[0-9]+$/', $_SERVER['HTTP_HOST'])) {
+    $uri = ltrim($_SERVER['REQUEST_URI'], '/');
+
+    if (preg_match('/^[-.0-9a-zA-Z]+\.'. $valetConfig['tld'] .'/', $uri, $matches)) {
+        $host = $matches[0];
+        $_SERVER['HTTP_HOST'] = $host;
+        $_SERVER['REQUEST_URI'] = str_replace($host, '', $uri);
+    }
+}
+
+/**
  * Parse the URI and site / host for the incoming request.
  */
 $uri = rawurldecode(

--- a/server.php
+++ b/server.php
@@ -111,7 +111,7 @@ $valetConfig = json_decode(
 if (preg_match('/^([0-9]+\.){3}[0-9]+$/', $_SERVER['HTTP_HOST'])) {
     $uri = ltrim($_SERVER['REQUEST_URI'], '/');
 
-    if (preg_match('/^[-.0-9a-zA-Z]+\.'. $valetConfig['tld'] .'/', $uri, $matches)) {
+    if (preg_match('/^[-.0-9a-zA-Z]+\.'.$valetConfig['tld'].'/', $uri, $matches)) {
         $host = $matches[0];
         $_SERVER['HTTP_HOST'] = $host;
         $_SERVER['REQUEST_URI'] = str_replace($host, '', $uri);


### PR DESCRIPTION
This PR enables a rudimentary version of local network sharing with the fix mentioned in (https://github.com/laravel/valet/issues/440#issuecomment-579830736). This pull request was suggested in (https://github.com/laravel/docs/pull/8267) by @driesvints.

I've tested the fix locally and it does enable local network sharing, though it's rudimentary at best since assets don't load properly given the URL doesn't match.

For example, if I have `http://laravel.test` and access is via local network sharing `http://192.168.1.111/laravel.test`, the site does load. But the asset URLs will use `http://laravel.test` and thus not load. I'm not sure if that is due to the `@vite` directive or something else. The same thing happens with the `asset` helper, which might be because of the `APP_URL`.

I did manage to get the CSS, JavaScript, and HMR working with Vite by starting the Vite server using the local IP address passed in as the host.

```bash
npm run dev -- --host 192.168.1.111
```

Since Vite adds the IP address in the `script` and `link` files, the IP address used for the host must be an address that can be accessed by all devices over the network, The safest route is to use the same IP address of the device you're trying to expose.

Not sure how to go about fixing the issue of built assets not loading due to the URL not matching though. 🤷‍♂️