### PR TITLE
Fix bedrockvaletdriver

### DIFF
--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -48,6 +48,7 @@ class BedrockValetDriver extends BasicValetDriver
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
         $_SERVER['PHP_SELF'] = $uri;
+        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
         return parent::frontControllerPath(

--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -50,17 +50,11 @@ class BedrockValetDriver extends BasicValetDriver
         $_SERVER['PHP_SELF'] = $uri;
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
-        if (strpos($uri, '/wp/') === 0) {
-            return is_dir($sitePath.'/web'.$uri)
-                            ? $sitePath.'/web'.$this->forceTrailingSlash($uri).'/index.php'
-                            : $sitePath.'/web'.$uri;
-        }
-
-        if ($uri !== '/' && file_exists($sitePath.'/web'.$uri)) {
-            return $sitePath.'/web'.$uri;
-        }
-
-        return $sitePath.'/web/index.php';
+        return parent::frontControllerPath(
+            $sitePath . '/web',
+            $siteName,
+            $this->forceTrailingSlash($uri)
+        );
     }
 
     /**

--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -52,7 +52,7 @@ class BedrockValetDriver extends BasicValetDriver
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
         return parent::frontControllerPath(
-            $sitePath . '/web',
+            $sitePath.'/web',
             $siteName,
             $this->forceTrailingSlash($uri)
         );


### PR DESCRIPTION
I'd experienced an issue with the bedrock valet driver for awhile specific to the custom wp-admin route provided by plugins, like the hidden backend feature in iThemes security. 

I finally dug into it and found that the driver is out of sync with the WordPress driver and had a few headers missing from the other drivers. So I tested updating it to match the WordPress driver and it fixed my problem. 

This uses the built in routing available instead of assuming that the folder has an index.php or is part of WordPress core. 

If accepted please kindly add [hacktoberfest-accepted] label too, thanks.