### PR TITLE
Enabling securing custom domains, by not adding default TLD to $domain when explicitly provided

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1088,7 +1088,7 @@ class Site
         //     return $parked['site'];
         // }
 
-        return ($domain ?: $this->host(getcwd())).'.'.$this->config->read()['tld'];
+        return ($domain ?: $this->host(getcwd()).'.'.$this->config->read()['tld']);
     }
 
     /**


### PR DESCRIPTION
Update the domain() function to include the default TLD only if the $domain variable is not given explicitly. If the $domain variable is given, just return that instead of sticking the default TLD on top. This feature lets you secure custom domains, e.g. "valet secure www.mywebsite.com" (if you also add www.mywebsite.com to your hosts file and create a symlink or folder in the Valet site directory, of course).

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
