### PR TITLE
fix for unwanted removal of .tld from site name if it isn't at the end

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -208,7 +208,10 @@ class Site
             $directory = $this->host(getcwd());
         }
 
-        $directory = str_replace('.'.$tld, '', $directory); // Remove .tld from sitename if it was provided
+        $length = strlen('.'.$tld);
+        if(substr($directory,-$length) === '.'.$tld){
+            $directory = substr($directory,0, -$length);// str_replace('.'.$tld, '', $directory); // Remove .tld from sitename if it was provided
+        }
 
         if (! $this->parked()->merge($this->links())->where('site', $directory)->count() > 0) {
             throw new DomainException("The [{$directory}] site could not be found in Valet's site list.");

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -596,6 +596,12 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
                 'url' => 'http://site2.test',
                 'path' => '/Users/name/code/site2',
             ],
+            'portal.test-site' => [
+                'site' => 'portal.test-site',
+                'secured' => 'X',
+                'url' => 'http://portal.test-site.test',
+                'path' => '/Users/name/code/portal.test-site',
+            ],
         ]));
 
         $siteMock->shouldReceive('host')->andReturn('site1');
@@ -610,6 +616,9 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals('site2.test', $site->getSiteUrl('site2'));
         $this->assertEquals('site2.test', $site->getSiteUrl('site2.test'));
+
+        $this->assertEquals('portal.test-site.test', $site->getSiteUrl('portal.test-site'));
+        $this->assertEquals('portal.test-site.test', $site->getSiteUrl('portal.test-site.test'));
     }
 
     public function test_it_throws_getting_nonexistent_site()


### PR DESCRIPTION
o added check if tld is found at the end and if so remove the tld
o added extra test to prove it works

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
