### PR TITLE
When formatting provided site name, only remove .tld if it's at the end

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -208,7 +208,10 @@ class Site
             $directory = $this->host(getcwd());
         }
 
-        $directory = str_replace('.'.$tld, '', $directory); // Remove .tld from sitename if it was provided
+        $length = strlen('.'.$tld);
+        if (substr($directory, -$length) === '.'.$tld) {
+            $directory = substr($directory, 0, -$length); // Remove .tld from sitename if it was provided
+        }
 
         if (! $this->parked()->merge($this->links())->where('site', $directory)->count() > 0) {
             throw new DomainException("The [{$directory}] site could not be found in Valet's site list.");

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -208,9 +208,9 @@ class Site
             $directory = $this->host(getcwd());
         }
 
-        $length = strlen('.'.$tld);
-        if (substr($directory, -$length) === '.'.$tld) {
-            $directory = substr($directory, 0, -$length); // Remove .tld from sitename if it was provided
+        // Remove .tld from the end of sitename if it was provided
+        if (ends_with($directory, '.'.$tld) {
+            $directory = substr($directory, 0, -(strlen('.'.$tld)));
         }
 
         if (! $this->parked()->merge($this->links())->where('site', $directory)->count() > 0) {

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -209,7 +209,7 @@ class Site
         }
 
         // Remove .tld from the end of sitename if it was provided
-        if (ends_with($directory, '.'.$tld) {
+        if (ends_with($directory, '.'.$tld)) {
             $directory = substr($directory, 0, -(strlen('.'.$tld)));
         }
 

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -596,6 +596,12 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
                 'url' => 'http://site2.test',
                 'path' => '/Users/name/code/site2',
             ],
+            'portal.test-site' => [
+                'site' => 'portal.test-site',
+                'secured' => 'X',
+                'url' => 'http://portal.test-site.test',
+                'path' => '/Users/name/code/portal.test-site',
+            ],
         ]));
 
         $siteMock->shouldReceive('host')->andReturn('site1');
@@ -610,6 +616,9 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals('site2.test', $site->getSiteUrl('site2'));
         $this->assertEquals('site2.test', $site->getSiteUrl('site2.test'));
+
+        $this->assertEquals('portal.test-site.test', $site->getSiteUrl('portal.test-site'));
+        $this->assertEquals('portal.test-site.test', $site->getSiteUrl('portal.test-site.test'));
     }
 
     public function test_it_throws_getting_nonexistent_site()


### PR DESCRIPTION
(copied from Issue #1298 for context):

**Description:**
TL;DR: If your site name contains your TLD (e.g. if your TLD is `.test` and your site name contains `.test`) it will be removed inappropriately.

In line with our regular site setup we have the same locally with valet:
- portal.test-work.test
- welcome.test-work.test

The moment it goes wrong is when I try to use the `isolate` option. Then I get an error: `portal-work isn't found as site name`. That is correct as it is indeed `portal.test-work`. The problem seems to be that `.test` is removed not just at the end, but just as it is found in the site name.

Searches on internet doesn't bring any solutions to the table.

**Steps To Reproduce:**
- add a link to your project with a specific site name in line with ours e.g. `portal.test-work`
- try to isolate the site with any php version
- you should get the error that the site name isn't found in the list of sites

**Solutions in this PR:**

- [x] Check if tld is at the end of the site name and, if so, remove it
- [x] Add corresponding test

Fixes #1295, Fixes #1298.
