### PR TITLE
Secure custom domains

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1078,12 +1078,11 @@ class Site
      *
      * @return string
      */
-    public function domain($domain)
+    public function domain($domain='')
     {
     	if (str_contains($domain, '.')) {
     		return $domain;
     	}
-
         return ($domain ?: $this->host(getcwd())) .'.'.$this->config->read()['tld'];
     }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1080,15 +1080,11 @@ class Site
      */
     public function domain($domain)
     {
-        // if ($this->parked()->pluck('site')->contains($domain)) {
-        //     return $domain;
-        // }
+    	if (str_contains($domain, '.')) {
+    		return $domain;
+    	}
 
-        // if ($parked = $this->parked()->where('path', getcwd())->first()) {
-        //     return $parked['site'];
-        // }
-
-        return ($domain ?: $this->host(getcwd())).'.'.$this->config->read()['tld'];
+        return ($domain ?: $this->host(getcwd())) .'.'.$this->config->read()['tld'];
     }
 
     /**

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1078,9 +1078,9 @@ class Site
      *
      * @return string
      */
-    public function domain($domain='')
+    public function domain($domain)
     {
-    	if (str_contains($domain, '.')) {
+    	if (is_string($domain) && str_contains($domain, '.')) {
     		return $domain;
     	}
         return ($domain ?: $this->host(getcwd())) .'.'.$this->config->read()['tld'];

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1080,7 +1080,7 @@ class Site
      */
     public function domain($domain)
     {
-    	if (is_string($domain) && str_contains($domain, '.')) {
+    	if (is_string($domain) && (strpos($domain, '.') !== false)) {
     		return $domain;
     	}
         return ($domain ?: $this->host(getcwd())) .'.'.$this->config->read()['tld'];

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1080,10 +1080,11 @@ class Site
      */
     public function domain($domain)
     {
-    	if (is_string($domain) && (strpos($domain, '.') !== false)) {
-    		return $domain;
-    	}
-        return ($domain ?: $this->host(getcwd())) .'.'.$this->config->read()['tld'];
+        if (is_string($domain) && (strpos($domain, '.') !== false)) {
+            return $domain;
+        }
+
+        return ($domain ?: $this->host(getcwd())).'.'.$this->config->read()['tld'];
     }
 
     /**

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -610,12 +610,33 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals('site2.test', $site->getSiteUrl('site2'));
         $this->assertEquals('site2.test', $site->getSiteUrl('site2.test'));
+    }
 
-        $this->assertEquals('site1.test', $site->domain(''));
+    public function test_site_correctly_generates_domain_names()
+    {
 
-        $this->assertEquals('site2.test', $site->domain('site2'));
-    	$this->assertEquals('site2.test', $site->domain('site2.test'));
-    	$this->assertEquals('www.example.com', $site->domain('www.example.com'));
+    	$config = Mockery::mock(Configuration::class);
+
+        swap(Configuration::class, $config);
+
+        $siteMock = Mockery::mock(Site::class, [
+            resolve(Brew::class),
+            resolve(Configuration::class),
+            resolve(CommandLine::class),
+            resolve(Filesystem::class),
+        ])->makePartial();
+
+        swap(Site::class, $siteMock);
+
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test', 'loopback' => VALET_LOOPBACK, 'paths' => []]);
+
+ 		$siteMock->shouldReceive('host')->andReturn('site1');
+
+    	$this->assertEquals('site1.test', $siteMock->domain(null));
+        $this->assertEquals('site2.test', $siteMock->domain('site2'));
+    	$this->assertEquals('site2.test', $siteMock->domain('site2.test'));
+    	$this->assertEquals('www.example.com', $siteMock->domain('www.example.com'));
     }
 
     public function test_it_throws_getting_nonexistent_site()

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -614,8 +614,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
     public function test_site_correctly_generates_domain_names()
     {
-
-    	$config = Mockery::mock(Configuration::class);
+        $config = Mockery::mock(Configuration::class);
 
         swap(Configuration::class, $config);
 
@@ -631,12 +630,12 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $config->shouldReceive('read')
             ->andReturn(['tld' => 'test', 'loopback' => VALET_LOOPBACK, 'paths' => []]);
 
- 		$siteMock->shouldReceive('host')->andReturn('site1');
+        $siteMock->shouldReceive('host')->andReturn('site1');
 
-    	$this->assertEquals('site1.test', $siteMock->domain(null));
+        $this->assertEquals('site1.test', $siteMock->domain(null));
         $this->assertEquals('site2.test', $siteMock->domain('site2'));
-    	$this->assertEquals('site2.test', $siteMock->domain('site2.test'));
-    	$this->assertEquals('www.example.com', $siteMock->domain('www.example.com'));
+        $this->assertEquals('site2.test', $siteMock->domain('site2.test'));
+        $this->assertEquals('www.example.com', $siteMock->domain('www.example.com'));
     }
 
     public function test_it_throws_getting_nonexistent_site()

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -610,6 +610,12 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals('site2.test', $site->getSiteUrl('site2'));
         $this->assertEquals('site2.test', $site->getSiteUrl('site2.test'));
+
+        $this->assertEquals('site1.test', $site->domain(''));
+
+        $this->assertEquals('site2.test', $site->domain('site2'));
+    	$this->assertEquals('site2.test', $site->domain('site2.test'));
+    	$this->assertEquals('www.example.com', $site->domain('www.example.com'));
     }
 
     public function test_it_throws_getting_nonexistent_site()


### PR DESCRIPTION
I have attempted a new pull request, one that includes a test and takes the feedback from [#1294](https://github.com/laravel/valet/pull/1294) into account. Apologies if this is simply an unwanted feature.

Update the domain() function to include the default TLD only if the $domain variable does not include a dot. This lets you secure custom domains, e.g. "valet secure [www.mywebsite.com](http://www.mywebsite.com/)". (You would also have to add [www.mywebsite.com](http://www.mywebsite.com/) to your hosts file and create a symlink or folder in the Valet site directory, of course.)

