### PR TITLE
If a site is serving from public, check for individual PHP files in the public directory

### DIFF
--- a/cli/drivers/BasicValetDriver.php
+++ b/cli/drivers/BasicValetDriver.php
@@ -68,6 +68,22 @@ class BasicValetDriver extends ValetDriver
             }
         }
 
+        $publicDynamicCandidates = [
+            $this->asActualFile($sitePath.'/public', $uri),
+            $this->asPhpIndexFileInDirectory($sitePath.'/public', $uri),
+            $this->asHtmlIndexFileInDirectory($sitePath.'/public', $uri),
+        ];
+
+        foreach ($publicDynamicCandidates as $candidate) {
+            if ($this->isActualFile($candidate)) {
+                $_SERVER['SCRIPT_FILENAME'] = $candidate;
+                $_SERVER['SCRIPT_NAME'] = str_replace($sitePath.'/public', '', $candidate);
+                $_SERVER['DOCUMENT_ROOT'] = $sitePath.'/public';
+
+                return $candidate;
+            }
+        }
+
         $fixedCandidatesAndDocroots = [
             $this->asRootPhpIndexFile($sitePath) => $sitePath,
             $this->asPublicPhpIndexFile($sitePath) => $sitePath.'/public',

--- a/cli/drivers/BasicValetDriver.php
+++ b/cli/drivers/BasicValetDriver.php
@@ -68,17 +68,19 @@ class BasicValetDriver extends ValetDriver
             }
         }
 
+        $sitePathPublic = $sitePath.'/public';
+
         $publicDynamicCandidates = [
-            $this->asActualFile($sitePath.'/public', $uri),
-            $this->asPhpIndexFileInDirectory($sitePath.'/public', $uri),
-            $this->asHtmlIndexFileInDirectory($sitePath.'/public', $uri),
+            $this->asActualFile($sitePathPublic, $uri),
+            $this->asPhpIndexFileInDirectory($sitePathPublic, $uri),
+            $this->asHtmlIndexFileInDirectory($sitePathPublic, $uri),
         ];
 
         foreach ($publicDynamicCandidates as $candidate) {
             if ($this->isActualFile($candidate)) {
                 $_SERVER['SCRIPT_FILENAME'] = $candidate;
-                $_SERVER['SCRIPT_NAME'] = str_replace($sitePath.'/public', '', $candidate);
-                $_SERVER['DOCUMENT_ROOT'] = $sitePath.'/public';
+                $_SERVER['SCRIPT_NAME'] = str_replace($sitePathPublic, '', $candidate);
+                $_SERVER['DOCUMENT_ROOT'] = $sitePathPublic;
 
                 return $candidate;
             }
@@ -86,8 +88,8 @@ class BasicValetDriver extends ValetDriver
 
         $fixedCandidatesAndDocroots = [
             $this->asRootPhpIndexFile($sitePath) => $sitePath,
-            $this->asPublicPhpIndexFile($sitePath) => $sitePath.'/public',
-            $this->asPublicHtmlIndexFile($sitePath) => $sitePath.'/public',
+            $this->asPublicPhpIndexFile($sitePath) => $sitePathPublic,
+            $this->asPublicHtmlIndexFile($sitePath) => $sitePathPublic,
         ];
 
         foreach ($fixedCandidatesAndDocroots as $candidate => $docroot) {


### PR DESCRIPTION
Currently the public directory is not searched for the requested php file.

Example directory structure:
```
- my-project
|- public
 |- myscript.php
 |- index.php
```

A `GET http://my-project.test/myscript.php` would currently execute `my-project/public/index.php` because the `myscript.php` file is only searched at the `$sitePath`, which in this case is `my-project/`.