### PR TITLE
Add `set-ngrok-token` command

### DIFF
--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -75,7 +75,7 @@ class Ngrok
     /**
      * Set the Ngrok auth token.
      *
-     * @param string $token
+     * @param  string  $token
      * @return string
      */
     public function setToken($token)

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -8,10 +8,16 @@ use GuzzleHttp\Client;
 
 class Ngrok
 {
+    public $cli;
     public $tunnelsEndpoints = [
         'http://127.0.0.1:4040/api/tunnels',
         'http://127.0.0.1:4041/api/tunnels',
     ];
+
+    public function __construct(CommandLine $cli)
+    {
+        $this->cli = $cli;
+    }
 
     /**
      * Get the current tunnel URL from the Ngrok API.
@@ -64,5 +70,16 @@ class Ngrok
                 return $tunnel->public_url;
             }
         }
+    }
+
+    /**
+     * Set the Ngrok auth token.
+     *
+     * @param string $token
+     * @return string
+     */
+    public function setToken($token)
+    {
+        return $this->cli->runAsUser('./bin/ngrok authtoken '.$token);
     }
 }

--- a/cli/app.php
+++ b/cli/app.php
@@ -576,7 +576,7 @@ You might also want to investigate your global Composer configs. Helpful command
                 info("Found '{$site}/.valetphprc' specifying version: {$phpVersion}");
             } else {
                 info("\nPlease provide a version number. E.g.:");
-                info("valet isolate php@8.2");
+                info('valet isolate php@8.2');
                 exit;
             }
         }

--- a/cli/app.php
+++ b/cli/app.php
@@ -322,6 +322,13 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Get the URL to the current Ngrok tunnel');
 
     /**
+     * Set the ngrok auth token.
+     */
+    $app->command('set-ngrok-token [token]', function (OutputInterface $output, $token = null) {
+        output(Ngrok::setToken($token));
+    })->descriptions('Set the Ngrok auth token');
+
+    /**
      * Start the daemon services.
      */
     $app->command('start [service]', function (OutputInterface $output, $service) {

--- a/tests/NgrokTest.php
+++ b/tests/NgrokTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Container\Container;
+use Valet\CommandLine;
 use Valet\Ngrok;
 use function Valet\user;
 
@@ -47,7 +48,7 @@ class NgrokTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             ],
         ];
 
-        $ngrok = new Ngrok;
+        $ngrok = new Ngrok(new CommandLine);
         $this->assertEquals('http://right-one.ngrok.io/', $ngrok->findHttpTunnelUrl($tunnels, 'mysite'));
     }
 
@@ -63,7 +64,7 @@ class NgrokTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             ],
         ];
 
-        $ngrok = new Ngrok;
+        $ngrok = new Ngrok(new CommandLine);
         $this->assertEquals('http://right-one.ngrok.io/', $ngrok->findHttpTunnelUrl($tunnels, 'MySite'));
     }
 }


### PR DESCRIPTION
This allows users to set their ngrok auth token, now required for all usages of `valet share`.