### PR TITLE
Support isolated sites running PHP 7.4

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -13,6 +13,7 @@ class Brew
         'php@8.2',
         'php@8.1',
         'php@8.0',
+        'php@7.4',
     ];
     const BREW_DISABLE_AUTO_CLEANUP = 'HOMEBREW_NO_INSTALL_CLEANUP=1';
     const LATEST_PHP_VERSION = 'php@8.2';

--- a/cli/Valet/Drivers/BasicValetDriver.php
+++ b/cli/Valet/Drivers/BasicValetDriver.php
@@ -40,7 +40,7 @@ class BasicValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if (file_exists($staticFilePath = $sitePath.rtrim($uri, '/').'/index.html')) {
             return $staticFilePath;

--- a/cli/Valet/Drivers/BasicWithPublicValetDriver.php
+++ b/cli/Valet/Drivers/BasicWithPublicValetDriver.php
@@ -25,7 +25,7 @@ class BasicWithPublicValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         $publicPath = $sitePath.'/public/'.trim($uri, '/');
 

--- a/cli/Valet/Drivers/LaravelValetDriver.php
+++ b/cli/Valet/Drivers/LaravelValetDriver.php
@@ -42,7 +42,7 @@ class LaravelValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if (file_exists($staticFilePath = $sitePath.'/public'.$uri)
            && is_file($staticFilePath)) {

--- a/cli/Valet/Drivers/Specific/BedrockValetDriver.php
+++ b/cli/Valet/Drivers/Specific/BedrockValetDriver.php
@@ -45,7 +45,7 @@ class BedrockValetDriver extends BasicValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         $staticFilePath = $sitePath.'/web'.$uri;
 

--- a/cli/Valet/Drivers/Specific/CakeValetDriver.php
+++ b/cli/Valet/Drivers/Specific/CakeValetDriver.php
@@ -27,7 +27,7 @@ class CakeValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if ($this->isActualFile($staticFilePath = $sitePath.'/webroot/'.$uri)) {
             return $staticFilePath;

--- a/cli/Valet/Drivers/Specific/Concrete5ValetDriver.php
+++ b/cli/Valet/Drivers/Specific/Concrete5ValetDriver.php
@@ -27,7 +27,7 @@ class Concrete5ValetDriver extends BasicValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if (stripos($uri, '/application/files') === 0) {
             return $sitePath.$uri;

--- a/cli/Valet/Drivers/Specific/ContaoValetDriver.php
+++ b/cli/Valet/Drivers/Specific/ContaoValetDriver.php
@@ -27,7 +27,7 @@ class ContaoValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if ($this->isActualFile($staticFilePath = $sitePath.'/web'.$uri)) {
             return $staticFilePath;

--- a/cli/Valet/Drivers/Specific/CraftValetDriver.php
+++ b/cli/Valet/Drivers/Specific/CraftValetDriver.php
@@ -47,7 +47,7 @@ class CraftValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         $frontControllerDirectory = $this->frontControllerDirectory($sitePath);
 

--- a/cli/Valet/Drivers/Specific/DrupalValetDriver.php
+++ b/cli/Valet/Drivers/Specific/DrupalValetDriver.php
@@ -38,7 +38,7 @@ class DrupalValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         $sitePath = $this->addSubdirectory($sitePath);
 

--- a/cli/Valet/Drivers/Specific/KirbyValetDriver.php
+++ b/cli/Valet/Drivers/Specific/KirbyValetDriver.php
@@ -27,7 +27,7 @@ class KirbyValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
             return $staticFilePath;

--- a/cli/Valet/Drivers/Specific/Magento2ValetDriver.php
+++ b/cli/Valet/Drivers/Specific/Magento2ValetDriver.php
@@ -34,7 +34,7 @@ class Magento2ValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         $this->checkMageMode($sitePath);
 

--- a/cli/Valet/Drivers/Specific/NeosValetDriver.php
+++ b/cli/Valet/Drivers/Specific/NeosValetDriver.php
@@ -43,7 +43,7 @@ class NeosValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if ($this->isActualFile($staticFilePath = $sitePath.'/Web'.$uri)) {
             return $staticFilePath;

--- a/cli/Valet/Drivers/Specific/StatamicV1ValetDriver.php
+++ b/cli/Valet/Drivers/Specific/StatamicV1ValetDriver.php
@@ -27,7 +27,7 @@ class StatamicV1ValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if (strpos($uri, '/_add-ons') === 0 || strpos($uri, '/_app') === 0 || strpos($uri, '/_content') === 0 ||
             strpos($uri, '/_cache') === 0 || strpos($uri, '/_config') === 0 || strpos($uri, '/_logs') === 0 ||

--- a/cli/Valet/Drivers/Specific/StatamicValetDriver.php
+++ b/cli/Valet/Drivers/Specific/StatamicValetDriver.php
@@ -27,7 +27,7 @@ class StatamicValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if (strpos($uri, '/site') === 0 && strpos($uri, '/site/themes') !== 0) {
             return false;

--- a/cli/Valet/Drivers/Specific/SymfonyValetDriver.php
+++ b/cli/Valet/Drivers/Specific/SymfonyValetDriver.php
@@ -29,7 +29,7 @@ class SymfonyValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if ($this->isActualFile($staticFilePath = $sitePath.'/web/'.$uri)) {
             return $staticFilePath;

--- a/cli/Valet/Drivers/Specific/Typo3ValetDriver.php
+++ b/cli/Valet/Drivers/Specific/Typo3ValetDriver.php
@@ -86,7 +86,7 @@ class Typo3ValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         // May the file contains a cache busting version string like filename.12345678.css
         // If that is the case, the file cannot be found on disk, so remove the version

--- a/cli/Valet/Drivers/ValetDriver.php
+++ b/cli/Valet/Drivers/ValetDriver.php
@@ -27,7 +27,9 @@ abstract class ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    abstract public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false;
+    // While we support PHP 7.4 for individual site isolation...
+    abstract public function isStaticFile(string $sitePath, string $siteName, string $uri);
+    //abstract public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false;
 
     /**
      * Get the fully resolved path to the application's front controller.

--- a/cli/Valet/Server.php
+++ b/cli/Valet/Server.php
@@ -4,13 +4,17 @@ namespace Valet;
 
 class Server
 {
+    // Skip constructor promotion until we stop supporting PHP@7.4 isolation
+    public $config;
+
     /**
      * Create a new Server instance.
      *
      * @param  array  $config
      */
-    public function __construct(public array $config)
+    public function __construct(array $config)
     {
+        $this->config = $config;
     }
 
     /**

--- a/cli/stubs/SampleValetDriver.php
+++ b/cli/stubs/SampleValetDriver.php
@@ -31,7 +31,7 @@ class SampleValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri): string|false
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
         if (file_exists($staticFilePath = $sitePath.'/public/'.$uri)) {
             return $staticFilePath;


### PR DESCRIPTION
Drop a few usages of PHP 8+ features so that users can isolate individual sites to PHP 7.4.

This still requires running PHP 8+ at the system level, but at least allows users to isolate certain sites to PHP 7.4.