### PR TITLE
Add which-pecl and pecl commands

### DIFF
--- a/cli/app.php
+++ b/cli/app.php
@@ -613,17 +613,24 @@ You might also want to investigate your global Composer configs. Helpful command
      * Get the PHP executable path for a site.
      */
     $app->command('which-php [site]', function (OutputInterface $output, $site) {
-        $phpVersion = Site::customPhpVersion(
-            Site::host($site ?: getcwd()).'.'.Configuration::read()['tld']
-        );
-
-        if (! $phpVersion) {
-            $phpVersion = Site::phpRcVersion($site ?: basename(getcwd()));
-        }
+        $phpVersion = Site::getPhpVersion($site);
 
         return output(Brew::getPhpExecutablePath($phpVersion));
     })->descriptions('Get the PHP executable path for a given site', [
         'site' => 'The site to get the PHP executable path for',
+    ]);
+
+    /**
+     * Get the PECL executable path for a site.
+     */
+    $app->command('which-pecl [site]', function ($site) {
+        $phpVersion = Site::getPhpVersion($site);
+
+        $peclPath = Brew::getPeclExecutablePath($phpVersion);
+
+        output($peclPath);
+    })->descriptions('Get the PECL executable path for a given site', [
+        'site' => 'The site to get the PECL executable path for',
     ]);
 
     /**
@@ -642,6 +649,15 @@ You might also want to investigate your global Composer configs. Helpful command
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
     })->descriptions("Proxy Composer commands with isolated site's PHP executable", [
         'command' => "Composer command to run with isolated site's PHP executable",
+    ]);
+
+    /**
+     * Proxy commands through to an isolated site's version of PECL.
+     */
+    $app->command('pecl [command]', function (OutputInterface $output, $command) {
+        warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
+    })->descriptions("Proxy Composer commands with isolated site's PHP executable", [
+        'command' => "PECL command to run with isolated site's PHP executable",
     ]);
 
     /**

--- a/tests/BaseApplicationTestCase.php
+++ b/tests/BaseApplicationTestCase.php
@@ -1,5 +1,6 @@
 <?php
 
+use Silly\Application;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
 class BaseApplicationTestCase extends Yoast\PHPUnitPolyfills\TestCases\TestCase
@@ -24,6 +25,9 @@ class BaseApplicationTestCase extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         Configuration::writeBaseConfiguration();
     }
 
+    /**
+     * @return array{0: Application, 1: ApplicationTester}
+     */
     public function appAndTester()
     {
         $app = require __DIR__.'/../cli/app.php';


### PR DESCRIPTION
This PR adds a "valet pecl" command which behaves in line with the existing "valet php" and "valet composer" commands, two very helpful commands in day-to-day development.

One thing I alway need to do when setting a new php project with a new php version is to install extensions like xdebug. What I do right now is to get the pecl binary via "valet which-php", replacing php with pecl and using that path to install the extensions I need. 
Even tho my dicussion about it (https://github.com/laravel/valet/discussions/1331) did not go so well, I still went and implemented it, because this command would help me a lot in my process and I think other people would benefit from it as well.