### PR TITLE
Drop unnecessary doc blocks

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -18,21 +18,12 @@ class Brew
     const BREW_DISABLE_AUTO_CLEANUP = 'HOMEBREW_NO_INSTALL_CLEANUP=1';
     const LATEST_PHP_VERSION = 'php@8.2';
 
-    /**
-     * Create a new Brew instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     */
     public function __construct(public CommandLine $cli, public Filesystem $files)
     {
     }
 
     /**
      * Ensure the formula exists in the current Homebrew configuration.
-     *
-     * @param  string  $formula
-     * @return bool
      */
     public function installed(string $formula): bool
     {
@@ -50,8 +41,6 @@ class Brew
 
     /**
      * Determine if a compatible PHP version is Homebrewed.
-     *
-     * @return bool
      */
     public function hasInstalledPhp(): bool
     {
@@ -64,8 +53,6 @@ class Brew
 
     /**
      * Get a list of supported PHP versions.
-     *
-     * @return Collection
      */
     public function supportedPhpVersions(): Collection
     {
@@ -74,8 +61,6 @@ class Brew
 
     /**
      * Get a list of installed PHP formulae.
-     *
-     * @return Collection
      */
     public function installedPhpFormulae(): Collection
     {
@@ -86,8 +71,6 @@ class Brew
 
     /**
      * Get the aliased formula version from Homebrew.
-     *
-     * @return string
      */
     public function determineAliasedVersion($formula): string
     {
@@ -102,8 +85,6 @@ class Brew
 
     /**
      * Determine if a compatible nginx version is Homebrewed.
-     *
-     * @return bool
      */
     public function hasInstalledNginx(): bool
     {
@@ -113,8 +94,6 @@ class Brew
 
     /**
      * Return name of the nginx service installed via Homebrew.
-     *
-     * @return string
      */
     public function nginxServiceName(): string
     {
@@ -123,11 +102,6 @@ class Brew
 
     /**
      * Ensure that the given formula is installed.
-     *
-     * @param  string  $formula
-     * @param  array  $options
-     * @param  array  $taps
-     * @return void
      */
     public function ensureInstalled(string $formula, array $options = [], array $taps = []): void
     {
@@ -138,11 +112,6 @@ class Brew
 
     /**
      * Install the given formula and throw an exception on failure.
-     *
-     * @param  string  $formula
-     * @param  array  $options
-     * @param  array  $taps
-     * @return void
      */
     public function installOrFail(string $formula, array $options = [], array $taps = []): void
     {
@@ -166,9 +135,6 @@ class Brew
 
     /**
      * Tap the given formulas.
-     *
-     * @param  dynamic[string]  $formula
-     * @return void
      */
     public function tap($formulas): void
     {
@@ -181,9 +147,6 @@ class Brew
 
     /**
      * Restart the given Homebrew services.
-     *
-     * @param  dynamic[string]  $services
-     * @return void
      */
     public function restartService($services): void
     {
@@ -205,9 +168,6 @@ class Brew
 
     /**
      * Stop the given Homebrew services.
-     *
-     * @param  dynamic[string]  $services
-     * @return
      */
     public function stopService($services): void
     {
@@ -241,8 +201,6 @@ class Brew
 
     /**
      * Determine if php is currently linked.
-     *
-     * @return bool
      */
     public function hasLinkedPhp(): bool
     {
@@ -251,8 +209,6 @@ class Brew
 
     /**
      * Get the linked php parsed.
-     *
-     * @return array
      */
     public function getParsedLinkedPhp(): array
     {
@@ -269,8 +225,6 @@ class Brew
      * Gets the currently linked formula by identifying the symlink in the hombrew bin directory.
      * Different to ->linkedPhp() in that this will just get the linked directory name,
      * whether that is php, php74 or php@7.4.
-     *
-     * @return string
      */
     public function getLinkedPhpFormula(): string
     {
@@ -281,8 +235,6 @@ class Brew
 
     /**
      * Determine which version of PHP is linked in Homebrew.
-     *
-     * @return string
      */
     public function linkedPhp(): string
     {
@@ -338,8 +290,6 @@ class Brew
 
     /**
      * Restart the linked PHP-FPM Homebrew service.
-     *
-     * @return void
      */
     public function restartLinkedPhp(): void
     {
@@ -348,8 +298,6 @@ class Brew
 
     /**
      * Create the "sudoers.d" entry for running Brew.
-     *
-     * @return void
      */
     public function createSudoersEntry(): void
     {
@@ -361,8 +309,6 @@ class Brew
 
     /**
      * Remove the "sudoers.d" entry for running Brew.
-     *
-     * @return void
      */
     public function removeSudoersEntry(): void
     {
@@ -371,10 +317,6 @@ class Brew
 
     /**
      * Link passed formula.
-     *
-     * @param  string  $formula
-     * @param  bool  $force
-     * @return string
      */
     public function link(string $formula, bool $force = false): string
     {
@@ -390,9 +332,6 @@ class Brew
 
     /**
      * Unlink passed formula.
-     *
-     * @param  string  $formula
-     * @return string
      */
     public function unlink(string $formula): string
     {
@@ -408,8 +347,6 @@ class Brew
 
     /**
      * Get all the currently running brew services.
-     *
-     * @return Collection
      */
     public function getAllRunningServices(): Collection
     {
@@ -421,8 +358,6 @@ class Brew
     /**
      * Get the currently running brew services as root.
      * i.e. /Library/LaunchDaemons (started at boot).
-     *
-     * @return Collection
      */
     public function getRunningServicesAsRoot(): Collection
     {
@@ -432,8 +367,6 @@ class Brew
     /**
      * Get the currently running brew services.
      * i.e. ~/Library/LaunchAgents (started at login).
-     *
-     * @return \Illuminate\Support\Collection
      */
     public function getRunningServicesAsUser(): Collection
     {
@@ -442,9 +375,6 @@ class Brew
 
     /**
      * Get the currently running brew services.
-     *
-     * @param  bool  $asUser
-     * @return Collection
      */
     public function getRunningServices(bool $asUser = false): Collection
     {
@@ -463,8 +393,6 @@ class Brew
 
     /**
      * Tell Homebrew to forcefully remove all PHP versions that Valet supports.
-     *
-     * @return string
      */
     public function uninstallAllPhpVersions(): string
     {
@@ -477,9 +405,6 @@ class Brew
 
     /**
      * Uninstall a Homebrew app by formula name.
-     *
-     * @param  string  $formula
-     * @return void
      */
     public function uninstallFormula(string $formula): void
     {
@@ -489,8 +414,6 @@ class Brew
 
     /**
      * Run Homebrew's cleanup commands.
-     *
-     * @return string
      */
     public function cleanupBrew(): string
     {
@@ -504,9 +427,6 @@ class Brew
 
     /**
      * Parse homebrew PHP Path.
-     *
-     * @param  string  $resolvedPath
-     * @return array
      */
     public function parsePhpPath(string $resolvedPath): array
     {
@@ -524,10 +444,6 @@ class Brew
 
     /**
      * Check if two PHP versions are equal.
-     *
-     * @param  string  $versionA
-     * @param  string  $versionB
-     * @return bool
      */
     public function arePhpVersionsEqual(string $versionA, string $versionB): bool
     {

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -7,10 +7,7 @@ use Symfony\Component\Process\Process;
 class CommandLine
 {
     /**
-     * Simple global function to run commands.
-     *
-     * @param  string  $command
-     * @return void
+     * Simple global function to run commands quietly.
      */
     public function quietly(string $command): void
     {
@@ -19,9 +16,6 @@ class CommandLine
 
     /**
      * Simple global function to run commands.
-     *
-     * @param  string  $command
-     * @return void
      */
     public function quietlyAsUser(string $command): void
     {
@@ -30,9 +24,6 @@ class CommandLine
 
     /**
      * Pass the command to the command line and display the output.
-     *
-     * @param  string  $command
-     * @return void
      */
     public function passthru(string $command): void
     {
@@ -41,10 +32,6 @@ class CommandLine
 
     /**
      * Run the given command as the non-root user.
-     *
-     * @param  string  $command
-     * @param  callable  $onError
-     * @return string
      */
     public function run(string $command, callable $onError = null): string
     {
@@ -53,10 +40,6 @@ class CommandLine
 
     /**
      * Run the given command.
-     *
-     * @param  string  $command
-     * @param  callable  $onError
-     * @return string
      */
     public function runAsUser(string $command, callable $onError = null): string
     {
@@ -65,10 +48,6 @@ class CommandLine
 
     /**
      * Run the given command.
-     *
-     * @param  string  $command
-     * @param  callable  $onError
-     * @return string
      */
     public function runCommand(string $command, callable $onError = null): string
     {

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -4,19 +4,12 @@ namespace Valet;
 
 class Configuration
 {
-    /**
-     * Create a new Valet configuration class instance.
-     *
-     * @param  Filesystem  $files
-     */
     public function __construct(public Filesystem $files)
     {
     }
 
     /**
      * Install the Valet configuration file.
-     *
-     * @return void
      */
     public function install(): void
     {
@@ -33,8 +26,6 @@ class Configuration
 
     /**
      * Forcefully delete the Valet home configuration directory and contents.
-     *
-     * @return void
      */
     public function uninstall(): void
     {
@@ -43,8 +34,6 @@ class Configuration
 
     /**
      * Create the Valet configuration directory.
-     *
-     * @return void
      */
     public function createConfigurationDirectory(): void
     {
@@ -54,8 +43,6 @@ class Configuration
 
     /**
      * Create the Valet drivers directory.
-     *
-     * @return void
      */
     public function createDriversDirectory(): void
     {
@@ -73,8 +60,6 @@ class Configuration
 
     /**
      * Create the Valet sites directory.
-     *
-     * @return void
      */
     public function createSitesDirectory(): void
     {
@@ -83,8 +68,6 @@ class Configuration
 
     /**
      * Create the directory for the Valet extensions.
-     *
-     * @return void
      */
     public function createExtensionsDirectory(): void
     {
@@ -93,8 +76,6 @@ class Configuration
 
     /**
      * Create the directory for Nginx logs.
-     *
-     * @return void
      */
     public function createLogDirectory(): void
     {
@@ -105,8 +86,6 @@ class Configuration
 
     /**
      * Create the directory for SSL certificates.
-     *
-     * @return void
      */
     public function createCertificatesDirectory(): void
     {
@@ -115,8 +94,6 @@ class Configuration
 
     /**
      * Write the base, initial configuration for Valet.
-     *
-     * @return void
      */
     public function writeBaseConfiguration(): void
     {
@@ -127,10 +104,6 @@ class Configuration
 
     /**
      * Add the given path to the configuration.
-     *
-     * @param  string  $path
-     * @param  bool  $prepend
-     * @return void
      */
     public function addPath(string $path, bool $prepend = false): void
     {
@@ -143,9 +116,6 @@ class Configuration
 
     /**
      * Prepend the given path to the configuration.
-     *
-     * @param  string  $path
-     * @return void
      */
     public function prependPath(string $path): void
     {
@@ -154,9 +124,6 @@ class Configuration
 
     /**
      * Remove the given path from the configuration.
-     *
-     * @param  string  $path
-     * @return void
      */
     public function removePath(string $path): void
     {
@@ -175,8 +142,6 @@ class Configuration
 
     /**
      * Prune all non-existent paths from the configuration.
-     *
-     * @return void
      */
     public function prune(): void
     {
@@ -193,8 +158,6 @@ class Configuration
 
     /**
      * Read the configuration file as JSON.
-     *
-     * @return array
      */
     public function read(): array
     {
@@ -203,12 +166,8 @@ class Configuration
 
     /**
      * Update a specific key in the configuration file.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return array
      */
-    public function updateKey(string $key, $value): array
+    public function updateKey(string $key, mixed $value): array
     {
         return tap($this->read(), function (&$config) use ($key, $value) {
             $config[$key] = $value;
@@ -219,9 +178,6 @@ class Configuration
 
     /**
      * Write the given configuration to disk.
-     *
-     * @param  array  $config
-     * @return void
      */
     public function write(array $config): void
     {
@@ -232,8 +188,6 @@ class Configuration
 
     /**
      * Get the configuration file path.
-     *
-     * @return string
      */
     public function path(): string
     {

--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -54,23 +54,12 @@ class Diagnose
     public $print;
     public $progressBar;
 
-    /**
-     * Create a new Diagnose instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @return void
-     */
     public function __construct(public CommandLine $cli, public Filesystem $files)
     {
     }
 
     /**
      * Run diagnostics.
-     *
-     * @param  bool  $print
-     * @param  bool  $plainText
-     * @return void
      */
     public function run(bool $print, bool $plainText): void
     {

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -47,6 +47,7 @@ class DnsMasq
 
     /**
      * Tell Homebrew to restart dnsmasq.
+     *
      * @return void
      */
     public function restart(): void

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -8,23 +8,12 @@ class DnsMasq
     public $dnsmasqSystemConfDir = BREW_PREFIX.'/etc/dnsmasq.d';
     public $resolverPath = '/etc/resolver';
 
-    /**
-     * Create a new DnsMasq Instance.
-     *
-     * @param  Brew  $brew
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @param  Configuration  $configuration
-     */
     public function __construct(public Brew $brew, public CommandLine $cli, public Filesystem $files, public Configuration $configuration)
     {
     }
 
     /**
      * Install and configure DnsMasq.
-     *
-     * @param  string  $tld
-     * @return void
      */
     public function install(string $tld = 'test'): void
     {
@@ -46,8 +35,6 @@ class DnsMasq
 
     /**
      * Forcefully uninstall dnsmasq.
-     *
-     * @return void
      */
     public function uninstall(): void
     {
@@ -60,7 +47,6 @@ class DnsMasq
 
     /**
      * Tell Homebrew to restart dnsmasq.
-     *
      * @return void
      */
     public function restart(): void
@@ -70,8 +56,6 @@ class DnsMasq
 
     /**
      * Ensure the DnsMasq configuration primary config is set to read custom configs.
-     *
-     * @return void
      */
     public function ensureUsingDnsmasqDForConfigs(): void
     {
@@ -107,9 +91,6 @@ class DnsMasq
 
     /**
      * Create the TLD-specific dnsmasq config file.
-     *
-     * @param  string  $tld
-     * @return void
      */
     public function createDnsmasqTldConfigFile(string $tld): void
     {
@@ -121,9 +102,6 @@ class DnsMasq
 
     /**
      * Create the resolver file to point the configured TLD to configured loopback address.
-     *
-     * @param  string  $tld
-     * @return void
      */
     public function createTldResolver(string $tld): void
     {
@@ -135,10 +113,6 @@ class DnsMasq
 
     /**
      * Update the TLD/domain resolved by DnsMasq.
-     *
-     * @param  string  $oldTld
-     * @param  string  $newTld
-     * @return void
      */
     public function updateTld(string $oldTld, string $newTld): void
     {
@@ -150,8 +124,6 @@ class DnsMasq
 
     /**
      * Refresh the DnsMasq configuration.
-     *
-     * @return void
      */
     public function refreshConfiguration(): void
     {
@@ -162,8 +134,6 @@ class DnsMasq
 
     /**
      * Get the custom configuration path.
-     *
-     * @return string
      */
     public function dnsmasqUserConfigDir(): string
     {

--- a/cli/Valet/Drivers/BasicValetDriver.php
+++ b/cli/Valet/Drivers/BasicValetDriver.php
@@ -6,11 +6,6 @@ class BasicValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -19,11 +14,6 @@ class BasicValetDriver extends ValetDriver
 
     /**
      * Take any steps necessary before loading the front controller for this driver.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function beforeLoading(string $sitePath, string $siteName, string $uri): void
     {
@@ -34,13 +24,8 @@ class BasicValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if (file_exists($staticFilePath = $sitePath.rtrim($uri, '/').'/index.html')) {
             return $staticFilePath;
@@ -53,11 +38,6 @@ class BasicValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/BasicWithPublicValetDriver.php
+++ b/cli/Valet/Drivers/BasicWithPublicValetDriver.php
@@ -25,7 +25,7 @@ class BasicWithPublicValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         $publicPath = $sitePath.'/public/'.trim($uri, '/');
 

--- a/cli/Valet/Drivers/LaravelValetDriver.php
+++ b/cli/Valet/Drivers/LaravelValetDriver.php
@@ -42,7 +42,7 @@ class LaravelValetDriver extends ValetDriver
      * @param  string  $uri
      * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if (file_exists($staticFilePath = $sitePath.'/public'.$uri)
            && is_file($staticFilePath)) {

--- a/cli/Valet/Drivers/Specific/BedrockValetDriver.php
+++ b/cli/Valet/Drivers/Specific/BedrockValetDriver.php
@@ -8,11 +8,6 @@ class BedrockValetDriver extends BasicValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -24,11 +19,6 @@ class BedrockValetDriver extends BasicValetDriver
 
     /**
      * Take any steps necessary before loading the front controller for this driver.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function beforeLoading(string $sitePath, string $siteName, string $uri): void
     {
@@ -39,11 +29,6 @@ class BedrockValetDriver extends BasicValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
     public function isStaticFile(string $sitePath, string $siteName, string $uri)
     {
@@ -58,11 +43,6 @@ class BedrockValetDriver extends BasicValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {
@@ -75,9 +55,6 @@ class BedrockValetDriver extends BasicValetDriver
 
     /**
      * Redirect to uri with trailing slash.
-     *
-     * @param  string  $uri
-     * @return string
      */
     private function forceTrailingSlash($uri)
     {

--- a/cli/Valet/Drivers/Specific/CakeValetDriver.php
+++ b/cli/Valet/Drivers/Specific/CakeValetDriver.php
@@ -8,11 +8,6 @@ class CakeValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,13 +16,8 @@ class CakeValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if ($this->isActualFile($staticFilePath = $sitePath.'/webroot/'.$uri)) {
             return $staticFilePath;
@@ -38,11 +28,6 @@ class CakeValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/Specific/Concrete5ValetDriver.php
+++ b/cli/Valet/Drivers/Specific/Concrete5ValetDriver.php
@@ -8,11 +8,6 @@ class Concrete5ValetDriver extends BasicValetDriver
 {
     /**
      * If a concrete directory exists, it's probably c5.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,13 +16,8 @@ class Concrete5ValetDriver extends BasicValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if (stripos($uri, '/application/files') === 0) {
             return $sitePath.$uri;
@@ -37,10 +27,7 @@ class Concrete5ValetDriver extends BasicValetDriver
     }
 
     /**
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
+     * Get the fully resolved path to the application's front controller.
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/Specific/ContaoValetDriver.php
+++ b/cli/Valet/Drivers/Specific/ContaoValetDriver.php
@@ -8,11 +8,6 @@ class ContaoValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,13 +16,8 @@ class ContaoValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if ($this->isActualFile($staticFilePath = $sitePath.'/web'.$uri)) {
             return $staticFilePath;
@@ -38,11 +28,6 @@ class ContaoValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/Specific/CraftValetDriver.php
+++ b/cli/Valet/Drivers/Specific/CraftValetDriver.php
@@ -8,11 +8,6 @@ class CraftValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,11 +16,8 @@ class CraftValetDriver extends ValetDriver
 
     /**
      * Determine the name of the directory where the front controller lives.
-     *
-     * @param  string  $sitePath
-     * @return string
      */
-    public function frontControllerDirectory($sitePath)
+    public function frontControllerDirectory($sitePath): string
     {
         $dirs = ['web', 'public'];
 
@@ -41,13 +33,8 @@ class CraftValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         $frontControllerDirectory = $this->frontControllerDirectory($sitePath);
 
@@ -60,11 +47,6 @@ class CraftValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/Specific/DrupalValetDriver.php
+++ b/cli/Valet/Drivers/Specific/DrupalValetDriver.php
@@ -8,11 +8,6 @@ class DrupalValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -32,13 +27,8 @@ class DrupalValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         $sitePath = $this->addSubdirectory($sitePath);
 
@@ -53,11 +43,6 @@ class DrupalValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {
@@ -88,7 +73,7 @@ class DrupalValetDriver extends ValetDriver
     /**
      * Add any matching subdirectory to the site path.
      */
-    public function addSubdirectory($sitePath)
+    public function addSubdirectory($sitePath): string
     {
         $paths = array_map(function ($subDir) use ($sitePath) {
             return "$sitePath/$subDir";
@@ -109,10 +94,8 @@ class DrupalValetDriver extends ValetDriver
 
     /**
      * Return an array of possible subdirectories.
-     *
-     * @return array
      */
-    private function possibleSubdirectories()
+    private function possibleSubdirectories(): array
     {
         return ['docroot', 'public', 'web'];
     }

--- a/cli/Valet/Drivers/Specific/JigsawValetDriver.php
+++ b/cli/Valet/Drivers/Specific/JigsawValetDriver.php
@@ -8,11 +8,6 @@ class JigsawValetDriver extends BasicValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,9 +16,6 @@ class JigsawValetDriver extends BasicValetDriver
 
     /**
      * Mutate the incoming URI.
-     *
-     * @param  string  $uri
-     * @return string
      */
     public function mutateUri(string $uri): string
     {

--- a/cli/Valet/Drivers/Specific/JoomlaValetDriver.php
+++ b/cli/Valet/Drivers/Specific/JoomlaValetDriver.php
@@ -8,11 +8,6 @@ class JoomlaValetDriver extends BasicValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,11 +16,6 @@ class JoomlaValetDriver extends BasicValetDriver
 
     /**
      * Take any steps necessary before loading the front controller for this driver.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function beforeLoading(string $sitePath, string $siteName, string $uri): void
     {

--- a/cli/Valet/Drivers/Specific/KatanaValetDriver.php
+++ b/cli/Valet/Drivers/Specific/KatanaValetDriver.php
@@ -8,11 +8,6 @@ class KatanaValetDriver extends BasicValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,9 +16,6 @@ class KatanaValetDriver extends BasicValetDriver
 
     /**
      * Mutate the incoming URI.
-     *
-     * @param  string  $uri
-     * @return string
      */
     public function mutateUri(string $uri): string
     {

--- a/cli/Valet/Drivers/Specific/KirbyValetDriver.php
+++ b/cli/Valet/Drivers/Specific/KirbyValetDriver.php
@@ -8,11 +8,6 @@ class KirbyValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,13 +16,8 @@ class KirbyValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
             return $staticFilePath;
@@ -40,11 +30,6 @@ class KirbyValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/Specific/Magento2ValetDriver.php
+++ b/cli/Valet/Drivers/Specific/Magento2ValetDriver.php
@@ -8,18 +8,11 @@ class Magento2ValetDriver extends ValetDriver
 {
     /**
      * Holds the MAGE_MODE from app/etc/config.php or $ENV.
-     *
-     * @var string
      */
-    private $mageMode;
+    private ?string $mageMode = null;
 
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -28,13 +21,8 @@ class Magento2ValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         $this->checkMageMode($sitePath);
 
@@ -79,34 +67,34 @@ class Magento2ValetDriver extends ValetDriver
     /**
      * Rewrite URLs that look like "versions12345/" to remove
      * the versions12345/ part.
-     *
-     * @param  string  $route
      */
-    private function handleForVersions($route)
+    private function handleForVersions($route): string
     {
         return preg_replace('/version\d*\//', '', $route);
     }
 
     /**
      * Determine the current MAGE_MODE.
-     *
-     * @param  string  $sitePath
      */
-    private function checkMageMode($sitePath)
+    private function checkMageMode($sitePath): void
     {
         if (null !== $this->mageMode) {
             // We have already figure out mode, no need to check it again
             return;
         }
+
         if (! file_exists($sitePath.'/index.php')) {
             $this->mageMode = 'production'; // Can't use developer mode without index.php in project root
 
             return;
         }
+
         $mageConfig = [];
+
         if (file_exists($sitePath.'/app/etc/env.php')) {
             $mageConfig = require $sitePath.'/app/etc/env.php';
         }
+
         if (array_key_exists('MAGE_MODE', $mageConfig)) {
             $this->mageMode = $mageConfig['MAGE_MODE'];
         }
@@ -115,18 +103,14 @@ class Magento2ValetDriver extends ValetDriver
     /**
      * Checks to see if route is referencing any directory inside pub. This is a dynamic check so that if any new
      * directories are added to pub this driver will not need to be updated.
-     *
-     * @param  string  $sitePath
-     * @param  string  $route
-     * @param  string  $pub
-     * @return bool
      */
-    private function isPubDirectory($sitePath, $route, $pub = '')
+    private function isPubDirectory($sitePath, $route, $pub = ''): bool
     {
         $sitePath .= '/pub/';
         $dirs = glob($sitePath.'*', GLOB_ONLYDIR);
 
         $dirs = str_replace($sitePath, '', $dirs);
+
         foreach ($dirs as $dir) {
             if (strpos($route, $pub.$dir.'/') === 0) {
                 return true;
@@ -138,11 +122,6 @@ class Magento2ValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/Specific/NeosValetDriver.php
+++ b/cli/Valet/Drivers/Specific/NeosValetDriver.php
@@ -8,11 +8,6 @@ class NeosValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,11 +16,6 @@ class NeosValetDriver extends ValetDriver
 
     /**
      * Take any steps necessary before loading the front controller for this driver.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function beforeLoading(string $sitePath, string $siteName, string $uri): void
     {
@@ -37,13 +27,8 @@ class NeosValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if ($this->isActualFile($staticFilePath = $sitePath.'/Web'.$uri)) {
             return $staticFilePath;
@@ -54,11 +39,6 @@ class NeosValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/Specific/SculpinValetDriver.php
+++ b/cli/Valet/Drivers/Specific/SculpinValetDriver.php
@@ -8,11 +8,6 @@ class SculpinValetDriver extends BasicValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -20,19 +15,19 @@ class SculpinValetDriver extends BasicValetDriver
             $this->isLegacySculpinProject($sitePath);
     }
 
-    private function isModernSculpinProject($sitePath)
+    private function isModernSculpinProject($sitePath): bool
     {
         return is_dir($sitePath.'/source') &&
             is_dir($sitePath.'/output_dev') &&
             $this->composerRequiresSculpin($sitePath);
     }
 
-    private function isLegacySculpinProject($sitePath)
+    private function isLegacySculpinProject($sitePath): bool
     {
         return is_dir($sitePath.'/.sculpin');
     }
 
-    private function composerRequiresSculpin($sitePath)
+    private function composerRequiresSculpin($sitePath): bool
     {
         if (! file_exists($sitePath.'/composer.json')) {
             return false;
@@ -50,9 +45,6 @@ class SculpinValetDriver extends BasicValetDriver
 
     /**
      * Mutate the incoming URI.
-     *
-     * @param  string  $uri
-     * @return string
      */
     public function mutateUri(string $uri): string
     {

--- a/cli/Valet/Drivers/Specific/StatamicV1ValetDriver.php
+++ b/cli/Valet/Drivers/Specific/StatamicV1ValetDriver.php
@@ -8,11 +8,6 @@ class StatamicV1ValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,13 +16,8 @@ class StatamicV1ValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if (strpos($uri, '/_add-ons') === 0 || strpos($uri, '/_app') === 0 || strpos($uri, '/_content') === 0 ||
             strpos($uri, '/_cache') === 0 || strpos($uri, '/_config') === 0 || strpos($uri, '/_logs') === 0 ||
@@ -45,11 +35,6 @@ class StatamicV1ValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/Specific/StatamicValetDriver.php
+++ b/cli/Valet/Drivers/Specific/StatamicValetDriver.php
@@ -8,11 +8,6 @@ class StatamicValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,13 +16,8 @@ class StatamicValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if (strpos($uri, '/site') === 0 && strpos($uri, '/site/themes') !== 0) {
             return false;
@@ -44,11 +34,6 @@ class StatamicValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {
@@ -93,17 +78,14 @@ class StatamicValetDriver extends ValetDriver
 
     /**
      * Get the locale from this URI.
-     *
-     * @param  string  $uri
-     * @return string|null
      */
-    public function getUriLocale($uri)
+    public function getUriLocale(string $uri): ?string
     {
         $parts = explode('/', $uri);
         $locale = $parts[1];
 
         if (count($parts) < 2 || ! in_array($locale, $this->getLocales())) {
-            return;
+            return null;
         }
 
         return $locale;
@@ -111,10 +93,8 @@ class StatamicValetDriver extends ValetDriver
 
     /**
      * Get the list of possible locales used in the first segment of a URI.
-     *
-     * @return array
      */
-    public function getLocales()
+    public function getLocales(): array
     {
         return [
             'af', 'ax', 'al', 'dz', 'as', 'ad', 'ao', 'ai', 'aq', 'ag', 'ar', 'am', 'aw', 'au', 'at', 'az', 'bs', 'bh',
@@ -136,11 +116,8 @@ class StatamicValetDriver extends ValetDriver
 
     /**
      * Get the path to a statically cached page.
-     *
-     * @param  string  $sitePath
-     * @return string
      */
-    protected function getStaticPath($sitePath)
+    protected function getStaticPath(string $sitePath): string
     {
         $parts = parse_url($_SERVER['REQUEST_URI']);
         $query = isset($parts['query']) ? $parts['query'] : '';

--- a/cli/Valet/Drivers/Specific/SymfonyValetDriver.php
+++ b/cli/Valet/Drivers/Specific/SymfonyValetDriver.php
@@ -8,11 +8,6 @@ class SymfonyValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -23,13 +18,8 @@ class SymfonyValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if ($this->isActualFile($staticFilePath = $sitePath.'/web/'.$uri)) {
             return $staticFilePath;
@@ -42,11 +32,6 @@ class SymfonyValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {

--- a/cli/Valet/Drivers/Specific/Typo3ValetDriver.php
+++ b/cli/Valet/Drivers/Specific/Typo3ValetDriver.php
@@ -43,11 +43,6 @@ class Typo3ValetDriver extends ValetDriver
 
     /**
      * Take any steps necessary before loading the front controller for this driver.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function beforeLoading(string $sitePath, string $siteName, string $uri): void
     {
@@ -63,11 +58,6 @@ class Typo3ValetDriver extends ValetDriver
     /**
      * Determine if the driver serves the request. For TYPO3, this is the
      * case, if a folder called "typo3" is present in the document root.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -80,13 +70,8 @@ class Typo3ValetDriver extends ValetDriver
      * Determine if the incoming request is for a static file. That is, it is
      * no PHP script file and the URI points to a valid file (no folder) on
      * the disk. Access to those static files will be authorized.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         // May the file contains a cache busting version string like filename.12345678.css
         // If that is the case, the file cannot be found on disk, so remove the version
@@ -108,11 +93,8 @@ class Typo3ValetDriver extends ValetDriver
 
     /**
      * Determines if the given URI is blacklisted so that access is prevented.
-     *
-     * @param  string  $uri
-     * @return bool
      */
-    private function isAccessAuthorized($uri)
+    private function isAccessAuthorized(string $uri): bool
     {
         foreach ($this->forbiddenUriPatterns as $forbiddenUriPattern) {
             if (preg_match("@$forbiddenUriPattern@", $uri)) {
@@ -127,11 +109,6 @@ class Typo3ValetDriver extends ValetDriver
      * Get the fully resolved path to the application's front controller.
      * This can be the currently requested PHP script, a folder that
      * contains an index.php or the global index.php otherwise.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {
@@ -164,10 +141,8 @@ class Typo3ValetDriver extends ValetDriver
      * Direct access to installtool via domain.dev/typo3/install/ will be redirected to
      * sysext install script. domain.dev/typo3 will be redirected to /typo3/, because
      * the generated JavaScript URIs on the login screen would be broken on /typo3.
-     *
-     * @param  string  $uri
      */
-    private function handleRedirectBackendShorthandUris($uri)
+    private function handleRedirectBackendShorthandUris(string $uri): void
     {
         if (rtrim($uri, '/') === '/typo3/install') {
             header('Location: /typo3/sysext/install/Start/Install.php');
@@ -183,13 +158,8 @@ class Typo3ValetDriver extends ValetDriver
     /**
      * Configures the $_SERVER globals for serving the script at
      * the specified URI and returns it absolute file path.
-     *
-     * @param  string  $sitePath
-     * @param  string  $uri
-     * @param  string  $script
-     * @return string
      */
-    private function serveScript($sitePath, $uri)
+    private function serveScript(string $sitePath, string $uri): string
     {
         $docroot = $sitePath.$this->documentRoot;
         $abspath = $docroot.$uri;

--- a/cli/Valet/Drivers/Specific/WordPressValetDriver.php
+++ b/cli/Valet/Drivers/Specific/WordPressValetDriver.php
@@ -8,11 +8,6 @@ class WordPressValetDriver extends BasicValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -21,11 +16,6 @@ class WordPressValetDriver extends BasicValetDriver
 
     /**
      * Take any steps necessary before loading the front controller for this driver.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function beforeLoading(string $sitePath, string $siteName, string $uri): void
     {
@@ -36,11 +26,6 @@ class WordPressValetDriver extends BasicValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {
@@ -51,11 +36,8 @@ class WordPressValetDriver extends BasicValetDriver
 
     /**
      * Redirect to uri with trailing slash.
-     *
-     * @param  string  $uri
-     * @return string
      */
-    private function forceTrailingSlash($uri)
+    private function forceTrailingSlash($uri): ?string
     {
         if (substr($uri, -1 * strlen('/wp-admin')) == '/wp-admin') {
             header('Location: '.$uri.'/');

--- a/cli/Valet/Drivers/ValetDriver.php
+++ b/cli/Valet/Drivers/ValetDriver.php
@@ -11,21 +11,11 @@ abstract class ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     abstract public function serves(string $sitePath, string $siteName, string $uri): bool;
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
     // While we support PHP 7.4 for individual site isolation...
     abstract public function isStaticFile(string $sitePath, string $siteName, string $uri);
@@ -33,21 +23,11 @@ abstract class ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|null
      */
     abstract public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string;
 
     /**
      * Find a driver that can serve the incoming request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return ValetDriver|null
      */
     public static function assign(string $sitePath, string $siteName, string $uri): ?ValetDriver
     {
@@ -79,9 +59,6 @@ abstract class ValetDriver
 
     /**
      * Get the custom driver class from the site path, if one exists.
-     *
-     * @param  string  $sitePath
-     * @return string|null
      */
     public static function customSiteDriver(string $sitePath): ?string
     {
@@ -96,9 +73,6 @@ abstract class ValetDriver
 
     /**
      * Get all of the driver classes in a given path.
-     *
-     * @param  string  $path
-     * @return array
      */
     public static function driversIn(string $path): array
     {
@@ -123,8 +97,6 @@ abstract class ValetDriver
 
     /**
      * Get all of the specific drivers shipped with Valet.
-     *
-     * @return array
      */
     public static function specificDrivers(): array
     {
@@ -135,8 +107,6 @@ abstract class ValetDriver
 
     /**
      * Get all of the custom drivers defined by the user locally.
-     *
-     * @return array
      */
     public static function customDrivers(): array
     {
@@ -147,11 +117,6 @@ abstract class ValetDriver
 
     /**
      * Take any steps necessary before loading the front controller for this driver.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function beforeLoading(string $sitePath, string $siteName, string $uri): void
     {
@@ -160,9 +125,6 @@ abstract class ValetDriver
 
     /**
      * Mutate the incoming URI.
-     *
-     * @param  string  $uri
-     * @return string
      */
     public function mutateUri(string $uri): string
     {
@@ -171,12 +133,6 @@ abstract class ValetDriver
 
     /**
      * Serve the static file at the given path.
-     *
-     * @param  string  $staticFilePath
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
      */
     public function serveStaticFile(string $staticFilePath, string $sitePath, string $siteName, string $uri): void
     {
@@ -203,9 +159,6 @@ abstract class ValetDriver
 
     /**
      * Determine if the path is a file and not a directory.
-     *
-     * @param  string  $path
-     * @return bool
      */
     protected function isActualFile(string $path): bool
     {
@@ -215,10 +168,6 @@ abstract class ValetDriver
     /**
      * Load server environment variables if available.
      * Processes any '*' entries first, and then adds site-specific entries.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @return void
      */
     public function loadServerEnvironmentVariables(string $sitePath, string $siteName): void
     {

--- a/cli/Valet/Filesystem.php
+++ b/cli/Valet/Filesystem.php
@@ -10,9 +10,6 @@ class Filesystem
 {
     /**
      * Determine if the given path is a directory.
-     *
-     * @param  string  $path
-     * @return bool
      */
     public function isDir(string $path): bool
     {
@@ -21,11 +18,6 @@ class Filesystem
 
     /**
      * Create a directory.
-     *
-     * @param  string  $path
-     * @param  string|null  $owner
-     * @param  int  $mode
-     * @return void
      */
     public function mkdir(string $path, ?string $owner = null, int $mode = 0755): void
     {
@@ -38,11 +30,6 @@ class Filesystem
 
     /**
      * Ensure that the given directory exists.
-     *
-     * @param  string  $path
-     * @param  string|null  $owner
-     * @param  int  $mode
-     * @return void
      */
     public function ensureDirExists(string $path, ?string $owner = null, int $mode = 0755): void
     {
@@ -53,10 +40,6 @@ class Filesystem
 
     /**
      * Create a directory as the non-root user.
-     *
-     * @param  string  $path
-     * @param  int  $mode
-     * @return void
      */
     public function mkdirAsUser(string $path, int $mode = 0755): void
     {
@@ -65,10 +48,6 @@ class Filesystem
 
     /**
      * Touch the given path.
-     *
-     * @param  string  $path
-     * @param  string|null  $owner
-     * @return string
      */
     public function touch(string $path, ?string $owner = null): string
     {
@@ -83,9 +62,6 @@ class Filesystem
 
     /**
      * Touch the given path as the non-root user.
-     *
-     * @param  string  $path
-     * @return string
      */
     public function touchAsUser(string $path): string
     {
@@ -94,9 +70,6 @@ class Filesystem
 
     /**
      * Determine if the given file exists.
-     *
-     * @param  string  $path
-     * @return bool
      */
     public function exists(string $path): bool
     {
@@ -105,9 +78,6 @@ class Filesystem
 
     /**
      * Read the contents of the given file.
-     *
-     * @param  string  $path
-     * @return string
      */
     public function get(string $path): string
     {
@@ -116,11 +86,6 @@ class Filesystem
 
     /**
      * Write to the given file.
-     *
-     * @param  string  $path
-     * @param  string  $contents
-     * @param  string|null  $owner
-     * @return void
      */
     public function put(string $path, string $contents, ?string $owner = null): void
     {
@@ -133,10 +98,6 @@ class Filesystem
 
     /**
      * Write to the given file as the non-root user.
-     *
-     * @param  string  $path
-     * @param  string|null  $contents
-     * @return void
      */
     public function putAsUser(string $path, ?string $contents): void
     {
@@ -145,11 +106,6 @@ class Filesystem
 
     /**
      * Append the contents to the given file.
-     *
-     * @param  string  $path
-     * @param  string  $contents
-     * @param  string|null  $owner
-     * @return void
      */
     public function append(string $path, string $contents, ?string $owner = null): void
     {
@@ -162,10 +118,6 @@ class Filesystem
 
     /**
      * Append the contents to the given file as the non-root user.
-     *
-     * @param  string  $path
-     * @param  string  $contents
-     * @return void
      */
     public function appendAsUser(string $path, string $contents): void
     {
@@ -174,10 +126,6 @@ class Filesystem
 
     /**
      * Copy the given file to a new location.
-     *
-     * @param  string  $from
-     * @param  string  $to
-     * @return void
      */
     public function copy(string $from, string $to): void
     {
@@ -186,10 +134,6 @@ class Filesystem
 
     /**
      * Copy the given file to a new location for the non-root user.
-     *
-     * @param  string  $from
-     * @param  string  $to
-     * @return void
      */
     public function copyAsUser(string $from, string $to): void
     {
@@ -200,10 +144,6 @@ class Filesystem
 
     /**
      * Create a symlink to the given target.
-     *
-     * @param  string  $target
-     * @param  string  $link
-     * @return void
      */
     public function symlink(string $target, string $link): void
     {
@@ -218,10 +158,6 @@ class Filesystem
      * Create a symlink to the given target for the non-root user.
      *
      * This uses the command line as PHP can't change symlink permissions.
-     *
-     * @param  string  $target
-     * @param  string  $link
-     * @return void
      */
     public function symlinkAsUser(string $target, string $link): void
     {
@@ -234,9 +170,6 @@ class Filesystem
 
     /**
      * Delete the file at the given path.
-     *
-     * @param  string  $path
-     * @return void
      */
     public function unlink(string $path): void
     {
@@ -247,9 +180,6 @@ class Filesystem
 
     /**
      * Recursively delete a directory and its contents.
-     *
-     * @param  string  $path
-     * @return void
      */
     public function rmDirAndContents(string $path): void
     {
@@ -269,10 +199,6 @@ class Filesystem
 
     /**
      * Change the owner of the given path.
-     *
-     * @param  string  $path
-     * @param  string  $user
-     * @return void
      */
     public function chown(string $path, string $user): void
     {
@@ -281,10 +207,6 @@ class Filesystem
 
     /**
      * Change the group of the given path.
-     *
-     * @param  string  $path
-     * @param  string  $group
-     * @return void
      */
     public function chgrp(string $path, string $group): void
     {
@@ -293,9 +215,6 @@ class Filesystem
 
     /**
      * Resolve the given path.
-     *
-     * @param  string  $path
-     * @return string
      */
     public function realpath(string $path): string
     {
@@ -304,9 +223,6 @@ class Filesystem
 
     /**
      * Determine if the given path is a symbolic link.
-     *
-     * @param  string  $path
-     * @return bool
      */
     public function isLink(string $path): bool
     {
@@ -315,9 +231,6 @@ class Filesystem
 
     /**
      * Resolve the given symbolic link.
-     *
-     * @param  string  $path
-     * @return string
      */
     public function readLink(string $path): string
     {
@@ -326,9 +239,6 @@ class Filesystem
 
     /**
      * Remove all of the broken symbolic links at the given path.
-     *
-     * @param  string  $path
-     * @return void
      */
     public function removeBrokenLinksAt(string $path): void
     {
@@ -343,9 +253,6 @@ class Filesystem
 
     /**
      * Determine if the given path is a broken symbolic link.
-     *
-     * @param  string  $path
-     * @return bool
      */
     public function isBrokenLink(string $path): bool
     {
@@ -354,9 +261,6 @@ class Filesystem
 
     /**
      * Scan the given directory path.
-     *
-     * @param  string  $path
-     * @return array
      */
     public function scandir(string $path): array
     {
@@ -368,9 +272,6 @@ class Filesystem
 
     /**
      * Get custom stub file if exists.
-     *
-     * @param  string  $filename
-     * @return string
      */
     public function getStub(string $filename): string
     {

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -9,15 +9,6 @@ class Nginx
 {
     const NGINX_CONF = BREW_PREFIX.'/etc/nginx/nginx.conf';
 
-    /**
-     * Create a new Nginx instance.
-     *
-     * @param  Brew  $brew
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @param  Configuration  $configuration
-     * @param  Site  $site
-     */
     public function __construct(public Brew $brew, public CommandLine $cli, public Filesystem $files,
                          public Configuration $configuration, public Site $site)
     {
@@ -25,8 +16,6 @@ class Nginx
 
     /**
      * Install the configuration files for Nginx.
-     *
-     * @return void
      */
     public function install(): void
     {
@@ -41,8 +30,6 @@ class Nginx
 
     /**
      * Install the Nginx configuration file.
-     *
-     * @return void
      */
     public function installConfiguration(): void
     {
@@ -58,8 +45,6 @@ class Nginx
 
     /**
      * Install the Valet Nginx server configuration file.
-     *
-     * @return void
      */
     public function installServer(): void
     {
@@ -84,8 +69,6 @@ class Nginx
      * Install the Nginx configuration directory to the ~/.config/valet directory.
      *
      * This directory contains all site-specific Nginx servers.
-     *
-     * @return void
      */
     public function installNginxDirectory(): void
     {
@@ -115,8 +98,6 @@ class Nginx
 
     /**
      * Generate fresh Nginx servers for existing secure sites.
-     *
-     * @return void
      */
     public function rewriteSecureNginxFiles(): void
     {
@@ -134,8 +115,6 @@ class Nginx
 
     /**
      * Restart the Nginx service.
-     *
-     * @return void
      */
     public function restart(): void
     {
@@ -146,8 +125,6 @@ class Nginx
 
     /**
      * Stop the Nginx service.
-     *
-     * @return void
      */
     public function stop(): void
     {
@@ -156,8 +133,6 @@ class Nginx
 
     /**
      * Forcefully uninstall Nginx.
-     *
-     * @return void
      */
     public function uninstall(): void
     {
@@ -168,8 +143,6 @@ class Nginx
 
     /**
      * Return a list of all sites with explicit Nginx configurations.
-     *
-     * @return Collection
      */
     public function configuredSites(): Collection
     {

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -21,9 +21,6 @@ class Ngrok
 
     /**
      * Get the current tunnel URL from the Ngrok API.
-     *
-     * @param  string|null  $domain
-     * @return string
      */
     public function currentTunnelUrl(?string $domain = null): string
     {
@@ -57,10 +54,6 @@ class Ngrok
 
     /**
      * Find the HTTP tunnel URL from the list of tunnels.
-     *
-     * @param  array  $tunnels
-     * @param  string  $domain
-     * @return string|null
      */
     public function findHttpTunnelUrl(array $tunnels, string $domain): ?string
     {
@@ -78,9 +71,6 @@ class Ngrok
 
     /**
      * Set the Ngrok auth token.
-     *
-     * @param  string  $token
-     * @return string
      */
     public function setToken($token)
     {

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -12,24 +12,12 @@ class PhpFpm
         'shivammathur/php',
     ];
 
-    /**
-     * Create a new PHP FPM class instance.
-     *
-     * @param  Brew  $brew
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @param  Configuration  $config
-     * @param  Site  $site
-     * @param  Nginx  $nginx
-     */
     public function __construct(public Brew $brew, public CommandLine $cli, public Filesystem $files, public Configuration $config, public Site $site, public Nginx $nginx)
     {
     }
 
     /**
      * Install and configure PhpFpm.
-     *
-     * @return void
      */
     public function install(): void
     {
@@ -55,8 +43,6 @@ class PhpFpm
 
     /**
      * Forcefully uninstall all of Valet's supported PHP versions and configurations.
-     *
-     * @return void
      */
     public function uninstall(): void
     {
@@ -69,9 +55,6 @@ class PhpFpm
      * Create (or re-create) the PHP FPM configuration files.
      *
      * Writes FPM config file, pointing to the correct .sock file, and log and ini files.
-     *
-     * @param  string  $phpVersion
-     * @return void
      */
     public function createConfigurationFiles(string $phpVersion): void
     {
@@ -118,9 +101,6 @@ class PhpFpm
 
     /**
      * Restart the PHP FPM process (if one specified) or processes (if none specified).
-     *
-     * @param  string|null  $phpVersion
-     * @return void
      */
     public function restart(?string $phpVersion = null): void
     {
@@ -129,8 +109,6 @@ class PhpFpm
 
     /**
      * Stop the PHP FPM process.
-     *
-     * @return void
      */
     public function stop(): void
     {
@@ -142,9 +120,6 @@ class PhpFpm
 
     /**
      * Get the path to the FPM configuration file for the current PHP version.
-     *
-     * @param  string|null  $phpVersion
-     * @return string
      */
     public function fpmConfigPath(?string $phpVersion = null): string
     {
@@ -174,9 +149,6 @@ class PhpFpm
 
     /**
      * Stop a given PHP version, if that specific version isn't being used globally or by any sites.
-     *
-     * @param  string|null  $phpVersion
-     * @return void
      */
     public function stopIfUnused(?string $phpVersion = null): void
     {
@@ -193,10 +165,6 @@ class PhpFpm
 
     /**
      * Isolate a given directory to use a specific version of PHP.
-     *
-     * @param  string  $directory
-     * @param  string  $version
-     * @return void
      */
     public function isolateDirectory(string $directory, string $version): void
     {
@@ -220,9 +188,6 @@ class PhpFpm
 
     /**
      * Remove PHP version isolation for a given directory.
-     *
-     * @param  string  $directory
-     * @return void
      */
     public function unIsolateDirectory(string $directory): void
     {
@@ -239,8 +204,6 @@ class PhpFpm
 
     /**
      * List all directories with PHP isolation configured.
-     *
-     * @return Collection
      */
     public function isolatedDirectories(): Collection
     {
@@ -253,10 +216,6 @@ class PhpFpm
 
     /**
      * Use a specific version of PHP globally.
-     *
-     * @param  string  $version
-     * @param  bool  $force
-     * @return string|void
      */
     public function useVersion(string $version, bool $force = false): ?string
     {
@@ -310,9 +269,6 @@ class PhpFpm
 
     /**
      * If passed php7.4, or php74, 7.4, or 74 formats, normalize to php@7.4 format.
-     *
-     * @param  string|null
-     * @return string
      */
     public function normalizePhpVersion(?string $version): string
     {
@@ -321,9 +277,6 @@ class PhpFpm
 
     /**
      * Validate the requested version to be sure we can support it.
-     *
-     * @param  string  $version
-     * @return string
      */
     public function validateRequestedVersion(string $version): string
     {
@@ -352,9 +305,6 @@ class PhpFpm
 
     /**
      * Get FPM sock file name for a given PHP version.
-     *
-     * @param  string|null  $phpVersion
-     * @return string
      */
     public static function fpmSockName(?string $phpVersion = null): string
     {
@@ -366,8 +316,6 @@ class PhpFpm
     /**
      * Get a list including the global PHP version and allPHP versions currently serving "isolated sites" (sites with
      * custom Nginx configs pointing them to a specific PHP version).
-     *
-     * @return array
      */
     public function utilizedPhpVersions(): array
     {

--- a/cli/Valet/Server.php
+++ b/cli/Valet/Server.php
@@ -7,11 +7,6 @@ class Server
     // Skip constructor promotion until we stop supporting PHP@7.4 isolation
     public $config;
 
-    /**
-     * Create a new Server instance.
-     *
-     * @param  array  $config
-     */
     public function __construct(array $config)
     {
         $this->config = $config;
@@ -19,9 +14,6 @@ class Server
 
     /**
      * Extract $uri from $SERVER['REQUEST_URI'] variable.
-     *
-     * @param  string  $requestUri  $_SERVER['REQUEST_URI']
-     * @return string
      */
     public static function uriFromRequestUri(string $requestUri): string
     {
@@ -32,9 +24,6 @@ class Server
 
     /**
      * Extract the domain from the site name.
-     *
-     * @param  string  $siteName
-     * @return string
      */
     public static function domainFromSiteName(string $siteName): string
     {
@@ -53,9 +42,6 @@ class Server
 
     /**
      * Show directory listing or 404 if directory doesn't exist.
-     *
-     * @param  string  $valetSitePath
-     * @param  string  $uri
      */
     public static function showDirectoryListing(string $valetSitePath, string $uri)
     {
@@ -86,9 +72,6 @@ class Server
 
     /**
      * Extract site name from HTTP host, stripping www. and supporting wildcard DNS.
-     *
-     * @param  string  $httpHost
-     * @return string
      */
     public function siteNameFromHttpHost(string $httpHost): string
     {
@@ -109,9 +92,6 @@ class Server
      * You may use wildcard DNS provider nip.io as a tool for testing your site via an IP address.
      * First, determine the IP address of your local computer (like 192.168.0.10).
      * Then, visit http://project.your-ip.nip.io - e.g.: http://laravel.192.168.0.10.nip.io.
-     *
-     * @param  string  $domain
-     * @return string
      */
     public function allowWildcardDnsDomains(string $domain): string
     {
@@ -147,9 +127,6 @@ class Server
     /**
      * Determine the fully qualified path to the site.
      * Inspects registered path directories, case-sensitive.
-     *
-     * @param  string  $siteName
-     * @return string|null
      */
     public function sitePath(string $siteName): ?string
     {
@@ -196,8 +173,6 @@ class Server
 
     /**
      * Return the default site path for uncaught URLs, if it's set.
-     *
-     * @return string|null
      **/
     public function defaultSitePath(): ?string
     {

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -8,23 +8,12 @@ use PhpFpm;
 
 class Site
 {
-    /**
-     * Create a new Site instance.
-     *
-     * @param  Brew  $brew
-     * @param  Configuration  $config
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     */
     public function __construct(public Brew $brew, public Configuration $config, public CommandLine $cli, public Filesystem $files)
     {
     }
 
     /**
      * Get the name of the site.
-     *
-     * @param  string|null  $name
-     * @return string
      */
     private function getRealSiteName(?string $name): string
     {
@@ -41,8 +30,6 @@ class Site
 
     /**
      * Get link name based on the current directory.
-     *
-     * @return null|string
      */
     private function getLinkNameByCurrentDir(): ?string
     {
@@ -59,9 +46,6 @@ class Site
 
     /**
      * Get the real hostname for the given path, checking links.
-     *
-     * @param  string  $path
-     * @return string|null
      */
     public function host(string $path): ?string
     {
@@ -76,10 +60,6 @@ class Site
 
     /**
      * Link the current working directory with the given name.
-     *
-     * @param  string  $target
-     * @param  string  $link
-     * @return string
      */
     public function link(string $target, string $link): string
     {
@@ -96,8 +76,6 @@ class Site
 
     /**
      * Pretty print out all links in Valet.
-     *
-     * @return Collection
      */
     public function links(): Collection
     {
@@ -112,8 +90,6 @@ class Site
 
     /**
      * Pretty print out all parked links in Valet.
-     *
-     * @return Collection
      */
     public function parked(): Collection
     {
@@ -141,8 +117,6 @@ class Site
 
     /**
      * Get all sites which are proxies (not Links, and contain proxy_pass directive).
-     *
-     * @return Collection
      */
     public function proxies(): Collection
     {
@@ -188,9 +162,6 @@ class Site
 
     /**
      * Get the site URL from a directory if it's a valid Valet site.
-     *
-     * @param  string  $directory
-     * @return string
      */
     public function getSiteUrl(string $directory): string
     {
@@ -214,10 +185,6 @@ class Site
 
     /**
      * Identify whether a site is for a proxy by reading the host name from its config file.
-     *
-     * @param  string  $site  Site name without TLD
-     * @param  string  $configContents  Config file contents
-     * @return string|null
      */
     public function getProxyHostForSite(string $site, string $configContents = null): ?string
     {
@@ -237,10 +204,6 @@ class Site
 
     /**
      * Get the contents of the configuration for the given site.
-     *
-     * @param  string  $site
-     * @param  string  $suffix
-     * @return string|null
      */
     public function getSiteConfigFileContents(string $site, ?string $suffix = null): ?string
     {
@@ -253,9 +216,6 @@ class Site
 
     /**
      * Get all certificates from config folder.
-     *
-     * @param  string|null  $path
-     * @return Collection
      */
     public function getCertificates(?string $path = null): Collection
     {
@@ -284,10 +244,6 @@ class Site
     /**
      * Get list of sites and return them formatted
      * Will work for symlink and normal site paths.
-     *
-     * @param  string  $path
-     * @param  Collection  $certs
-     * @return Collection
      */
     public function getSites(string $path, Collection $certs): Collection
     {
@@ -324,9 +280,6 @@ class Site
 
     /**
      * Unlink the given symbolic link.
-     *
-     * @param  string|null  $name
-     * @return string
      */
     public function unlink(?string $name = null): string
     {
@@ -341,8 +294,6 @@ class Site
 
     /**
      * Remove all broken symbolic links.
-     *
-     * @return void
      */
     public function pruneLinks(): void
     {
@@ -357,9 +308,6 @@ class Site
 
     /**
      * Get the PHP version for the given site.
-     *
-     * @param  string  $url  Site URL including the TLD
-     * @return string
      */
     public function getPhpVersion(string $url): string
     {
@@ -378,10 +326,6 @@ class Site
      * There are only two supported values: tld and loopback
      * And those must be submitted in pairs else unexpected results may occur.
      * eg: both $old and $new should contain the same indexes.
-     *
-     * @param  array  $old
-     * @param  array  $new
-     * @return void
      */
     public function resecureForNewConfiguration(array $old, array $new): void
     {
@@ -424,11 +368,6 @@ class Site
 
     /**
      * Parse Nginx site config file contents to swap old domain to new.
-     *
-     * @param  string  $siteConf  Nginx site config content
-     * @param  string  $old  Old domain
-     * @param  string  $new  New domain
-     * @return string
      */
     public function replaceOldDomainWithNew(string $siteConf, string $old, string $new): string
     {
@@ -451,11 +390,6 @@ class Site
 
     /**
      * Parse Nginx site config file contents to swap old loopback address to new.
-     *
-     * @param  string  $siteConf  Nginx site config content
-     * @param  string  $old  Old loopback address
-     * @param  string  $new  New loopback address
-     * @return string
      */
     public function replaceOldLoopbackWithNew(string $siteConf, string $old, string $new): string
     {
@@ -488,8 +422,6 @@ class Site
 
     /**
      * Get all of the URLs that are currently secured.
-     *
-     * @return array
      */
     public function secured(): array
     {
@@ -623,9 +555,6 @@ class Site
 
     /**
      * Create the private key for the TLS certificate.
-     *
-     * @param  string  $keyPath
-     * @return void
      */
     public function createPrivateKey(string $keyPath): void
     {
@@ -634,12 +563,6 @@ class Site
 
     /**
      * Create the signing request for the TLS certificate.
-     *
-     * @param  string  $url
-     * @param  string  $keyPath
-     * @param  string  $csrPath
-     * @param  string  $confPath
-     * @return void
      */
     public function createSigningRequest(string $url, string $keyPath, string $csrPath, string $confPath): void
     {
@@ -650,10 +573,7 @@ class Site
     }
 
     /**
-     * Trust the given root certificate file in the Mac Keychain.
-     *
-     * @param  string  $pemPath
-     * @return void
+     * Trust the given root certificate file in the macOS Keychain.
      */
     public function trustCa(string $caPemPath): void
     {
@@ -664,9 +584,6 @@ class Site
 
     /**
      * Trust the given certificate file in the Mac Keychain.
-     *
-     * @param  string  $crtPath
-     * @return void
      */
     public function trustCertificate(string $crtPath): void
     {
@@ -677,10 +594,6 @@ class Site
 
     /**
      * Build the SSL config for the given URL.
-     *
-     * @param  string  $path
-     * @param  string  $url
-     * @return void
      */
     public function buildCertificateConf(string $path, string $url): void
     {
@@ -690,10 +603,6 @@ class Site
 
     /**
      * Build the TLS secured Nginx server for the given URL.
-     *
-     * @param  string  $url
-     * @param  string|null  $siteConf  (optional) Nginx site config file content
-     * @return string
      */
     public function buildSecureNginxServer(string $url, ?string $siteConf = null): string
     {
@@ -722,10 +631,6 @@ class Site
     /**
      * Create new nginx config or modify existing nginx config to isolate this site
      * to a custom version of PHP.
-     *
-     * @param  string  $valetSite
-     * @param  string  $phpVersion
-     * @return void
      */
     public function isolate(string $valetSite, string $phpVersion): void
     {
@@ -746,9 +651,6 @@ class Site
 
     /**
      * Remove PHP Version isolation from a specific site.
-     *
-     * @param  string  $valetSite
-     * @return void
      */
     public function removeIsolation(string $valetSite): void
     {
@@ -765,9 +667,6 @@ class Site
 
     /**
      * Unsecure the given URL so that it will use HTTP again.
-     *
-     * @param  string  $url
-     * @return void
      */
     public function unsecure(string $url): void
     {
@@ -798,8 +697,6 @@ class Site
 
     /**
      * Un-secure all sites.
-     *
-     * @return void
      */
     public function unsecureAll(): void
     {
@@ -878,9 +775,6 @@ class Site
 
     /**
      * Unsecure the given URL so that it will use HTTP again.
-     *
-     * @param  string  $url
-     * @return void
      */
     public function proxyDelete(string $url): void
     {
@@ -897,10 +791,6 @@ class Site
 
     /**
      * Create the given nginx host.
-     *
-     * @param  string  $url
-     * @param  string  $siteConf  pregenerated Nginx config file contents
-     * @return void
      */
     public function put(string $url, string $siteConf): void
     {
@@ -915,10 +805,6 @@ class Site
 
     /**
      * Remove old loopback interface alias and add a new one if necessary.
-     *
-     * @param  string  $oldLoopback
-     * @param  string  $loopback
-     * @return void
      */
     public function aliasLoopback(string $oldLoopback, string $loopback): void
     {
@@ -935,9 +821,6 @@ class Site
 
     /**
      * Remove loopback interface alias.
-     *
-     * @param  string  $loopback
-     * @return void
      */
     public function removeLoopbackAlias(string $loopback): void
     {
@@ -950,9 +833,6 @@ class Site
 
     /**
      * Add loopback interface alias.
-     *
-     * @param  string  $loopback
-     * @return void
      */
     public function addLoopbackAlias(string $loopback): void
     {
@@ -965,9 +845,6 @@ class Site
 
     /**
      * Remove old LaunchDaemon and create a new one if necessary.
-     *
-     * @param  string  $loopback
-     * @return void
      */
     public function updateLoopbackPlist(string $loopback): void
     {
@@ -989,8 +866,6 @@ class Site
 
     /**
      * Remove loopback interface alias launch daemon plist file.
-     *
-     * @return void
      */
     public function removeLoopbackPlist(): void
     {
@@ -1003,8 +878,6 @@ class Site
 
     /**
      * Remove loopback interface alias and launch daemon plist file for uninstall purpose.
-     *
-     * @return void
      */
     public function uninstallLoopback(): void
     {
@@ -1017,8 +890,6 @@ class Site
 
     /**
      * Return Valet home path constant.
-     *
-     * @return string
      */
     public function valetHomePath(): string
     {
@@ -1027,8 +898,6 @@ class Site
 
     /**
      * Return Valet loopback configuration.
-     *
-     * @return string
      */
     public function valetLoopback(): string
     {
@@ -1037,8 +906,6 @@ class Site
 
     /**
      * Get the path to loopback LaunchDaemon.
-     *
-     * @return string
      */
     public function plistPath(): string
     {
@@ -1047,9 +914,6 @@ class Site
 
     /**
      * Get the path to Nginx site configuration files.
-     *
-     * @param  string|null  $additionalPath
-     * @return string
      */
     public function nginxPath(?string $additionalPath = null): string
     {
@@ -1058,9 +922,6 @@ class Site
 
     /**
      * Get the path to the linked Valet sites.
-     *
-     * @param  string|null  $link
-     * @return string
      */
     public function sitesPath(?string $link = null): string
     {
@@ -1069,9 +930,6 @@ class Site
 
     /**
      * Get the path to the Valet CA certificates.
-     *
-     * @param  string|null  $caFile
-     * @return string
      */
     public function caPath(?string $caFile = null): string
     {
@@ -1080,10 +938,6 @@ class Site
 
     /**
      * Get the path to the Valet TLS certificates.
-     *
-     * @param  string  $url
-     * @param  string  $extension
-     * @return string
      */
     public function certificatesPath(?string $url = null, ?string $extension = null): string
     {
@@ -1095,9 +949,6 @@ class Site
 
     /**
      * Make the domain name based on parked domains or the internal TLD.
-     *
-     * @param  string|null  $domain
-     * @return string
      */
     public function domain(?string $domain): string
     {
@@ -1120,9 +971,6 @@ class Site
 
     /**
      * Replace Loopback configuration line in Valet site configuration file contents.
-     *
-     * @param  string  $siteConf
-     * @return string
      */
     public function replaceLoopback(string $siteConf): string
     {
@@ -1143,9 +991,6 @@ class Site
 
     /**
      * Extract PHP version of exising nginx conifg.
-     *
-     * @param  string  $url
-     * @return string|null
      */
     public function customPhpVersion(string $url): ?string
     {
@@ -1164,10 +1009,6 @@ class Site
 
     /**
      * Replace .sock file in an Nginx site configuration file contents.
-     *
-     * @param  string  $siteConf
-     * @param  string  $phpVersion
-     * @return string
      */
     public function replaceSockFile(string $siteConf, string $phpVersion): string
     {
@@ -1181,9 +1022,6 @@ class Site
 
     /**
      * Get PHP version from .valetphprc for a site.
-     *
-     * @param  string  $site
-     * @return string|null
      */
     public function phpRcVersion(string $site): ?string
     {

--- a/cli/Valet/Status.php
+++ b/cli/Valet/Status.php
@@ -7,9 +7,6 @@ class Status
     public $brewServicesUserOutput;
     public $brewServicesSudoOutput;
 
-    /**
-     * Create a new Status instance.
-     */
     public function __construct(public Configuration $config, public Brew $brew, public CommandLine $cli, public Filesystem $files)
     {
     }

--- a/cli/Valet/Upgrader.php
+++ b/cli/Valet/Upgrader.php
@@ -13,8 +13,6 @@ class Upgrader
 
     /**
      * Run all the upgrades that should be run every time Valet commands are run.
-     *
-     * @return void
      */
     public function onEveryRun(): void
     {
@@ -26,8 +24,6 @@ class Upgrader
 
     /**
      * Prune all non-existent paths from the configuration.
-     *
-     * @return void
      */
     public function pruneMissingDirectories(): void
     {
@@ -41,8 +37,6 @@ class Upgrader
 
     /**
      * Remove all broken symbolic links in the Valet config Sites diretory.
-     *
-     * @return void
      */
     public function pruneSymbolicLinks(): void
     {
@@ -52,8 +46,6 @@ class Upgrader
     /**
      * If the user has the old `SampleValetDriver` without the Valet namespace,
      * replace it with the new `SampleValetDriver` that uses the namespace.
-     *
-     * @return void
      */
     public function fixOldSampleValetDriver(): void
     {
@@ -71,8 +63,6 @@ class Upgrader
 
     /**
      * Throw an exception if the user has old (non-namespaced) custom drivers.
-     *
-     * @return void
      */
     public function errorIfOldCustomDrivers(): void
     {

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -8,20 +8,12 @@ class Valet
 {
     public $valetBin = BREW_PREFIX.'/bin/valet';
 
-    /**
-     * Create a new Valet instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     */
     public function __construct(public CommandLine $cli, public Filesystem $files)
     {
     }
 
     /**
      * Symlink the Valet Bash script into the user's local bin.
-     *
-     * @return void
      */
     public function symlinkToUsersBin(): void
     {
@@ -32,8 +24,6 @@ class Valet
 
     /**
      * Remove the symlink from the user's local bin.
-     *
-     * @return void
      */
     public function unlinkFromUsersBin(): void
     {
@@ -42,9 +32,6 @@ class Valet
 
     /**
      * Determine if this is the latest version of Valet.
-     *
-     * @param  string  $currentVersion
-     * @return bool
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
@@ -58,8 +45,6 @@ class Valet
 
     /**
      * Create the "sudoers.d" entry for running Valet.
-     *
-     * @return void
      */
     public function createSudoersEntry(): void
     {
@@ -71,8 +56,6 @@ class Valet
 
     /**
      * Remove the "sudoers.d" entry for running Valet.
-     *
-     * @return void
      */
     public function removeSudoersEntry(): void
     {
@@ -81,8 +64,6 @@ class Valet
 
     /**
      * Run composer global diagnose.
-     *
-     * @return void
      */
     public function composerGlobalDiagnose(): void
     {
@@ -91,8 +72,6 @@ class Valet
 
     /**
      * Run composer global update.
-     *
-     * @return void
      */
     public function composerGlobalUpdate(): void
     {

--- a/cli/includes/facades.php
+++ b/cli/includes/facades.php
@@ -9,19 +9,15 @@ class Facade
      *
      * @return string
      */
-    public static function containerKey()
+    public static function containerKey(): string
     {
         return 'Valet\\'.basename(str_replace('\\', '/', get_called_class()));
     }
 
     /**
      * Call a non-static method on the facade.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
      */
-    public static function __callStatic($method, $parameters)
+    public static function __callStatic(string $method, array $parameters): mixed
     {
         $resolvedInstance = Container::getInstance()->make(static::containerKey());
 

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -31,9 +31,6 @@ define('ISOLATED_PHP_VERSION', 'ISOLATED_PHP_VERSION');
 
 /**
  * Set or get a global console writer.
- *
- * @param  null|OutputInterface  $writer
- * @return OutputInterface|\NullWriter|null
  */
 function writer(?OutputInterface $writer = null): OutputInterface|\NullWriter|null
 {
@@ -54,20 +51,14 @@ function writer(?OutputInterface $writer = null): OutputInterface|\NullWriter|nu
 
 /**
  * Output the given text to the console.
- *
- * @param  string  $output
- * @return void
  */
-function info($output)
+function info($output): void
 {
     output('<info>'.$output.'</info>');
 }
 
 /**
  * Output the given text to the console.
- *
- * @param  string  $output
- * @return void
  */
 function warning(string $output): void
 {
@@ -76,10 +67,6 @@ function warning(string $output): void
 
 /**
  * Output a table to the console.
- *
- * @param  array  $headers
- * @param  array  $rows
- * @return void
  */
 function table(array $headers = [], array $rows = []): void
 {
@@ -92,8 +79,6 @@ function table(array $headers = [], array $rows = []): void
 
 /**
  * Return whether the app is in the testing environment.
- *
- * @return bool
  */
 function testing(): bool
 {
@@ -102,9 +87,6 @@ function testing(): bool
 
 /**
  * Output the given text to the console.
- *
- * @param  string  $output
- * @return void
  */
 function output(string $output): void
 {
@@ -113,9 +95,6 @@ function output(string $output): void
 
 /**
  * Resolve the given class from the container.
- *
- * @param  string  $class
- * @return mixed
  */
 function resolve(string $class): mixed
 {
@@ -124,10 +103,6 @@ function resolve(string $class): mixed
 
 /**
  * Swap the given class implementation in the container.
- *
- * @param  string  $class
- * @param  mixed  $instance
- * @return void
  */
 function swap(string $class, mixed $instance): void
 {
@@ -136,11 +111,6 @@ function swap(string $class, mixed $instance): void
 
 /**
  * Retry the given function N times.
- *
- * @param  int  $retries
- * @param  callable  $retries
- * @param  int  $sleep
- * @return mixed
  */
 function retry(int $retries, callable $fn, int $sleep = 0): mixed
 {
@@ -164,8 +134,6 @@ function retry(int $retries, callable $fn, int $sleep = 0): mixed
 
 /**
  * Verify that the script is currently running as "sudo".
- *
- * @return void
  */
 function should_be_sudo(): void
 {
@@ -176,10 +144,6 @@ function should_be_sudo(): void
 
 /**
  * Tap the given value.
- *
- * @param  mixed  $value
- * @param  callable  $callback
- * @return mixed
  */
 function tap(mixed $value, callable $callback): mixed
 {
@@ -190,10 +154,6 @@ function tap(mixed $value, callable $callback): mixed
 
 /**
  * Determine if a given string ends with a given substring.
- *
- * @param  string  $haystack
- * @param  string|array  $needles
- * @return bool
  */
 function ends_with(string $haystack, array|string $needles): bool
 {
@@ -208,10 +168,6 @@ function ends_with(string $haystack, array|string $needles): bool
 
 /**
  * Determine if a given string starts with a given substring.
- *
- * @param  string  $haystack
- * @param  string|string[]  $needles
- * @return bool
  */
 function starts_with(string $haystack, array|string $needles): bool
 {

--- a/cli/stubs/SampleValetDriver.php
+++ b/cli/stubs/SampleValetDriver.php
@@ -8,11 +8,6 @@ class SampleValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
@@ -25,13 +20,8 @@ class SampleValetDriver extends ValetDriver
 
     /**
      * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
         if (file_exists($staticFilePath = $sitePath.'/public/'.$uri)) {
             return $staticFilePath;
@@ -42,11 +32,6 @@ class SampleValetDriver extends ValetDriver
 
     /**
      * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): string
     {


### PR DESCRIPTION
Following Laravel's changes, I'm adding type hints and return types and removing unnecessary doc blocks from Valet v4.