### PR TITLE
Fixes permission denied check when result starts with 'Permission denied'

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -620,7 +620,7 @@ class Site
         ));
 
         // If cert could not be created using runAsUser(), use run().
-        if (strpos($result, 'Permission denied')) {
+        if (strpos($result, 'Permission denied') !== false) {
             $this->cli->run(sprintf(
                 'openssl x509 -req -sha256 -days %s -CA "%s" -CAkey "%s" %s -in "%s" -out "%s" -extensions v3_req -extfile "%s"',
                 $caExpireInDays, $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath


### PR DESCRIPTION
When creating a certificate, if the result of the command starts with "Permission denied" it doesn't know that the permission was denied, so it doesn't try to run as root.

The current check will only work if the result contains "Permission denied" but will fail if the result _starts with_ "Permission denied" since that will return `0`.

I also wasn't sure which branch to PR this into, but it looks like `master` is typically where things get PR'd into. Let me know if it needs to be into a different branch and I can change it.