### PR TITLE
Support PHP 7

### DIFF
--- a/find-usable-php.php
+++ b/find-usable-php.php
@@ -17,6 +17,7 @@ $phps = explode(PHP_EOL, trim(shell_exec('brew list --formula | grep php')));
 // Normalize version numbers
 $phps = array_reduce($phps, function ($carry, $php) {
     $carry[$php] = presumePhpVersionFromBrewFormulaName($php);
+
     return $carry;
 }, []);
 
@@ -39,7 +40,7 @@ $foundVersion = reset($modernPhps);
 echo getPhpExecutablePath(array_search($foundVersion, $phps));
 
 /**
- * Function definitions
+ * Function definitions.
  */
 
 /**
@@ -73,7 +74,7 @@ function presumePhpVersionFromBrewFormulaName(string $formulaName): ?string
         // Figure out its link
         $details = json_decode(shell_exec("brew info $formulaName --json"));
 
-        if (!empty($details[0]->aliases[0])) {
+        if (! empty($details[0]->aliases[0])) {
             $formulaName = $details[0]->aliases[0];
         } else {
             return null;
@@ -84,5 +85,5 @@ function presumePhpVersionFromBrewFormulaName(string $formulaName): ?string
         return null;
     }
 
-    return substr($formulaName, strpos($formulaName, "@") + 1);
+    return substr($formulaName, strpos($formulaName, '@') + 1);
 }

--- a/find-usable-php.php
+++ b/find-usable-php.php
@@ -1,0 +1,88 @@
+<?php
+
+$minimumPhpVersion = '8.0';
+
+// First, check if the system's linked "php" is 8+; if so, return that. This
+// is the most likely, most ideal, and fastest possible case
+$linkedPhpVersion = shell_exec('php -r "echo phpversion();"');
+
+if (version_compare($linkedPhpVersion, $minimumPhpVersion) >= 0) {
+    return 'php';
+}
+
+// If not, let's find it whether we have a version of PHP installed that's 8+;
+// all users that run through this code path will see Valet run more slowly
+$phps = explode(PHP_EOL, trim(shell_exec('brew list --formula | grep php')));
+
+// Normalize version numbers
+$phps = array_reduce($phps, function ($carry, $php) {
+    $carry[$php] = presumePhpVersionFromBrewFormulaName($php);
+    return $carry;
+}, []);
+
+// Filter out older versions of PHP
+$modernPhps = array_filter($phps, function ($php) use ($minimumPhpVersion) {
+    return version_compare($php, $minimumPhpVersion) >= 0;
+});
+
+// If we don't have any modern versions of PHP, throw an error
+if (empty($modernPhps)) {
+    throw new Exception('Sorry, but you do not have a version of PHP installed that is compatible with Valet (8+).');
+}
+
+// Sort newest version to oldest
+sort($modernPhps);
+$modernPhps = array_reverse($modernPhps);
+
+// Grab the highest, set as $foundVersion, and output its path
+$foundVersion = reset($modernPhps);
+echo getPhpExecutablePath(array_search($foundVersion, $phps));
+
+/**
+ * Function definitions
+ */
+
+/**
+ * Extract PHP executable path from PHP Version.
+ * Copied from Brew.php and modified.
+ *
+ * @param  string|null  $phpFormulaName  For example, "php@8.1"
+ * @return string
+ */
+function getPhpExecutablePath(string $phpFormulaName = null): string
+{
+    $brewPrefix = exec('printf $(brew --prefix)');
+
+    // Check the default `/opt/homebrew/opt/php@8.1/bin/php` location first
+    if (file_exists($brewPrefix."/opt/{$phpFormulaName}/bin/php")) {
+        return $brewPrefix."/opt/{$phpFormulaName}/bin/php";
+    }
+
+    // Check the `/opt/homebrew/opt/php71/bin/php` location for older installations
+    $oldPhpFormulaName = str_replace(['@', '.'], '', $phpFormulaName); // php@7.1 to php71
+    if (file_exists($brewPrefix."/opt/{$oldPhpFormulaName}/bin/php")) {
+        return $brewPrefix."/opt/{$oldPhpFormulaName}/bin/php";
+    }
+
+    throw new Exception('Cannot find an executable path for provided PHP version: '.$phpFormulaName);
+}
+
+function presumePhpVersionFromBrewFormulaName(string $formulaName): ?string
+{
+    if ($formulaName === 'php') {
+        // Figure out its link
+        $details = json_decode(shell_exec("brew info $formulaName --json"));
+
+        if (!empty($details[0]->aliases[0])) {
+            $formulaName = $details[0]->aliases[0];
+        } else {
+            return null;
+        }
+    }
+
+    if (strpos($formulaName, 'php@') === false) {
+        return null;
+    }
+
+    return substr($formulaName, strpos($formulaName, "@") + 1);
+}

--- a/upgrade.md
+++ b/upgrade.md
@@ -5,3 +5,4 @@
     - Match the new type hints of the base ValetDriver
     - Extend the new namespaced drivers instead of the old globally-namespaced drivers
     - Add namespace
+- Probably a lot more, @todo forgot to flesh this out as i went

--- a/valet
+++ b/valet
@@ -20,12 +20,32 @@ then
     DIR=$(php -r "echo realpath('$DIR/../laravel/valet');")
 fi
 
+# Get a command-line executable we can use for php that's 8+; if this
+# is the inside loop (Valet runs itself 2x in some settings), skip
+# checking and pulling again by reading the exported env var
+if [[ $PHP_EXECUTABLE = "" ]]
+then
+    PHP=$(php $DIR/find-usable-php.php)
+
+    # Validate output before running it on the CLI
+    if [[ ! -f $PHP ]]; then
+        echo "Error finding executable PHP. Quitting for safety."
+        echo "Provided output from find-usable-php.php:"
+        echo $PHP
+        exit
+    fi
+
+    export PHP_EXECUTABLE=$PHP
+else
+    PHP=$PHP_EXECUTABLE
+fi
+
 # If the command is the "share" command we will need to resolve out any
 # symbolic links for the site. Before starting Ngrok, we will fire a
 # process to retrieve the live Ngrok tunnel URL in the background.
 if [[ "$1" = "share" ]]
 then
-    SHARETOOL="$(php "$DIR/cli/valet.php" share-tool)"
+    SHARETOOL="$($PHP "$DIR/cli/valet.php" share-tool)"
 
     if [[ $SHARETOOL = "ngrok" ]]
     then
@@ -35,7 +55,7 @@ then
         for PARAM in ${PARAMS[@]}
         do
             if [[ ${PARAM:0:1} != '-' ]]; then
-                PARAMS=("${PARAMS[@]/$PARAM}") #Quotes when working with strings
+                PARAMS=("${PARAMS[@]/$PARAM}") # Quotes when working with strings
             fi
         done
 
@@ -52,7 +72,7 @@ then
             fi
         done
 
-        TLD=$(php "$DIR/cli/valet.php" tld)
+        TLD=$($PHP "$DIR/cli/valet.php" tld)
 
         # Decide the correct PORT: uses 60 for secure, else 80
         if grep --quiet --no-messages 443 ~/.config/valet/Nginx/$HOST*
@@ -96,7 +116,7 @@ then
             fi
         done
 
-        TLD=$(php "$DIR/cli/valet.php" tld)
+        TLD=$($PHP "$DIR/cli/valet.php" tld)
 
         # Decide the correct PORT: uses 443 for secure, else 80
         if grep --quiet --no-messages 443 ~/.config/valet/Nginx/$HOST*
@@ -123,14 +143,14 @@ then
 # Proxy PHP commands to the "php" executable on the isolated site
 elif [[ "$1" = "php" ]]
 then
-    $(php "$DIR/cli/valet.php" which-php) "${@:2}"
+    $($PHP "$DIR/cli/valet.php" which-php) "${@:2}"
 
     exit
 
 # Proxy Composer commands with the "php" executable on the isolated site
 elif [[ "$1" = "composer" ]]
 then
-    $(php "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
+    $($PHP "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
 
     exit
 
@@ -144,5 +164,5 @@ else
         exit
     fi
 
-    php "$DIR/cli/valet.php" "$@"
+    $PHP "$DIR/cli/valet.php" "$@"
 fi


### PR DESCRIPTION
This PR adds support for users running PHP 7.4 who have PHP 8+ installed on their machine.

Calls to `valet` now check if the current linked PHP version is 8+; if not, they check whether there's a Brew-installed version of PHP that's 8+, and if so, uses those commands to run Valet.

This shouldn't introduce any lag for users with modern PHP installed, as `php -r "echo phpversion();"` is *very* fast. Users running PHP prior to 8 will see a close-to-one-second lag in all Valet commands; this way we're providing support for that, but also encouraging those users to start using PHP 8+ and to use `valet php` or `valet composer` to proxy their calls back to the older, isolated PHP versions.

This is a temporary fix, and should be removed in the next major version, although at that point we may choose to keep this script but bump up the version we're checking against.

Currently tested and working on PHP 7.4, since WordPress still runs on PHP 7.4.

I'll test PHP 7.3 and 7.2, but if either require any major changes, I don't plan to support them.

- [x] Test on PHP 7.4
- [ ] Test on PHP 8.0+ to make sure this doesn't introduce any lag
- [ ] Test on PHP 7.3
- [ ] Test on PHP 7.2