### PR TITLE
Implement `valet fetch-share-url` when working with Expose

### DIFF
--- a/cli/Valet/Composer.php
+++ b/cli/Valet/Composer.php
@@ -14,13 +14,12 @@ class Composer
     {
         $result = $this->cli->runAsUser("composer global show --format json -- $namespacedPackage");
 
-        if (starts_with($result, 'Changed current')) {
-            $result = strstr($result, '{');
-        }
-
-        // should be a json response, but if not installed then "not found"
         if (str_contains($result, 'InvalidArgumentException') && str_contains($result, 'not found')) {
             return false;
+        }
+
+        if (starts_with($result, 'Changed current')) {
+            $result = strstr($result, '{');
         }
 
         $details = json_decode($result, true);
@@ -41,19 +40,14 @@ class Composer
 
     public function installedVersion(string $namespacedPackage): ?string
     {
-        if (! $this->installed($namespacedPackage)) {
+        $result = $this->cli->runAsUser("composer global show --format json -- $namespacedPackage");
+
+        if (str_contains($result, 'InvalidArgumentException') && str_contains($result, 'not found')) {
             return null;
         }
-
-        $result = $this->cli->runAsUser("composer global show --format json -- $namespacedPackage");
 
         if (starts_with($result, 'Changed current')) {
             $result = strstr($result, '{');
-        }
-
-        // should be a json response, but if not installed then "not found"
-        if (str_contains($result, 'InvalidArgumentException') && str_contains($result, 'not found')) {
-            return null;
         }
 
         $details = json_decode($result, true);

--- a/cli/Valet/Composer.php
+++ b/cli/Valet/Composer.php
@@ -38,4 +38,27 @@ class Composer
             throw new DomainException('Composer was unable to install ['.$namespacedPackage.'].');
         });
     }
+
+    public function installedVersion(string $namespacedPackage): ?string
+    {
+        if (! $this->installed($namespacedPackage)) {
+            return null;
+        }
+
+        $result = $this->cli->runAsUser("composer global show --format json -- $namespacedPackage");
+
+        if (starts_with($result, 'Changed current')) {
+            $result = strstr($result, '{');
+        }
+
+        // should be a json response, but if not installed then "not found"
+        if (str_contains($result, 'InvalidArgumentException') && str_contains($result, 'not found')) {
+            return null;
+        }
+
+        $details = json_decode($result, true);
+        $versions = $details['versions'];
+
+        return reset($versions);
+    }
 }

--- a/cli/Valet/Expose.php
+++ b/cli/Valet/Expose.php
@@ -59,6 +59,14 @@ class Expose
     }
 
     /**
+     * Return which version of Expose is installed.
+     */
+    public function installedVersion(): ?string
+    {
+        return $this->composer->installedVersion('beyondcode/expose');
+    }
+
+    /**
      * Make sure Expose is installed.
      */
     public function ensureInstalled(): void

--- a/cli/Valet/Expose.php
+++ b/cli/Valet/Expose.php
@@ -2,7 +2,6 @@
 
 namespace Valet;
 
-use DomainException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
 
@@ -27,7 +26,7 @@ class Expose
                 }
             }, 250);
 
-            if (!empty($response)) {
+            if (! empty($response)) {
                 return $response;
             }
 

--- a/cli/app.php
+++ b/cli/app.php
@@ -345,7 +345,7 @@ if (is_dir(VALET_HOME_PATH)) {
 
         switch ($tool) {
             case 'expose':
-                output(Expose::currentTunnelUrl(Site::domain($domain)));
+                output(Expose::currentTunnelUrl($domain ?: Site::host(getcwd())));
             break;
             case 'ngrok':
                 try {
@@ -380,6 +380,7 @@ if (is_dir(VALET_HOME_PATH)) {
 
         if ($tool === 'expose') {
             if (Expose::installed()) {
+                // @todo: Check it's the right version (has /api/tunnels/)
                 return;
             }
 

--- a/cli/app.php
+++ b/cli/app.php
@@ -381,6 +381,9 @@ if (is_dir(VALET_HOME_PATH)) {
         if ($tool === 'expose') {
             if (Expose::installed()) {
                 // @todo: Check it's the right version (has /api/tunnels/)
+                // E.g. if (Expose::installedVersion)
+                // if (version_compare(Expose::installedVersion(), $minimumExposeVersion) < 0) {
+                // prompt them to upgrade
                 return;
             }
 

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -88,7 +88,7 @@ function testing(): bool
 /**
  * Output the given text to the console.
  */
-function output(string $output = ''): void
+function output(?string $output = ''): void
 {
     writer()->writeln($output);
 }

--- a/tests/ComposerTest.php
+++ b/tests/ComposerTest.php
@@ -57,4 +57,24 @@ class ComposerTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         resolve(Composer::class)->installOrFail('beyondcode/expose');
     }
+
+    public function test_installed_version_returns_null_when_given_package_is_not_installed()
+    {
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('runAsUser')->once()->with('composer global show --format json -- beyondcode/expose')
+        ->andReturn("Changed current directory to /Users/mattstauffer/.composer\n\n[InvalidArgumentException]\nPackage beyondcode/expose not found");
+        swap(CommandLine::class, $cli);
+
+        $this->assertNull(resolve(Composer::class)->installedVersion('beyondcode/expose'));
+    }
+
+    public function test_installed_version_returns_version_when_package_is_installed()
+    {
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('runAsUser')->twice()->with('composer global show --format json -- beyondcode/expose')
+            ->andReturn('{"versions":["1.4.2"]}');
+        swap(CommandLine::class, $cli);
+
+        $this->assertEquals('1.4.2', resolve(Composer::class)->installedVersion('beyondcode/expose'));
+    }
 }

--- a/tests/ComposerTest.php
+++ b/tests/ComposerTest.php
@@ -62,7 +62,7 @@ class ComposerTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     {
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('runAsUser')->once()->with('composer global show --format json -- beyondcode/expose')
-        ->andReturn("Changed current directory to /Users/mattstauffer/.composer\n\n[InvalidArgumentException]\nPackage beyondcode/expose not found");
+            ->andReturn("Changed current directory to /Users/mattstauffer/.composer\n\n[InvalidArgumentException]\nPackage beyondcode/expose not found");
         swap(CommandLine::class, $cli);
 
         $this->assertNull(resolve(Composer::class)->installedVersion('beyondcode/expose'));
@@ -71,7 +71,7 @@ class ComposerTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     public function test_installed_version_returns_version_when_package_is_installed()
     {
         $cli = Mockery::mock(CommandLine::class);
-        $cli->shouldReceive('runAsUser')->twice()->with('composer global show --format json -- beyondcode/expose')
+        $cli->shouldReceive('runAsUser')->once()->with('composer global show --format json -- beyondcode/expose')
             ->andReturn('{"versions":["1.4.2"]}');
         swap(CommandLine::class, $cli);
 


### PR DESCRIPTION
Depends on https://github.com/beyondcode/expose/pull/363, which hasn't been merged or released yet.

I want to update this to check for the version number of Expose as a dependency once this feature is tagged/released.