### PR TITLE
Add artisan command

### DIFF
--- a/cli/app.php
+++ b/cli/app.php
@@ -645,6 +645,15 @@ You might also want to investigate your global Composer configs. Helpful command
     ]);
 
     /**
+     * Proxy commands through to an isolated site's version of Artisan.
+     */
+    $app->command('artisan [command]', function (OutputInterface $output, $command) {
+        warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
+    })->descriptions("Proxy Artisan commands with isolated site's PHP executable", [
+        'command' => "Artisan command to run with isolated site's PHP executable",
+    ]);
+
+    /**
      * Tail log file.
      */
     $app->command('log [-f|--follow] [-l|--lines=] [key]', function (OutputInterface $output, $follow, $lines, $key = null) {

--- a/valet
+++ b/valet
@@ -93,6 +93,13 @@ then
 
     exit
 
+# Proxy Artisan commands with the "php" executable on the isolated site
+elif [[ "$1" = "artisan" ]]
+then
+    $(php "$DIR/cli/valet.php" which-php) artisan "${@:2}"
+
+    exit
+
 # Finally, for every other command we will just proxy into the PHP tool
 # and let it handle the request. These are commands which can be run
 # without sudo and don't require taking over terminals like Ngrok.


### PR DESCRIPTION
This PR adds a "valet artisan" command which behaves in line with the existing "valet php" and "valet composer" commands. The "valet artisan" command is basically a shortcut for "valet php artisan"