### PR TITLE
Make 127.0.0.1 SERVER_ADDR definition only if null

### DIFF
--- a/cli/Valet/Drivers/BasicValetDriver.php
+++ b/cli/Valet/Drivers/BasicValetDriver.php
@@ -51,7 +51,7 @@ class BasicValetDriver extends ValetDriver
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
         $_SERVER['PHP_SELF'] = $uri;
-        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
+        $_SERVER['SERVER_ADDR'] = $_SERVER['SERVER_ADDR'] ?? '127.0.0.1';
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
         $dynamicCandidates = [

--- a/cli/Valet/Drivers/BedrockValetDriver.php
+++ b/cli/Valet/Drivers/BedrockValetDriver.php
@@ -49,10 +49,6 @@ class BedrockValetDriver extends BasicValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        $_SERVER['PHP_SELF'] = $uri;
-        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
-        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
-
         return parent::frontControllerPath(
             $sitePath.'/web',
             $siteName,

--- a/cli/Valet/Drivers/WordPressValetDriver.php
+++ b/cli/Valet/Drivers/WordPressValetDriver.php
@@ -27,12 +27,10 @@ class WordPressValetDriver extends BasicValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        $_SERVER['PHP_SELF'] = $uri;
-        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
-        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
-
         return parent::frontControllerPath(
-            $sitePath, $siteName, $this->forceTrailingSlash($uri)
+            $sitePath,
+            $siteName,
+            $this->forceTrailingSlash($uri)
         );
     }
 


### PR DESCRIPTION
`BasicValetDriver` and a few drivers which extend it set the `SERVER_ADDR` to `127.0.0.1`. To be honest, I'm not sure what circumstance actually requires this.

Here's the PR that introduced it, which doesn't tell us much: https://github.com/laravel/valet/pull/380

So, in order to support local network sharing in #1284, I'm going to make what I hope a very narrow change that sets it to `127.0.0.1` only if it's `null`.  It doesn't break any tests and doesn't break my environment, so hopefully I'm understanding correctly that this is workable.

I originally wrote this using `??=` but we're stuck on PHP 7.2+.