### PR TITLE
Add php isolation from link command

### DIFF
--- a/cli/app.php
+++ b/cli/app.php
@@ -175,7 +175,7 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Register a symbolic link with Valet.
      */
-    $app->command('link [name] [--secure]', function (OutputInterface $output, $name, $secure) {
+    $app->command('link [name] [--secure] [--phpVersion=]', function (OutputInterface $output, $name, $secure, $phpVersion = null) {
         $linkPath = Site::link(getcwd(), $name = $name ?: basename(getcwd()));
 
         info('A ['.$name.'] symbolic link has been created in ['.$linkPath.'].');
@@ -183,7 +183,18 @@ if (is_dir(VALET_HOME_PATH)) {
         if ($secure) {
             $this->runCommand('secure '.$name);
         }
-    })->descriptions('Link the current working directory to Valet');
+
+        if ($phpVersion) {
+            $this->runCommand(sprintf(
+                'isolate php@%s --site=%s',
+                $phpVersion,
+                $name
+            ));
+        }
+    })->descriptions('Link the current working directory to Valet', [
+        '--secure' => 'Link the site with a trusted TLS certificate',
+        '--phpVersion' => 'The PHP version you want to use to serve the site; e.g 8.1',
+    ]);
 
     /**
      * Display all of the registered symbolic links.
@@ -559,7 +570,7 @@ You might also want to investigate your global Composer configs. Helpful command
 
         PhpFpm::useVersion($phpVersion, $force);
     })->descriptions('Change the version of PHP used by Valet', [
-        'phpVersion' => 'The PHP version you want to use, e.g php@7.3',
+        'phpVersion' => 'The PHP version you want to use, e.g php@8.1',
     ]);
 
     /**

--- a/cli/app.php
+++ b/cli/app.php
@@ -175,25 +175,25 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Register a symbolic link with Valet.
      */
-    $app->command('link [name] [--secure] [--phpVersion=]', function (OutputInterface $output, $name, $secure, $phpVersion = null) {
+    $app->command('link [name] [--secure] [--isolate]', function (OutputInterface $output, $name, $secure, $isolate) {
         $linkPath = Site::link(getcwd(), $name = $name ?: basename(getcwd()));
 
         info('A ['.$name.'] symbolic link has been created in ['.$linkPath.'].');
 
         if ($secure) {
-            $this->runCommand('secure '.$name);
+            $this->runCommand('secure');
         }
 
-        if ($phpVersion) {
-            $this->runCommand(sprintf(
-                'isolate php@%s --site=%s',
-                $phpVersion,
-                $name
-            ));
+        if ($isolate) {
+            if (Site::phpRcVersion($name)) {
+                $this->runCommand('isolate');
+            } else {
+                warning('Valet could not determine which PHP version to use for this site.');
+            }
         }
     })->descriptions('Link the current working directory to Valet', [
-        '--secure' => 'Link the site with a trusted TLS certificate',
-        '--phpVersion' => 'The PHP version you want to use to serve the site; e.g 8.1',
+        '--secure' => 'Link the site with a trusted TLS certificate.',
+        '--isolate' => 'Isolate the site to the PHP version specified in the current working directory\'s .valetphprc file.',
     ]);
 
     /**


### PR DESCRIPTION
This PR  improves the `valet link` command by adding an `--isolate` option to allow users to link, secure and isolate a site in one command.

**Before**
```bash
valet link --secure && valet isolate
```

**After**
```bash
valet link --secure --isolate
```

Please note that the `--isolate` option requires a `.valetphprc` file in the projects root directory as I could not get `$this->runCommand`  to accept any additional arguments / options.