### PR TITLE
Use Pint for Code Styling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,6 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.styleci.yml export-ignore
 phpunit.xml export-ignore
 CHANGELOG.md export-ignore
 phpunit.xml.dist export-ignore

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,7 @@
+name: fix code styling
+
+on: [push]
+
+jobs:
+  lint:
+    uses: laravel/.github/.github/workflows/coding-standards.yml@main

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -5,3 +5,5 @@ on: [push]
 jobs:
   lint:
     uses: laravel/.github/.github/workflows/coding-standards.yml@main
+    with:
+      fix: github.ref_name == 'master'

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,6 +4,5 @@ on: [push]
 
 jobs:
   lint:
+    if: ${{ github.ref_name == 'master' }}
     uses: laravel/.github/.github/workflows/coding-standards.yml@main
-    with:
-      fix: ${{ github.ref_name == 'master' }}

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,5 +4,6 @@ on: [push]
 
 jobs:
   lint:
-    if: ${{ github.ref_name == 'master' }}
     uses: laravel/.github/.github/workflows/coding-standards.yml@main
+    with:
+      fix: ${{ github.ref_name == 'master' }}

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -6,4 +6,4 @@ jobs:
   lint:
     uses: laravel/.github/.github/workflows/coding-standards.yml@main
     with:
-      fix: github.ref_name == 'master'
+      fix: ${{ github.ref_name == 'master' }}

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,0 @@
-php:
-  preset: laravel
-js: true
-css: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 <p align="center">
 <a href="https://github.com/laravel/valet/actions?query=workflow%3ATests"><img src="https://github.com/laravel/valet/workflows/Tests/badge.svg?branch=master" alt="Build Status"></a>
+<a href="https://github.com/laravel/valet/actions/workflows/coding-standards.yml">
+    <img src="https://github.com/laravel/valet/actions/workflows/coding-standards.yml/badge.svg" alt="Coding Standards" />
+</a>
 <a href="https://packagist.org/packages/laravel/valet"><img src="https://poser.pugx.org/laravel/valet/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/laravel/valet"><img src="https://poser.pugx.org/laravel/valet/v/stable.svg" alt="Latest Stable Version"></a>
 <a href="https://packagist.org/packages/laravel/valet"><img src="https://poser.pugx.org/laravel/valet/license.svg" alt="License"></a>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 <p align="center">
 <a href="https://github.com/laravel/valet/actions?query=workflow%3ATests"><img src="https://github.com/laravel/valet/workflows/Tests/badge.svg?branch=master" alt="Build Status"></a>
-<a href="https://github.com/laravel/valet/actions/workflows/coding-standards.yml">
-    <img src="https://github.com/laravel/valet/actions/workflows/coding-standards.yml/badge.svg" alt="Coding Standards" />
-</a>
 <a href="https://packagist.org/packages/laravel/valet"><img src="https://poser.pugx.org/laravel/valet/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/laravel/valet"><img src="https://poser.pugx.org/laravel/valet/v/stable.svg" alt="Latest Stable Version"></a>
 <a href="https://packagist.org/packages/laravel/valet"><img src="https://poser.pugx.org/laravel/valet/license.svg" alt="License"></a>

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -22,10 +22,13 @@ class Brew
         'php71',
         'php70',
     ];
+
     const BREW_DISABLE_AUTO_CLEANUP = 'HOMEBREW_NO_INSTALL_CLEANUP=1';
+
     const LATEST_PHP_VERSION = 'php@8.1';
 
     public $cli;
+
     public $files;
 
     /**

--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -51,8 +51,11 @@ class Diagnose
     ];
 
     public $cli;
+
     public $files;
+
     public $print;
+
     public $progressBar;
 
     /**

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -5,12 +5,17 @@ namespace Valet;
 class DnsMasq
 {
     public $brew;
+
     public $cli;
+
     public $files;
+
     public $configuration;
 
     public $dnsmasqMasterConfigFile = BREW_PREFIX.'/etc/dnsmasq.conf';
+
     public $dnsmasqSystemConfDir = BREW_PREFIX.'/etc/dnsmasq.d';
+
     public $resolverPath = '/etc/resolver';
 
     /**

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -7,10 +7,15 @@ use DomainException;
 class Nginx
 {
     public $brew;
+
     public $cli;
+
     public $files;
+
     public $configuration;
+
     public $site;
+
     const NGINX_CONF = BREW_PREFIX.'/etc/nginx/nginx.conf';
 
     /**

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Client;
 class Ngrok
 {
     public $cli;
+
     public $tunnelsEndpoints = [
         'http://127.0.0.1:4040/api/tunnels',
         'http://127.0.0.1:4041/api/tunnels',

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -7,10 +7,15 @@ use DomainException;
 class PhpFpm
 {
     public $brew;
+
     public $cli;
+
     public $files;
+
     public $config;
+
     public $site;
+
     public $nginx;
 
     public $taps = [

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -8,8 +8,11 @@ use PhpFpm;
 class Site
 {
     public $brew;
+
     public $config;
+
     public $cli;
+
     public $files;
 
     /**

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Client;
 class Valet
 {
     public $cli;
+
     public $files;
 
     public $valetBin = BREW_PREFIX.'/bin/valet';

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -972,6 +972,7 @@ class CommandLineFake extends CommandLine
 class FixturesSiteFake extends Site
 {
     private $valetHomePath;
+
     private $crtCounter = 0;
 
     public function valetHomePath()


### PR DESCRIPTION
This PR sets up Pint to lint code and fail when code isn't styled according to Laravel's coding standards. It will only auto-commit when it's run on master.

This PR also includes the first run and fixes by Pint.