### PR TITLE
Update php and composer commands to allow passing in specific site

### DIFF
--- a/cli/app.php
+++ b/cli/app.php
@@ -641,19 +641,21 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * Proxy commands through to an isolated site's version of PHP.
      */
-    $app->command('php [command]', function (OutputInterface $output, $command) {
+    $app->command('php [--site=] [command]', function (OutputInterface $output, $command) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
     })->descriptions("Proxy PHP commands with isolated site's PHP executable", [
         'command' => "Command to run with isolated site's PHP executable",
+        '--site' => 'Specify the site to use to get the PHP version (e.g. if the site isn\'t linked as its directory name)',
     ]);
 
     /**
      * Proxy commands through to an isolated site's version of Composer.
      */
-    $app->command('composer [command]', function (OutputInterface $output, $command) {
+    $app->command('composer [--site=] [command]', function (OutputInterface $output, $command) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
     })->descriptions("Proxy Composer commands with isolated site's PHP executable", [
         'command' => "Composer command to run with isolated site's PHP executable",
+        '--site' => 'Specify the site to use to get the PHP version (e.g. if the site isn\'t linked as its directory name)',
     ]);
 
     /**

--- a/valet
+++ b/valet
@@ -82,14 +82,24 @@ then
 # Proxy PHP commands to the "php" executable on the isolated site
 elif [[ "$1" = "php" ]]
 then
-    $(php "$DIR/cli/valet.php" which-php) "${@:2}"
+    if [[ $2 == *"--site="* ]]; then
+        SITE=${2#*=}
+        $(php "$DIR/cli/valet.php" which-php $SITE) "${@:3}"
+    else
+        $(php "$DIR/cli/valet.php" which-php) "${@:2}"
+    fi
 
     exit
 
 # Proxy Composer commands with the "php" executable on the isolated site
 elif [[ "$1" = "composer" ]]
 then
-    $(php "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
+    if [[ $2 == *"--site="* ]]; then
+        SITE=${2#*=}
+        $(php "$DIR/cli/valet.php" which-php $SITE) $(which composer) "${@:3}"
+    else
+        $(php "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
+    fi
 
     exit
 


### PR DESCRIPTION
Closes #1367.

E.g., to run this command:

```bash
valet php -v
```

When you've linked a site using a name other than the directory name; for example:

```bash
cd /tmp
mkdir my-site
cd my-site
valet link different-name-than-folder
valet isolate different-name-than-folder php@8.0
```

This PR allows you to run this:

```bash
valet php --site=different-name-than-folder -v
```