### PR TITLE
`brew tap` no longer necessary with Homebrew 4

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Collection;
 class PhpFpm
 {
     public $taps = [
-        'homebrew/homebrew-core',
         'shivammathur/php',
     ];
 


### PR DESCRIPTION
Tapping `homebrew/core` is no longer necessary with [Homebrew 4](https://brew.sh/2023/02/16/homebrew-4.0.0/). 

> - Using JSON files downloaded from [formulae.brew.sh](https://formulae.brew.sh/) for package installation rather than local `homebrew/core` and `homebrew/cask` taps.
> - Unless you are developing formulae or casks, you can `brew untap homebrew/core` and `brew untap homebrew/cask` to save some space.

If a user has upgraded to Homebrew 4, we could skip tapping the repository. This will save about 600MB.

```
Untapping homebrew/core...
Untapped 3 commands and 6580 formulae (6,934 files, 609.7MB).
```

There are some things to take into consideration: 

1. Either Laravel Valet enforce Homebrew 4 (which shouldn't be a problem if Valet runs `brew update`)
2. or check which version of Homebrew is installed.