### PR TITLE
More robust check for Bedrock environments

### DIFF
--- a/cli/Valet/Drivers/Specific/BedrockValetDriver.php
+++ b/cli/Valet/Drivers/Specific/BedrockValetDriver.php
@@ -11,10 +11,11 @@ class BedrockValetDriver extends BasicValetDriver
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
-        return file_exists($sitePath.'/web/app/mu-plugins/bedrock-autoloader.php') ||
-              (is_dir($sitePath.'/web/app/') &&
-               file_exists($sitePath.'/web/wp-config.php') &&
-               file_exists($sitePath.'/config/application.php'));
+        return $this->composerRequires('roots/bedrock-autoloader') ||
+            file_exists($sitePath.'/web/app/mu-plugins/bedrock-autoloader.php') ||
+            (is_dir($sitePath.'/web/app/') &&
+                file_exists($sitePath.'/web/wp-config.php') &&
+                file_exists($sitePath.'/config/application.php'));
     }
 
     /**

--- a/cli/Valet/Drivers/Specific/BedrockValetDriver.php
+++ b/cli/Valet/Drivers/Specific/BedrockValetDriver.php
@@ -11,7 +11,7 @@ class BedrockValetDriver extends BasicValetDriver
      */
     public function serves(string $sitePath, string $siteName, string $uri): bool
     {
-        return $this->composerRequires('roots/bedrock-autoloader') ||
+        return $this->composerRequires($sitePath, 'roots/bedrock-autoloader') ||
             file_exists($sitePath.'/web/app/mu-plugins/bedrock-autoloader.php') ||
             (is_dir($sitePath.'/web/app/') &&
                 file_exists($sitePath.'/web/wp-config.php') &&


### PR DESCRIPTION
Addresses the issue that prompted #1342 by checking for Bedrock-specific Composer dependencies in addition to the existing checks.
