### PR TITLE
Fix read non existing config file

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -152,7 +152,10 @@ class Configuration
      */
     public function read(): array
     {
-        return json_decode($this->files->get($this->path()), true, 512, JSON_THROW_ON_ERROR);
+        if ($this->files->exists($this->path())) {
+            return json_decode($this->files->get($this->path()), true, 512, JSON_THROW_ON_ERROR);
+        }
+        return [];
     }
 
     /**


### PR DESCRIPTION
When composer installing valet, the `config.json` does not exist yet. If we do a status check like `valet status`, the non existing config file is read. Which throws an error/warning. 

```
>> % ./valet status
Checking status...
PHP Warning:  file_get_contents(/Users/someone/.config/valet/config.json): Failed to open stream: No such file or directory in /Users/someone/Development/Tools/valet/cli/Valet/Filesystem.php on line 84

Warning: file_get_contents(/Users/someone/.config/valet/config.json): Failed to open stream: No such file or directory in /Users/someone/Development/Tools/valet/cli/Valet/Filesystem.php on line 84

Valet status: Error

+------------------------------------------+----------+
| Check                                    | Success? |
+------------------------------------------+----------+
| Is Valet fully installed?                | No       |
| Is Valet config valid?                   | No       |
| Is Homebrew installed?                   | Yes      |
| Is DnsMasq installed?                    | Yes      |
| Is Dnsmasq running?                      | Yes      |
| Is Dnsmasq running as root?              | Yes      |
| Is Nginx installed?                      | Yes      |
| Is Nginx running?                        | Yes      |
| Is Nginx running as root?                | Yes      |
| Is PHP installed?                        | Yes      |
| Is linked PHP (php@8.1) running?         | Yes      |
| Is linked PHP (php@8.1) running as root? | Yes      |
| Is valet.sock present?                   | No       |
+------------------------------------------+----------+

Debug suggestions:
Run `composer require laravel/valet` and `valet install`.
Run `valet install` to update your configuration.
Run `valet install`.
```

To fix this we can first check the file of its existence before reading it. 