### PR TITLE
Fix read non existing config file

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -152,7 +152,10 @@ class Configuration
      */
     public function read(): array
     {
-        return json_decode($this->files->get($this->path()), true, 512, JSON_THROW_ON_ERROR);
+        if ($this->files->exists($this->path())) {
+            return json_decode($this->files->get($this->path()), true, 512, JSON_THROW_ON_ERROR);
+        }
+        return [];
     }
 
     /**

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -135,13 +135,12 @@ class CliTest extends BaseApplicationTestCase
         $brew->shouldReceive('installed')->twice()->andReturn(true);
 
         $cli = Mockery::mock(CommandLine::class);
-
         $cli->shouldReceive('run')->once()->andReturn(true);
         $cli->shouldReceive('runAsUser')->once()->with('brew services info --all --json')->andReturn('[{"name":"nginx","running":true}]');
         $cli->shouldReceive('run')->once()->with('brew services info --all --json')->andReturn('[{"name":"nginx","running":true},{"name":"dnsmasq","running":true},{"name":"php@8.2","running":true}]');
 
         $files = Mockery::mock(Filesystem::class.'[exists]');
-        $files->shouldReceive('exists')->once()->andReturn(true);
+        $files->shouldReceive('exists')->andReturn(true);
 
         swap(Brew::class, $brew);
         swap(CommandLine::class, $cli);
@@ -168,7 +167,7 @@ class CliTest extends BaseApplicationTestCase
         $cli->shouldReceive('run')->once()->with('brew services info --all --json')->andReturn('[{"name":"nginx","running":true}]');
 
         $files = Mockery::mock(Filesystem::class.'[exists]');
-        $files->shouldReceive('exists')->once()->andReturn(false);
+        $files->shouldReceive('exists')->andReturn(false);
 
         swap(Brew::class, $brew);
         swap(CommandLine::class, $cli);


### PR DESCRIPTION
When composer installing valet, the config.json does not exist yet. If we do a status check like valet status, the non existing config file is read. Which throws an error/warning.

```
.. % ./valet status
Checking status...
PHP Warning:  file_get_contents(/Users/someone/.config/valet/config.json): Failed to open stream: No such file or directory in /Users/someone/Development/Tools/valet/cli/Valet/Filesystem.php on line 84

Warning: file_get_contents(/Users/someone/.config/valet/config.json): Failed to open stream: No such file or directory in /Users/someone/Development/Tools/valet/cli/Valet/Filesystem.php on line 84

Valet status: Error

+------------------------------------------+----------+
| Check                                    | Success? |
+------------------------------------------+----------+
| Is Valet fully installed?                | No       |
| Is Valet config valid?                   | No       |
| Is Homebrew installed?                   | Yes      |
| Is DnsMasq installed?                    | Yes      |
| Is Dnsmasq running?                      | Yes      |
| Is Dnsmasq running as root?              | Yes      |
| Is Nginx installed?                      | Yes      |
| Is Nginx running?                        | Yes      |
| Is Nginx running as root?                | Yes      |
| Is PHP installed?                        | Yes      |
| Is linked PHP (php@8.1) running?         | Yes      |
| Is linked PHP (php@8.1) running as root? | Yes      |
| Is valet.sock present?                   | No       |
+------------------------------------------+----------+

Debug suggestions:
Run `composer require laravel/valet` and `valet install`.
Run `valet install` to update your configuration.
Run `valet install`.
```

To fix this we can first check the file of its existence before reading it.