### PR TITLE
[v4] Fix ngrok.io proxy/forwarding detection

### DIFF
--- a/cli/Valet/Drivers/LaravelValetDriver.php
+++ b/cli/Valet/Drivers/LaravelValetDriver.php
@@ -18,8 +18,8 @@ class LaravelValetDriver extends ValetDriver
      */
     public function beforeLoading(string $sitePath, string $siteName, string $uri): void
     {
-        // Shortcut for getting the "local" hostname as the HTTP_HOST
-        if (isset($_SERVER['HTTP_X_ORIGINAL_HOST'], $_SERVER['HTTP_X_FORWARDED_HOST'])) {
+        // Shortcut for getting the "local" hostname as the HTTP_HOST, especially when proxied or using 'share'
+        if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
             $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
         }
     }


### PR DESCRIPTION
Fixes #1384

Since Valet 4 uses Ngrok v3, this change is needed to accommodate the change ngrok made:
> In ngrok v3 the `X-Original-Host` header was replaced with the more standard `X-Forwarded-Host` to better align with web standards.
> More Info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host

Credit to @streamingsystems for doing the legwork.
