### PR TITLE
Add driver for Radicle by roots.io

### DIFF
--- a/cli/Valet/Drivers/Specific/RadicleValetDriver.php
+++ b/cli/Valet/Drivers/Specific/RadicleValetDriver.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Valet\Drivers;
+
+class RadicleValetDriver extends BasicValetDriver
+{
+    /**
+     * Determine if the driver serves the request.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return bool
+     */
+    public function serves($sitePath, $siteName, $uri)
+    {
+        return is_dir($sitePath.'/.radicle-setup');
+    }
+
+    /**
+     * Determine if the incoming request is for a static file.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string|false
+     */
+    public function isStaticFile($sitePath, $siteName, $uri)
+    {
+        $staticFilePath = $sitePath.'/public'.$uri;
+
+        if ($this->isActualFile($staticFilePath)) {
+            return $staticFilePath;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        return parent::frontControllerPath(
+            $sitePath.'/public',
+            $siteName,
+            $this->forceTrailingSlash($uri)
+        );
+    }
+
+    /**
+     * Redirect to uri with trailing slash.
+     *
+     * @param  string  $uri
+     * @return string
+     */
+    private function forceTrailingSlash($uri)
+    {
+        if (substr($uri, -1 * strlen('/wp/wp-admin')) == '/wp/wp-admin') {
+            header('Location: '.$uri.'/');
+            exit;
+        }
+
+        return $uri;
+    }
+}

--- a/cli/Valet/Drivers/Specific/RadicleValetDriver.php
+++ b/cli/Valet/Drivers/Specific/RadicleValetDriver.php
@@ -12,9 +12,9 @@ class RadicleValetDriver extends BasicValetDriver
      * @param  string  $uri
      * @return bool
      */
-    public function serves($sitePath, $siteName, $uri)
+    public function serves($sitePath, $siteName, $uri): bool
     {
-        return is_dir($sitePath.'/.radicle-setup');
+        return is_dir($sitePath . '/.radicle-setup');
     }
 
     /**
@@ -27,7 +27,7 @@ class RadicleValetDriver extends BasicValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        $staticFilePath = $sitePath.'/public'.$uri;
+        $staticFilePath = $sitePath . '/public' . $uri;
 
         if ($this->isActualFile($staticFilePath)) {
             return $staticFilePath;
@@ -44,10 +44,10 @@ class RadicleValetDriver extends BasicValetDriver
      * @param  string  $uri
      * @return string
      */
-    public function frontControllerPath($sitePath, $siteName, $uri)
+    public function frontControllerPath($sitePath, $siteName, $uri): ?string
     {
         return parent::frontControllerPath(
-            $sitePath.'/public',
+            $sitePath . '/public',
             $siteName,
             $this->forceTrailingSlash($uri)
         );
@@ -62,7 +62,7 @@ class RadicleValetDriver extends BasicValetDriver
     private function forceTrailingSlash($uri)
     {
         if (substr($uri, -1 * strlen('/wp/wp-admin')) == '/wp/wp-admin') {
-            header('Location: '.$uri.'/');
+            header('Location: ' . $uri . '/');
             exit;
         }
 


### PR DESCRIPTION
The good folks at [roots](https://roots.io) released a new opinionated boilerplate called for WordPress that brings a lot of Laravel-esque goodness to WP development.

However, the current `BedrockValetDriver` is not compatible with it, and so Valet doesn't work out-of-the-box.

This PR seeks to fix that by adding a new `RadicleValetDriver` that should do the trick.