### PR TITLE
Install older PHP versions via alternate tap

### DIFF
--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -203,6 +203,22 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         resolve(Brew::class)->linkedPhp();
     }
 
+    public function test_outdated_php_versions_use_the_alternate_tap()
+    {
+        $brewMock = Mockery::mock(Brew::class, [
+            $cli = Mockery::mock(CommandLine::class),
+            Mockery::mock(Filesystem::class),
+        ])->makePartial();
+
+        $brewMock->shouldReceive('limitedPhpVersions')->andReturn(collect([
+            'php@7.0',
+        ]));
+
+        $cli->shouldReceive('runAsUser')->once()->with(Brew::BREW_DISABLE_AUTO_CLEANUP.' brew install shivammathur/php/php@7.0', Mockery::type('Closure'));
+
+        $brewMock->installOrFail('php@7.0');
+    }
+
     public function test_install_or_fail_will_install_brew_formulae()
     {
         $cli = Mockery::mock(CommandLine::class);


### PR DESCRIPTION
Fixes #1407

Homebrew's support policy now aggressively disables older versions earlier than it did previously. That is why we tap the `shivammathur/php` repository.

But since Homebrew also now "keeps" those old formulae but marks them as disabled, when Valet runs `brew install php@7.4` it fails because Homebrew just aborts due to its flags in the outdated formula. (They mark it as "disabled" and/or "keg_only :versioned_formula".) To override that we must use `brew install shivammathur/php/php@7.4` internally.

Therefore, we need to maintain a list of which PHP Versions we wish to specifically prefix with the `shivammathur/php` tap in order to bypass Homebrew's flags.

**ANNUAL MAINTENANCE**
1. This PR adds the array of `LIMITED_PHP_VERSIONS` which we will have to update annually when new PHP versions are retired as others are released.
2. We should also annually update the `LATEST_PHP_VERSION` string.
