### PR TITLE
Add "valet stop dnsmasq" option

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -48,6 +48,14 @@ class DnsMasq
     }
 
     /**
+     * Stop the dnsmasq service.
+     */
+    public function stop(): void
+    {
+        $this->brew->stopService(['dnsmasq']);
+    }
+
+    /**
      * Tell Homebrew to restart dnsmasq.
      */
     public function restart(): void

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -112,6 +112,7 @@ class PhpFpm
      */
     public function stop(): void
     {
+        info('Stopping phpfpm...');
         call_user_func_array(
             [$this->brew, 'stopService'],
             Brew::SUPPORTED_PHP_VERSIONS
@@ -138,6 +139,7 @@ class PhpFpm
      */
     public function stopRunning(): void
     {
+        info('Stopping phpfpm...');
         $this->brew->stopService(
             $this->brew->getAllRunningServices()
                 ->filter(function ($service) {

--- a/cli/app.php
+++ b/cli/app.php
@@ -506,7 +506,13 @@ if (is_dir(VALET_HOME_PATH)) {
                 PhpFpm::stopRunning();
                 Nginx::stop();
 
-                return info('Valet services have been stopped.');
+                return info('Valet core services have been stopped. To also stop dnsmasq, run: valet stop dnsmasq');
+            case 'all':
+                PhpFpm::stopRunning();
+                Nginx::stop();
+                Dnsmasq::stop();
+
+                return info('All Valet services have been stopped.');
             case 'nginx':
                 Nginx::stop();
 
@@ -515,10 +521,14 @@ if (is_dir(VALET_HOME_PATH)) {
                 PhpFpm::stopRunning();
 
                 return info('PHP has been stopped.');
+            case 'dnsmasq':
+                Dnsmasq::stop();
+
+                return info('dnsmasq has been stopped.');
         }
 
         return warning(sprintf('Invalid valet service name [%s]', $service));
-    })->descriptions('Stop the Valet services');
+    })->descriptions('Stop the core Valet services, or all services by specifying "all".');
 
     /**
      * Uninstall Valet entirely. Requires --force to actually remove; otherwise manual instructions are displayed.

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -759,7 +759,7 @@ class CliTest extends BaseApplicationTestCase
         $tester->run(['command' => 'stop']);
         $tester->assertCommandIsSuccessful();
 
-        $this->assertStringContainsString('Valet services have been stopped.', $tester->getDisplay());
+        $this->assertStringContainsString('Valet core services have been stopped.', $tester->getDisplay());
     }
 
     public function test_stop_command_stops_nginx()
@@ -790,6 +790,21 @@ class CliTest extends BaseApplicationTestCase
         $tester->assertCommandIsSuccessful();
 
         $this->assertStringContainsString('PHP has been stopped', $tester->getDisplay());
+    }
+
+    public function test_stop_all_command_stops_dnsmasq()
+    {
+        [$app, $tester] = $this->appAndTester();
+
+        $phpfpm = Mockery::mock(DnsMasq::class);
+        $phpfpm->shouldReceive('stop');
+
+        swap(DnsMasq::class, $phpfpm);
+
+        $tester->run(['command' => 'stop', 'service' => 'dnsmasq']);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('dnsmasq has been stopped', $tester->getDisplay());
     }
 
     public function test_stop_command_handles_bad_services()


### PR DESCRIPTION
Fixes #1419

Adds:
- `valet stop dnsmasq`
- `valet stop all` (which includes php, nginx, dnsmasq) ... while `valet stop` still only stops nginx/php as it always has.
- When `valet stop` is called without a service name, a message indicates that dnsmasq can also be stopped via `valet stop dnsmasq`
- Aside: _phpfpm_ now also displays a message when stopping; previously it was silent.
