### PR TITLE
Fix link command's `--isolate` argument with custom name

### DIFF
--- a/cli/app.php
+++ b/cli/app.php
@@ -201,7 +201,7 @@ if (is_dir(VALET_HOME_PATH)) {
         }
 
         if ($isolate) {
-            if (Site::phpRcVersion($name)) {
+            if (Site::phpRcVersion($name, getcwd())) {
                 $this->runCommand('isolate --site='.$name);
             } else {
                 warning('Valet could not determine which PHP version to use for this site.');

--- a/cli/app.php
+++ b/cli/app.php
@@ -197,12 +197,12 @@ if (is_dir(VALET_HOME_PATH)) {
         info('A ['.$name.'] symbolic link has been created in ['.$linkPath.'].');
 
         if ($secure) {
-            $this->runCommand('secure');
+            $this->runCommand('secure '.$name);
         }
 
         if ($isolate) {
             if (Site::phpRcVersion($name)) {
-                $this->runCommand('isolate');
+                $this->runCommand('isolate --site='.$name);
             } else {
                 warning('Valet could not determine which PHP version to use for this site.');
             }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php": "^7.1|^8.0",
         "illuminate/collections": "^8.0|^9.0|^10.0",
         "illuminate/container": "~5.1|^6.0|^7.0|^8.0|^9.0|^10.0",
-        "mnapoli/silly": "^1.0",
+        "mnapoli/silly": "^1.5",
         "symfony/console": "^3.0|^4.0|^5.0|^6.0",
         "symfony/process": "^3.0|^4.0|^5.0|^6.0",
         "guzzlehttp/guzzle": "^6.0|^7.4",

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
             "tests/Drivers/BaseDriverTestCase.php"
         ]
     },
+    "conflict": {
+        "mnapoli/silly": ">=1.8.1 <1.8.3"
+    },
     "require": {
         "php": "^7.1|^8.0",
         "illuminate/collections": "^8.0|^9.0|^10.0",

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -259,17 +259,17 @@ class CliTest extends BaseApplicationTestCase
     {
         [$app, $tester] = $this->appAndTester();
 
-        $cwd  = getcwd();
+        $cwd = getcwd();
         $name = 'tighten';
         $host = $name.'.test';
 
         $customPhpVersion = '82';
-        $phpRcVersion     = '8.2';
-        $fullPhpVersion   = 'php@8.2';
+        $phpRcVersion = '8.2';
+        $fullPhpVersion = 'php@8.2';
 
-        $brewMock  = Mockery::mock(Brew::class);
+        $brewMock = Mockery::mock(Brew::class);
         $nginxMock = Mockery::mock(Nginx::class);
-        $siteMock  = Mockery::mock(RealSite::class);
+        $siteMock = Mockery::mock(RealSite::class);
 
         $phpFpmMock = Mockery::mock(PhpFpm::class, [
             $brewMock,

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -10,6 +10,7 @@ use Valet\Filesystem;
 use Valet\Nginx;
 use Valet\Ngrok;
 use Valet\PhpFpm;
+use function Valet\resolve;
 use Valet\Site as RealSite;
 use Valet\Valet;
 
@@ -252,6 +253,70 @@ class CliTest extends BaseApplicationTestCase
         $tester->assertCommandIsSuccessful();
 
         $this->assertStringContainsString('site has been secured', $tester->getDisplay());
+    }
+
+    public function test_link_command_with_isolate_flag_isolates()
+    {
+        [$app, $tester] = $this->appAndTester();
+
+        $cwd  = getcwd();
+        $name = 'tighten';
+        $host = $name.'.test';
+
+        $customPhpVersion = '82';
+        $phpRcVersion     = '8.2';
+        $fullPhpVersion   = 'php@8.2';
+
+        $brewMock  = Mockery::mock(Brew::class);
+        $nginxMock = Mockery::mock(Nginx::class);
+        $siteMock  = Mockery::mock(RealSite::class);
+
+        $phpFpmMock = Mockery::mock(PhpFpm::class, [
+            $brewMock,
+            resolve(CommandLine::class),
+            resolve(Filesystem::class),
+            resolve(RealConfiguration::class),
+            $siteMock,
+            $nginxMock,
+        ])->makePartial();
+
+        swap(Brew::class, $brewMock);
+        swap(Nginx::class, $nginxMock);
+        swap(PhpFpm::class, $phpFpmMock);
+        swap(RealSite::class, $siteMock);
+
+        $brewMock->shouldReceive('supportedPhpVersions')->andReturn(collect([
+            'php@8.2',
+            'php@8.1',
+        ]));
+
+        $brewMock->shouldReceive('ensureInstalled')->with($fullPhpVersion, [], $phpFpmMock->taps);
+        $brewMock->shouldReceive('installed')->with($fullPhpVersion);
+        $brewMock->shouldReceive('determineAliasedVersion')->with($fullPhpVersion)->andReturn($fullPhpVersion);
+
+        $siteMock->shouldReceive('link')->with($cwd, $name)->once();
+        $siteMock->shouldReceive('getSiteUrl')->with($name)->andReturn($host);
+        $siteMock->shouldReceive('phpRcVersion')->with($name, $cwd)->andReturn($phpRcVersion);
+        $siteMock->shouldReceive('customPhpVersion')->with($host)->andReturn($customPhpVersion);
+        $siteMock->shouldReceive('isolate')->with($host, $fullPhpVersion);
+
+        $phpFpmMock->shouldReceive('stopIfUnused')->with($customPhpVersion)->once();
+        $phpFpmMock->shouldReceive('createConfigurationFiles')->with($fullPhpVersion)->once();
+        $phpFpmMock->shouldReceive('restart')->with($fullPhpVersion)->once();
+
+        $nginxMock->shouldReceive('restart')->once();
+
+        // These should only run when doing global PHP switches
+        $brewMock->shouldNotReceive('stopService');
+        $brewMock->shouldNotReceive('link');
+        $brewMock->shouldNotReceive('unlink');
+        $phpFpmMock->shouldNotReceive('stopRunning');
+        $phpFpmMock->shouldNotReceive('install');
+
+        $tester->run(['command' => 'link', 'name' => 'tighten', '--isolate' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('is now using '.$fullPhpVersion, $tester->getDisplay());
     }
 
     public function test_links_command()


### PR DESCRIPTION
Related to #1386.

Tested in laravel/valet v4.1.2 with [mnapoli/silly](https://github.com/mnapoli/silly) v1.8.2 and [symfony/console](https://github.com/symfony/console) v6.2.5.

~~🟡 Unfortunately, a bug introduced in mnapoli/silly v1.8.1 breaks all arguments in `runCommand()` method preventing this pull request from resolving the isolation issue. See mnapoli/silly#69 for details and mnapoli/silly#70 for pull request.~~

🟢 Bug resolved in [mnapoli/silly v1.8.3](https://github.com/mnapoli/silly/releases/tag/1.8.3).

Passing a custom hostname to the `link` command with the `--isolate` argument will result in either a mismatched site being isolated or the site not being found:

```sh
~/Projects/example.com/www/_codebase
$ valet link example --secure --isolate
A [example] symbolic link has been created in [~/.config/valet/Sites/example].
Restarting nginx...
The [example.test] site has been secured with a fresh TLS certificate.
Found '_codebase/.valetrc' or '_codebase/.valetphprc' specifying version: php@8.1

In Site.php line 182:

  The [_codebase] site could not be found in Valet's site list.


link [--secure] [--isolate] [--] [<name>]
```

The reason for this is because the `isolate` command defaults to using the current directory's _name_ which won't match the custom hostname.

This issue does not affect the `secure` command because it resolves the hostname from the current directory's _full path_.

This pull request passes the hostname (regardless if custom or the current directory's name) to both sub-commands to ensure consistency of operations.
