### PR TITLE
Only delete DNSMasq resolver when Herd is not installed

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -43,8 +43,13 @@ class DnsMasq
         $this->brew->stopService('dnsmasq');
         $this->brew->uninstallFormula('dnsmasq');
         $this->cli->run('rm -rf '.BREW_PREFIX.'/etc/dnsmasq.d/dnsmasq-valet.conf');
-        $tld = $this->configuration->read()['tld'];
-        $this->files->unlink($this->resolverPath.'/'.$tld);
+
+        // As Laravel Herd uses the same DnsMasq resolver, we should only
+        // delete if, if Herd is not installed.
+        if (!$this->files->exists('/Applications/Herd.app')) {
+            $tld = $this->configuration->read()['tld'];
+            $this->files->unlink($this->resolverPath . '/' . $tld);
+        }
     }
 
     /**

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -45,7 +45,7 @@ class DnsMasq
         $this->cli->run('rm -rf '.BREW_PREFIX.'/etc/dnsmasq.d/dnsmasq-valet.conf');
 
         // As Laravel Herd uses the same DnsMasq resolver, we should only
-        // delete if, if Herd is not installed.
+        // delete it if Herd is not installed.
         if (!$this->files->exists('/Applications/Herd.app')) {
             $tld = $this->configuration->read()['tld'];
             $this->files->unlink($this->resolverPath . '/' . $tld);


### PR DESCRIPTION
This PR ensures that the DNSMasq resolver configuration file only gets deleted when Laravel Herd is not installed.
Right now this introduces a bug when a user:

1. Installs Herd
2. Uninstalls Valet

As Valet then deletes the DNSMasq resolver that Herd still uses.