### PR TITLE
Add support for proxying multiple domains at once

### DIFF
--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -396,6 +396,23 @@ class CliTest extends BaseApplicationTestCase
         $tester->assertCommandIsSuccessful();
     }
 
+    public function test_proxy_command_with_multiple_domains()
+    {
+        [$app, $tester] = $this->appAndTester();
+
+        $site = Mockery::mock(RealSite::class);
+        $site->shouldReceive('proxyCreate')->with('my-app,subdomain.my-app', 'http://127.0.0.1:8000', false)->once();
+
+        $nginx = Mockery::mock(Nginx::class);
+        $nginx->shouldReceive('restart')->once();
+
+        swap(Nginx::class, $nginx);
+        swap(RealSite::class, $site);
+
+        $tester->run(['command' => 'proxy', 'domain' => 'my-app,subdomain.my-app', 'host' => 'http://127.0.0.1:8000']);
+        $tester->assertCommandIsSuccessful();
+    }
+
     public function test_unproxy_command()
     {
         [$app, $tester] = $this->appAndTester();


### PR DESCRIPTION
This PR adds support for proxying multiple domains at once with a comma separated list of domains, such as `valet proxy my-domain,sub.my-domain http://127.0.0.1:8000`

The change is backwards compatible, since I explode the URL by comma, if there's no comma present it works as before.

Reason for this change is working locally with Octane can be a bit frustrating. We have an app that uses multiple domains and we use Valet to proxy those domains to Octane. However, currently we'd have to run these commands:
```sh
valet proxy domain http://127.0.0.1:8000
valet proxy sub.domain http://127.0.0.1:8000
valet proxy api.domain http://127.0.0.1:8000
```
This not only takes a long time, Valet also restarts nginx after each command, prompting for the sudo password every time.
With this change it can be done in a single command, is much faster and only restarts nginx once;
```sh
valet proxy domain,sub.domain,api.domain http://127.0.0.1:8000
```

It also includes the `unproxy` command
```sh
valet unproxy domain,sub.domain,api.domain
```
And this will also work if you proxied `domain,api.domain` and then run `valet unproxy api.domain`, as it will only unproxy the `api.domain` and keep the `domain` proxy