### PR TITLE
Drop Mailhog and Redis from default logs list, since Valet doesn't install them

### DIFF
--- a/cli/app.php
+++ b/cli/app.php
@@ -728,8 +728,6 @@ if (is_dir(VALET_HOME_PATH)) {
         $defaultLogs = [
             'php-fpm' => BREW_PREFIX.'/var/log/php-fpm.log',
             'nginx' => VALET_HOME_PATH.'/Log/nginx-error.log',
-            'mailhog' => BREW_PREFIX.'/var/log/mailhog.log',
-            'redis' => BREW_PREFIX.'/var/log/redis.log',
         ];
 
         $configLogs = data_get(Configuration::read(), 'logs');


### PR DESCRIPTION
In the original PR (https://github.com/laravel/valet/pull/757), we included Mailhog and Redis, but it's always bothered me because they're not actually installed by default.

This PR removes them and only has default log items that are actually installed.
