### PR TITLE
Allow LaravelValetDriver to serve other /public/*.php files

### DIFF
--- a/cli/Valet/Drivers/LaravelValetDriver.php
+++ b/cli/Valet/Drivers/LaravelValetDriver.php
@@ -52,6 +52,11 @@ class LaravelValetDriver extends ValetDriver
      */
     public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
     {
+        if (file_exists($staticFilePath = $sitePath.'/public'.$uri)
+           && $this->isActualFile($staticFilePath)) {
+            return $staticFilePath;
+        }
+
         return $sitePath.'/public/index.php';
     }
 }


### PR DESCRIPTION
When PHP files other than index.php exist in /public/ this allows them to be served by the Laravel driver.

I discussed this previously at: https://github.com/laravel/valet/discussions/1430#discussioncomment-6536474 ... but I think it's safe to include in the core LaravelValetDriver by default.
