### PR TITLE
handle deprecated http2_push_preload conf for nginx >= 1.25.1

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -631,8 +631,11 @@ class Site
     public function buildSecureNginxServer(string $url, string $siteConf = null): string
     {
         if ($siteConf === null) {
+            $nginxVersion = ltrim(exec('nginx -v'), 'nginx version: nginx/');
+            $configFile = version_compare($nginxVersion, '1.25.1', ">=") ? 'secure.valet.conf' : 'secure.valet-legacy.conf';
+
             $siteConf = $this->replaceOldLoopbackWithNew(
-                $this->files->getStub('secure.valet.conf'),
+                $this->files->getStub($configFile),
                 'VALET_LOOPBACK',
                 $this->valetLoopback()
             );
@@ -774,8 +777,11 @@ class Site
                 $proxyUrl .= '.'.$tld;
             }
 
+            $nginxVersion = ltrim(exec('nginx -v'), 'nginx version: nginx/');
+            $configFile = version_compare($nginxVersion, '1.25.1', ">=") ? 'secure.proxy.valet.conf' : 'secure.proxy.valet-legacy.conf';
+
             $siteConf = $this->replaceOldLoopbackWithNew(
-                $this->files->getStub($secure ? 'secure.proxy.valet.conf' : 'proxy.valet.conf'),
+                $this->files->getStub($secure ? $configFile : 'proxy.valet.conf'),
                 'VALET_LOOPBACK',
                 $this->valetLoopback()
             );

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -631,7 +631,7 @@ class Site
     public function buildSecureNginxServer(string $url, string $siteConf = null): string
     {
         if ($siteConf === null) {
-            $nginxVersion = str_replace('nginx version: nginx/', '', exec('nginx -v'));
+            $nginxVersion = str_replace('nginx version: nginx/', '', exec('nginx -v 2>&1'));
             $configFile = version_compare($nginxVersion, '1.25.1', ">=") ? 'secure.valet.conf' : 'secure.valet-legacy.conf';
 
             $siteConf = $this->replaceOldLoopbackWithNew(
@@ -777,7 +777,7 @@ class Site
                 $proxyUrl .= '.'.$tld;
             }
 
-            $nginxVersion = str_replace('nginx version: nginx/', '', exec('nginx -v'));
+            $nginxVersion = str_replace('nginx version: nginx/', '', exec('nginx -v 2>&1'));
             $configFile = version_compare($nginxVersion, '1.25.1', ">=") ? 'secure.proxy.valet.conf' : 'secure.proxy.valet-legacy.conf';
 
             $siteConf = $this->replaceOldLoopbackWithNew(

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -631,7 +631,7 @@ class Site
     public function buildSecureNginxServer(string $url, string $siteConf = null): string
     {
         if ($siteConf === null) {
-            $nginxVersion = ltrim(exec('nginx -v'), 'nginx version: nginx/');
+            $nginxVersion = str_replace('nginx version: nginx/', '', exec('nginx -v'));
             $configFile = version_compare($nginxVersion, '1.25.1', ">=") ? 'secure.valet.conf' : 'secure.valet-legacy.conf';
 
             $siteConf = $this->replaceOldLoopbackWithNew(
@@ -777,7 +777,7 @@ class Site
                 $proxyUrl .= '.'.$tld;
             }
 
-            $nginxVersion = ltrim(exec('nginx -v'), 'nginx version: nginx/');
+            $nginxVersion = str_replace('nginx version: nginx/', '', exec('nginx -v'));
             $configFile = version_compare($nginxVersion, '1.25.1', ">=") ? 'secure.proxy.valet.conf' : 'secure.proxy.valet-legacy.conf';
 
             $siteConf = $this->replaceOldLoopbackWithNew(

--- a/cli/stubs/secure.proxy.valet-legacy.conf
+++ b/cli/stubs/secure.proxy.valet-legacy.conf
@@ -1,0 +1,57 @@
+# valet stub: secure.proxy.valet.conf
+
+server {
+    listen 127.0.0.1:80;
+    #listen VALET_LOOPBACK:80; # valet loopback
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 127.0.0.1:443 ssl http2;
+    #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+    http2_push_preload on;
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    ssl_certificate "VALET_CERT";
+    ssl_certificate_key "VALET_KEY";
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/VALET_SITE-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location / {
+        proxy_pass VALET_PROXY_HOST;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Client-Verify   SUCCESS;
+        proxy_set_header   X-Client-DN       $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Subject     $ssl_client_s_dn;
+        proxy_set_header   X-SSL-Issuer      $ssl_client_i_dn;
+        proxy_set_header   X-NginX-Proxy true;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_read_timeout 1800;
+        proxy_connect_timeout 1800;
+        chunked_transfer_encoding on;
+        proxy_redirect off;
+        proxy_buffering off;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/cli/stubs/secure.proxy.valet.conf
+++ b/cli/stubs/secure.proxy.valet.conf
@@ -8,13 +8,13 @@ server {
 }
 
 server {
-    listen 127.0.0.1:443 ssl http2;
-    #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
+    listen 127.0.0.1:443 ssl;
+    #listen VALET_LOOPBACK:443 ssl; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
     client_max_body_size 128M;
-    http2_push_preload on;
+    http2 on;
 
     location /VALET_STATIC_PREFIX/ {
         internal;

--- a/cli/stubs/secure.valet-legacy.conf
+++ b/cli/stubs/secure.valet-legacy.conf
@@ -1,0 +1,93 @@
+server {
+    listen 127.0.0.1:80;
+    #listen VALET_LOOPBACK:80; # valet loopback
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 127.0.0.1:443 ssl http2;
+    #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 512M;
+    http2_push_preload on;
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    ssl_certificate "VALET_CERT";
+    ssl_certificate_key "VALET_KEY";
+
+    location / {
+        rewrite ^ "VALET_SERVER_PATH" last;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/nginx-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass "unix:VALET_HOME_PATH/valet.sock";
+        fastcgi_index "VALET_SERVER_PATH";
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+server {
+    listen 127.0.0.1:60;
+    #listen VALET_LOOPBACK:60; # valet loopback
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location / {
+        rewrite ^ "VALET_SERVER_PATH" last;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/nginx-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass "unix:VALET_HOME_PATH/valet.sock";
+        fastcgi_index "VALET_SERVER_PATH";
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -6,13 +6,12 @@ server {
 }
 
 server {
-    listen 127.0.0.1:443 ssl http2;
-    #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
+    listen 127.0.0.1:443 ssl;
+    #listen VALET_LOOPBACK:443 ssl; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
     client_max_body_size 512M;
-    http2_push_preload on;
 
     location /VALET_STATIC_PREFIX/ {
         internal;

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -12,6 +12,7 @@ server {
     root /;
     charset utf-8;
     client_max_body_size 512M;
+    http2  on;
 
     location /VALET_STATIC_PREFIX/ {
         internal;


### PR DESCRIPTION
Updated the config so it will work for fresh installs.

removed http2 and http2_push_preload because they are deprecated in latest Nginx versions. 