### PR TITLE
Bandage for 502 errors using Gettext/PostgreSQL/MongoDB

### DIFF
--- a/cli/stubs/etc-phpfpm-valet.conf
+++ b/cli/stubs/etc-phpfpm-valet.conf
@@ -24,3 +24,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 
+;; these are an attempt to mitigate 502 errors caused by segfaults in upstream processes caused by krb5 v1.21 added in June 2023 to php's core build. Ref Issue #1433
+; for gettext
+env['LC_ALL'] = C
+; for postgres
+env['PGGSSENCMODE'] = disable
+


### PR DESCRIPTION
Many have reported that these changes "do" help the problem. 
And yet many others have reported that they make no difference.
Your mileage may vary. But, contributing this PR for the benefit of those for whom it "does" help.

To activate: simply run `valet install` after `composer global upgrade laravel/valet -W` to get the version of Valet this is merged into.

Closes #1433

This PR is merely a bandage for a broader problem that exists in the PHP build for MacOS. See the issue referenced above for discussion and links to Homebrew and PHP repository discussions. The problem is not in Homebrew, but in the PHP build published by the PHP core. Chime in on the PHP discussion if you want to stir up more active participation for a proper fix, telling them that you're a Mac user encountering the fork segfaults (they won't care whether you're using Valet, but they will recognize if you mention Homebrew).
