### PR TITLE
add server name to valet.conf

### DIFF
--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -1,6 +1,7 @@
 server {
     listen 127.0.0.1:80 default_server;
     #listen VALET_LOOPBACK:80; # valet loopback
+    server_name valet;
     root /;
     charset utf-8;
     client_max_body_size 128M;


### PR DESCRIPTION
Added server name to nginx for more comfortable debugging in PHPStorm. PHPStorm requires not empty server_name 
