### PR TITLE
Update "fetch-share-url" to pull correct URL for HTTPS tunnels, not just HTTP

### DIFF
--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -51,15 +51,14 @@ class Ngrok
     }
 
     /**
-     * Find the HTTP tunnel URL from the list of tunnels.
+     * Find the HTTP/HTTPS tunnel URL from the list of tunnels.
      */
     public function findHttpTunnelUrl(array $tunnels, string $domain): ?string
     {
         // If there are active tunnels on the Ngrok instance we will spin through them and
         // find the one responding on HTTP. Each tunnel has an HTTP and a HTTPS address
-        // but for local dev purposes we just desire the plain HTTP URL endpoint.
         foreach ($tunnels as $tunnel) {
-            if ($tunnel->proto === 'http' && strpos($tunnel->config->addr, strtolower($domain))) {
+            if (($tunnel->proto === 'http' || $tunnel->proto === 'https')  && strpos($tunnel->config->addr, strtolower($domain))) {
                 return $tunnel->public_url;
             }
         }

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -55,16 +55,28 @@ class Ngrok
      */
     public function findHttpTunnelUrl(array $tunnels, string $domain): ?string
     {
+        $httpTunnel = null;
+        $httpsTunnel = null;
+
         // If there are active tunnels on the Ngrok instance we will spin through them and
         // find the one responding on HTTP. Each tunnel has an HTTP and a HTTPS address
+        // if no HTTP tunnel is found we will return the HTTPS tunnel as a fallback.
+
+        // Iterate through tunnels to find both HTTP and HTTPS tunnels
         foreach ($tunnels as $tunnel) {
-            if (($tunnel->proto === 'http' || $tunnel->proto === 'https')  && stripos($tunnel->config->addr, $domain)) {
-                return $tunnel->public_url;
+            if (stripos($tunnel->config->addr, $domain)) {
+                if ($tunnel->proto === 'http') {
+                    $httpTunnel = $tunnel->public_url;
+                } elseif ($tunnel->proto === 'https') {
+                    $httpsTunnel = $tunnel->public_url;
+                }
             }
         }
 
-        return null;
+        // Return HTTP tunnel if available, otherwise return HTTPS tunnel
+        return $httpTunnel ?? $httpsTunnel;
     }
+
 
     /**
      * Set the Ngrok auth token.

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -58,7 +58,7 @@ class Ngrok
         // If there are active tunnels on the Ngrok instance we will spin through them and
         // find the one responding on HTTP. Each tunnel has an HTTP and a HTTPS address
         foreach ($tunnels as $tunnel) {
-            if (($tunnel->proto === 'http' || $tunnel->proto === 'https')  && strpos($tunnel->config->addr, strtolower($domain))) {
+            if (($tunnel->proto === 'http' || $tunnel->proto === 'https')  && stripos($tunnel->config->addr, $domain)) {
                 return $tunnel->public_url;
             }
         }

--- a/tests/NgrokTest.php
+++ b/tests/NgrokTest.php
@@ -31,21 +31,34 @@ class NgrokTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
                 'config' => (object) [
                     'addr' => 'http://mysite.test:80',
                 ],
-                'public_url' => 'https://right-one.ngrok.io/',
+                'public_url' => 'http://bad-proto.ngrok.io/',
             ],
             (object) [
                 'proto' => 'http',
                 'config' => (object) [
-                    'addr' => 'http://mynewsite.test:80',
+                    'addr' => 'http://nottherightone.test:80',
                 ],
-                'public_url' => 'http://new-right-one.ngrok.io/',
+                'public_url' => 'http://bad-site.ngrok.io/',
+            ],
+            (object) [
+                'proto' => 'http',
+                'config' => (object) [
+                    'addr' => 'http://mysite.test:80',
+                ],
+                'public_url' => 'http://right-one.ngrok.io/',
+            ],
+             (object) [
+                'proto' => 'https',
+                'config' => (object) [
+                    'addr' => 'http://mysecuresite.test:80',
+                ],
+                'public_url' => 'http://secure-right-one.ngrok.io/',
             ],
         ];
 
         $ngrok = resolve(Ngrok::class);
-        $this->assertEquals('https://right-one.ngrok.io/', $ngrok->findHttpTunnelUrl($tunnels, 'mysite'));
-        $this->assertEquals('http://new-right-one.ngrok.io/', $ngrok->findHttpTunnelUrl($tunnels, 'mynewsite'));
-
+        $this->assertEquals('http://right-one.ngrok.io/', $ngrok->findHttpTunnelUrl($tunnels, 'mysite'));
+        $this->assertEquals('http://secure-right-one.ngrok.io/', $ngrok->findHttpTunnelUrl($tunnels, 'mysecuresite'));
     }
 
     public function test_it_checks_against_lowercased_domain()

--- a/tests/NgrokTest.php
+++ b/tests/NgrokTest.php
@@ -31,26 +31,21 @@ class NgrokTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
                 'config' => (object) [
                     'addr' => 'http://mysite.test:80',
                 ],
-                'public_url' => 'http://bad-proto.ngrok.io/',
+                'public_url' => 'https://right-one.ngrok.io/',
             ],
             (object) [
                 'proto' => 'http',
                 'config' => (object) [
-                    'addr' => 'http://nottherightone.test:80',
+                    'addr' => 'http://mynewsite.test:80',
                 ],
-                'public_url' => 'http://bad-site.ngrok.io/',
-            ],
-            (object) [
-                'proto' => 'http',
-                'config' => (object) [
-                    'addr' => 'http://mysite.test:80',
-                ],
-                'public_url' => 'http://right-one.ngrok.io/',
+                'public_url' => 'http://new-right-one.ngrok.io/',
             ],
         ];
 
         $ngrok = resolve(Ngrok::class);
-        $this->assertEquals('http://right-one.ngrok.io/', $ngrok->findHttpTunnelUrl($tunnels, 'mysite'));
+        $this->assertEquals('https://right-one.ngrok.io/', $ngrok->findHttpTunnelUrl($tunnels, 'mysite'));
+        $this->assertEquals('http://new-right-one.ngrok.io/', $ngrok->findHttpTunnelUrl($tunnels, 'mynewsite'));
+
     }
 
     public function test_it_checks_against_lowercased_domain()


### PR DESCRIPTION
Every time I'm using `valet fetch-share-url` it's giving this error

`There is no Ngrok tunnel established for ***********.test`


During deep diving, I found that my tunnel is using HTTPS protocol which is why it's unable to get the shared URL!

![image](https://github.com/laravel/valet/assets/16163521/24e7fb7a-3c92-4af4-ba89-969c6d61aeaf)


This pull request will solve this issue!