### PR TITLE
added the ability to renew certs and view their expiration dates

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -3,7 +3,6 @@
 namespace Valet;
 
 use DateTime;
-use DateInterval;
 use DomainException;
 use Illuminate\Support\Collection;
 use PhpFpm;
@@ -503,21 +502,12 @@ class Site
     }
 
     /**
-     * Renews expired or expiring (within 60 days) domains with a trusted TLS certificate.
+     * Renews all domains with a trusted TLS certificate.
      */
-    public function renew($expireIn = 368, $days = 60): void
+    public function renew($expireIn): void
     {
-        $now = (new DateTime())->add(new DateInterval('P' . $days . 'D'));
-        // Update anything expiring in the next 60 days
-        $sites = collect(Site::securedWithDates())
-            ->filter(fn ($row) => $row['exp'] < $now)
-            ->values();
-        if ($sites->isEmpty()) {
-            info('No sites need renewing.');
-            exit;
-        }
-        $sites->each(function ($row) use ($expireIn) {
-            $url = Site::domain($row['site']);
+        collect($this->securedWithDates())->each(function ($row) use ($expireIn) {
+            $url = $this->domain($row['site']);
 
             $this->secure($url, null, $expireIn);
 

--- a/cli/app.php
+++ b/cli/app.php
@@ -312,7 +312,6 @@ if (is_dir(VALET_HOME_PATH)) {
         $sites->each(function ($row) use ($expireIn) {
             $url = Site::domain($row['site']);
 
-            Site::unsecure($url);
             Site::secure($url, null, $expireIn);
 
             info('The [' . $url . '] site has been secured with a fresh TLS certificate.');

--- a/cli/app.php
+++ b/cli/app.php
@@ -300,23 +300,7 @@ if (is_dir(VALET_HOME_PATH)) {
      * Renews expired or expiring (within 60 days) domains with a trusted TLS certificate.
      */
     $app->command('renew [--expireIn=] [--days=]', function (OutputInterface $output, $expireIn = 368, $days = 60) {
-        $now = (new DateTime())->add(new DateInterval('P' . $days . 'D'));
-        // Update anything expiring in the next 60 days
-        $sites = collect(Site::securedWithDates())
-            ->filter(fn ($row) => $row['exp'] < $now)
-            ->values();
-        if ($sites->isEmpty()) {
-            info('No sites need renewing.');
-            exit;
-        }
-        $sites->each(function ($row) use ($expireIn) {
-            $url = Site::domain($row['site']);
-
-            Site::secure($url, null, $expireIn);
-
-            info('The [' . $url . '] site has been secured with a fresh TLS certificate.');
-        });
-
+        Site::renew($expireIn, $days);
         Nginx::restart();
     })->descriptions('Renews expired or expiring (within 60 days) domains with a trusted TLS certificate.', [
         '--expireIn' => 'The amount of days the self signed certificate is valid for. Default is set to "368"',

--- a/cli/app.php
+++ b/cli/app.php
@@ -297,14 +297,13 @@ if (is_dir(VALET_HOME_PATH)) {
     ]);
 
     /**
-     * Renews expired or expiring (within 60 days) domains with a trusted TLS certificate.
+     * Renews all domains with a trusted TLS certificate.
      */
-    $app->command('renew [--expireIn=] [--days=]', function (OutputInterface $output, $expireIn = 368, $days = 60) {
-        Site::renew($expireIn, $days);
+    $app->command('renew [--expireIn=]', function (OutputInterface $output, $expireIn = 368) {
+        Site::renew($expireIn);
         Nginx::restart();
-    })->descriptions('Renews expired or expiring (within 60 days) domains with a trusted TLS certificate.', [
+    })->descriptions('Renews all domains with a trusted TLS certificate.', [
         '--expireIn' => 'The amount of days the self signed certificate is valid for. Default is set to "368"',
-        '--days' => 'Renews sites expiring within the next X days. Default is set to 60.',
     ]);
 
     /**

--- a/cli/app.php
+++ b/cli/app.php
@@ -61,6 +61,7 @@ $app->command('install', function (OutputInterface $output) {
     output();
     DnsMasq::install(Configuration::read()['tld']);
     output();
+    Site::renew();
     Nginx::restart();
     output();
     Valet::symlinkToUsersBin();

--- a/cli/app.php
+++ b/cli/app.php
@@ -284,7 +284,7 @@ if (is_dir(VALET_HOME_PATH)) {
             ->when($expiring, fn ($collection) => $collection->filter(fn ($row) => $row['exp'] < $now))
             ->map(function ($row) {
                 return [
-                    'Site' => $row['host'],
+                    'Site' => $row['site'],
                     'Valid Until' => $row['exp']->format('Y-m-d H:i:s T'),
                 ];
             })
@@ -310,7 +310,7 @@ if (is_dir(VALET_HOME_PATH)) {
             exit;
         }
         $sites->each(function ($row) use ($expireIn) {
-            $url = Site::domain($row['host']);
+            $url = Site::domain($row['site']);
 
             Site::unsecure($url);
             Site::secure($url, null, $expireIn);

--- a/cli/app.php
+++ b/cli/app.php
@@ -280,7 +280,7 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('secured [--expiring] [--days=]', function (OutputInterface $output, $expiring = null, $days = 60) {
         $now = (new Datetime())->add(new DateInterval('P' . $days . 'D'));
-        $sites = collect(Site::secured())
+        $sites = collect(Site::securedWithDates())
             ->when($expiring, fn ($collection) => $collection->filter(fn ($row) => $row['exp'] < $now))
             ->map(function ($row) {
                 return [
@@ -302,7 +302,7 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('renew [--expireIn=] [--days=]', function (OutputInterface $output, $expireIn = 368, $days = 60) {
         $now = (new DateTime())->add(new DateInterval('P' . $days . 'D'));
         // Update anything expiring in the next 60 days
-        $sites = collect(Site::secured())
+        $sites = collect(Site::securedWithDates())
             ->filter(fn ($row) => $row['exp'] < $now)
             ->values();
         if ($sites->isEmpty()) {

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -455,14 +455,7 @@ class CliTest extends BaseApplicationTestCase
         [$app, $tester] = $this->appAndTester();
 
         $site = Mockery::mock(RealSite::class);
-        $site->shouldReceive('securedWithDates')->andReturn([
-            [
-                'site' => 'tighten.test',
-                'exp' => new DateTime('Aug  2 13:16:40 2023 GMT')
-            ]
-        ]);
-        $site->shouldReceive('domain')->with('tighten.test')->andReturn('tighten.test');
-        $site->shouldReceive('secure')->with('tighten.test', null, 368)->once();
+        $site->shouldReceive('renew')->andReturn();
         swap(RealSite::class, $site);
 
         $nginx = Mockery::mock(Nginx::class);
@@ -471,8 +464,6 @@ class CliTest extends BaseApplicationTestCase
 
         $tester->run(['command' => 'renew']);
         $tester->assertCommandIsSuccessful();
-
-        $this->assertStringContainsString('tighten.test', $tester->getDisplay());
     }
 
     public function test_proxy_command()

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -450,6 +450,31 @@ class CliTest extends BaseApplicationTestCase
         $this->assertStringContainsString('tighten.test', $tester->getDisplay());
     }
 
+    public function test_renew_command()
+    {
+        [$app, $tester] = $this->appAndTester();
+
+        $site = Mockery::mock(RealSite::class);
+        $site->shouldReceive('securedWithDates')->andReturn([
+            [
+                'site' => 'tighten.test',
+                'exp' => new DateTime('Aug  2 13:16:40 2023 GMT')
+            ]
+        ]);
+        $site->shouldReceive('domain')->with('tighten.test')->andReturn('tighten.test');
+        $site->shouldReceive('secure')->with('tighten.test', null, 368)->once();
+        swap(RealSite::class, $site);
+
+        $nginx = Mockery::mock(Nginx::class);
+        $nginx->shouldReceive('restart')->once();
+        swap(Nginx::class, $nginx);
+
+        $tester->run(['command' => 'renew']);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('tighten.test', $tester->getDisplay());
+    }
+
     public function test_proxy_command()
     {
         [$app, $tester] = $this->appAndTester();

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -436,7 +436,12 @@ class CliTest extends BaseApplicationTestCase
         [$app, $tester] = $this->appAndTester();
 
         $site = Mockery::mock(RealSite::class);
-        $site->shouldReceive('secured')->andReturn(['tighten.test']);
+        $site->shouldReceive('securedWithDates')->andReturn([
+            [
+                'site' => 'tighten.test',
+                'exp' => new DateTime('Aug  2 13:16:40 2024 GMT')
+            ]
+        ]);
         swap(RealSite::class, $site);
 
         $tester->run(['command' => 'secured']);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I was helping a teammate today resolve an issue with a certificate issue locally. After discovering the cert had expired, I thought it might be nice to expose certificate expiration dates when listing secured sites. It would also be nice to be able to renew those certs.

This PR adds both of those features.
