### PR TITLE
Trust CA Certificate only

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -526,6 +526,14 @@ class Site
         $caKeyPath = $this->caPath('LaravelValetCASelfSigned.key');
 
         if ($this->files->exists($caKeyPath) && $this->files->exists($caPemPath)) {
+
+            $isTrusted = $this->cli->run(sprintf(
+                'security verify-cert -c "%s"', $caPemPath
+            ));
+
+            if (strpos($isTrusted, '...certificate verification successful.') === false) {
+                $this->trustCa($caPemPath);
+            }
             return;
         }
 
@@ -608,8 +616,6 @@ class Site
                 $caExpireInDays, $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath
             ));
         }
-
-        $this->trustCertificate($crtPath);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As a follow-up to #1461, this PR changes the certificate trust logic only to need to trust the `LaravelValetCASelfSigned.pem` certificate. Since all site certificates are generated from this CA, trusting the CA makes trusting the site certificate redundant. 

I noticed my `LaravelValetCASelfSigned.pem` was not trusted on my system, so I added a check for that anytime `secure` is called to ensure the root CA is trusted. 

This will make sure the sudo call to add an entry to the system keychain is called at most once when calling the renew command. Once the CA is trusted, there will be no need to authenticate when calling `secure` or `renew` commands.

I left the `unsecure` command alone since it won't hurt to clean up old certificates if needed.