### PR TITLE
Allow renew() to be called without parameters

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -503,7 +503,7 @@ class Site
     /**
      * Renews all domains with a trusted TLS certificate.
      */
-    public function renew($expireIn): void
+    public function renew($expireIn = 368): void
     {
         collect($this->securedWithDates())->each(function ($row) use ($expireIn) {
             $url = $this->domain($row['site']);


### PR DESCRIPTION
A reasonable default is set here, consistent with the default set in other places.

Fixes #1464
Updates #1461

@driesvints Can you review and consider releasing a patch, since this is a breaking bug that occurs on `valet install` (which people run not only to install Valet, but also after upgrading it)