### PR TITLE
certificate renew issue in `valet install`; no value for expireIn provided

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -502,7 +502,7 @@ class Site
 
     /**
      * Renews all domains with a trusted TLS certificate.
-     * @param  int  $certificateExpireInDays  The number of days the self signed certificate is valid.
+     * @param  int  $expireIn  The number of days the self signed certificate is valid.
      *                                         Certificates SHOULD NOT have a validity period greater than 397 days.
      */
     public function renew($expireIn = 396): void

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -502,8 +502,10 @@ class Site
 
     /**
      * Renews all domains with a trusted TLS certificate.
+     * @param  int  $certificateExpireInDays  The number of days the self signed certificate is valid.
+     *                                         Certificates SHOULD NOT have a validity period greater than 397 days.
      */
-    public function renew($expireIn): void
+    public function renew($expireIn = 396): void
     {
         collect($this->securedWithDates())->each(function ($row) use ($expireIn) {
             $url = $this->domain($row['site']);


### PR DESCRIPTION
`valet install` is throwing this error as no default value is provided for `Site::renew();`
<img width="996" alt="image" src="https://github.com/laravel/valet/assets/16163521/069a6aa7-2524-4a76-aec4-75e924717a77">