### PR TITLE
Allow specifying php version to restart

### DIFF
--- a/cli/app.php
+++ b/cli/app.php
@@ -495,25 +495,27 @@ if (is_dir(VALET_HOME_PATH)) {
      * Restart the daemon services.
      */
     $app->command('restart [service]', function (OutputInterface $output, $service) {
-        switch ($service) {
-            case '':
-                DnsMasq::restart();
-                PhpFpm::restart();
-                Nginx::restart();
+        $serviceContainsPhp = is_string($service) && false !== strpos($service, 'php');
 
-                return info('Valet services have been restarted.');
-            case 'dnsmasq':
-                DnsMasq::restart();
+        if ($service == '') {
+            DnsMasq::restart();
+            PhpFpm::restart();
+            Nginx::restart();
 
-                return info('dnsmasq has been restarted.');
-            case 'nginx':
-                Nginx::restart();
+            return info('Valet services have been restarted.');
+        } elseif ($service == 'dnsmasq') {
+            DnsMasq::restart();
 
-                return info('Nginx has been restarted.');
-            case 'php':
-                PhpFpm::restart();
+            return info('dnsmasq has been restarted.');
+        } elseif ($service == 'nginx') {
+            Nginx::restart();
 
-                return info('PHP has been restarted.');
+            return info('Nginx has been restarted.');
+        } elseif ($serviceContainsPhp) {
+            $hasSpecifiedVersion = $service !== 'php';
+            PhpFpm::restart($hasSpecifiedVersion ? PhpFpm::normalizePhpVersion($service) : null);
+
+            return info('PHP has been restarted.');
         }
 
         return warning(sprintf('Invalid valet service name [%s]', $service));

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -776,6 +776,46 @@ class CliTest extends BaseApplicationTestCase
         $this->assertStringContainsString('PHP has been restarted.', $tester->getDisplay());
     }
 
+    public function test_restart_command_restarts_php_version()
+    {
+        [$app, $tester] = $this->appAndTester();
+
+        $phpfpm = Mockery::mock(PhpFpm::class);
+        $phpfpm->shouldReceive('normalizePhpVersion')
+            ->withArgs(['php@8.1'])
+            ->passthru()
+            ->once();
+        $phpfpm->shouldReceive('restart')->withArgs(['php@8.1'])->once();
+
+        swap(PhpFpm::class, $phpfpm);
+
+        $tester->run(['command' => 'restart', 'service' => 'php@8.1']);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('PHP has been restarted.', $tester->getDisplay());
+    }
+
+    public function test_restart_command_restarts_php_denormalized_version()
+    {
+        [$app, $tester] = $this->appAndTester();
+
+        $phpfpm = Mockery::mock(PhpFpm::class);
+        $phpfpm->shouldReceive('normalizePhpVersion')
+            ->withArgs(['php81'])
+            ->passthru()
+            ->once();
+        $phpfpm->shouldReceive('restart')
+            ->withArgs(['php@8.1'])
+            ->once();
+
+        swap(PhpFpm::class, $phpfpm);
+
+        $tester->run(['command' => 'restart', 'service' => 'php81']);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('PHP has been restarted.', $tester->getDisplay());
+    }
+
     public function test_start_command()
     {
         [$app, $tester] = $this->appAndTester();


### PR DESCRIPTION
This PR adds the ability to specify aPHP version to restart. This reduces the time it takes to restart PHP on system with multiple PHP versions installed when change an ini value or troubleshooting.

Let me know if this is of interest to the project and if I should add similar functionality for starting and stopping php.