### PR TITLE
Add values() call to reset keys after modifying paths

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -117,7 +117,7 @@ class Configuration
         $this->write(tap($this->read(), function (&$config) use ($path, $prepend) {
             $method = $prepend ? 'prepend' : 'push';
 
-            $config['paths'] = collect($config['paths'])->{$method}($path)->unique()->all();
+            $config['paths'] = collect($config['paths'])->{$method}($path)->unique()->values()->all();
         }));
     }
 


### PR DESCRIPTION
This fixes an issue where running commands like `valet link foo` would cause the `paths` config array in ~/.config/valet/config.json to turn into an object with non-sequential keys. This in turn caused phpmon to fail with "Laravel Valet configuration file invalid or missing", when it tried to parse the config file.