### PR TITLE
Ignore invalid paths

### DIFF
--- a/cli/Valet/Server.php
+++ b/cli/Valet/Server.php
@@ -160,6 +160,10 @@ class Server
         $domain = static::domainFromSiteName($siteName);
 
         foreach ($this->config['paths'] as $path) {
+            if (! is_dir($path)) {
+                continue;
+            }
+
             $handle = opendir($path);
 
             if ($handle === false) {

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -90,6 +90,13 @@ class ServerTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $this->assertNull($server->defaultSitePath());
     }
 
+    public function test_it_ignores_invalid_paths()
+    {
+        $server = new Server(['paths' => ['fake' => __DIR__.'/invalid_path']]);
+
+        $this->assertNull($server->sitePath('tighten'));
+    }
+
     public function test_it_tests_whether_host_is_ip_address()
     {
         $this->assertTrue(Server::hostIsIpAddress('192.168.1.1'));


### PR DESCRIPTION
### Why?

While removing a directory that is parked in Valet. I encountered an error originating from Herd's Valet, though the issue lies with Valet itself. And from a user's perspective, I believe Valet should remain operational even if one of the paths is invalid

![image](https://github.com/laravel/valet/assets/8272048/5e0f5b63-62d5-44bf-b4b2-6bbdaae693f4)

#### Suggestion
Introducing a command such as `valet check` would be beneficial. It could report on Valet's status, confirming if all paths are correct or if any path is invalid.