### PR TITLE
Support Illuminate:11 and Symfony:7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,13 +39,13 @@
     },
     "require": {
         "php": "^7.1|^8.0",
-        "illuminate/collections": "^8.0|^9.0|^10.0",
-        "illuminate/container": "~5.1|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/collections": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/container": "~5.1|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "mnapoli/silly": "^1.5",
-        "symfony/console": "^3.0|^4.0|^5.0|^6.0",
-        "symfony/process": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/console": "^3.0|^4.0|^5.0|^6.0|^7.0",
+        "symfony/process": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "guzzlehttp/guzzle": "^6.0|^7.4",
-        "symfony/event-dispatcher": "^3.0|^4.0|^5.0|^6.0"
+        "symfony/event-dispatcher": "^3.0|^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",


### PR DESCRIPTION
Fixes #1480

Updated composer.json to include support for Illuminate v11 and Symfony v7