### PR TITLE
fix: Warning: Constant VALET_* already defined in X

### DIFF
--- a/server.php
+++ b/server.php
@@ -9,8 +9,8 @@ use Valet\Server;
 /**
  * Define the user's "~/.config/valet" path.
  */
-define('VALET_HOME_PATH', posix_getpwuid(fileowner(__FILE__))['dir'].'/.config/valet');
-define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
+defined('VALET_HOME_PATH') or define('VALET_HOME_PATH', posix_getpwuid(fileowner(__FILE__))['dir'].'/.config/valet');
+defined('VALET_STATIC_PREFIX') or define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
 
 /**
  * Load the Valet configuration.


### PR DESCRIPTION
Similar issue as in https://github.com/laravel/prompts/pull/146. To make packages like `symfony/var-dumper` available globally you prepend the global Composer autoload.php like so:

```
// php.ini

auto_prepend_file = ${HOME}/.composer/vendor/autoload.php
```
![image](https://github.com/laravel/valet/assets/32384907/b12418b4-a7c7-43e2-9829-5c0e12fd9be3)
From: https://symfony.com/doc/current/components/var_dumper.html

In Valet this can result in

```
( ! ) Warning: Constant VALET_HOME_PATH already defined in ~/.composer/vendor/laravel/valet/server.php on line 12
Call Stack
#	Time	Memory	Function	Location
1	0.0354	571296	{main}( )	.../server.php:0
2	0.0380	571488	define( $constant_name = 'VALET_HOME_PATH', $value = '~/.config/valet' )	.../server.php:12

( ! ) Warning: Constant VALET_STATIC_PREFIX already defined in ~/.composer/vendor/laravel/valet/server.php on line 13
Call Stack
#	Time	Memory	Function	Location
1	0.0354	571296	{main}( )	.../server.php:0
```