### PR TITLE
Require Trusting CA when securing sites

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -476,7 +476,7 @@ class Site
         $phpVersion = $this->customPhpVersion($url);
 
         // Create the CA if it doesn't exist.
-        // If the user cancels the trust operation, the old certificate will be not removed.
+        // If the user cancels the trust operation, the old certificate will not be removed.
         $this->files->ensureDirExists($this->caPath(), user());
         $caExpireInDate = (new \DateTime())->diff(new \DateTime("+{$caExpireInYears} years"));
         $this->createCa($caExpireInDate->format('%a'));

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -475,17 +475,18 @@ class Site
         // Extract in order to later preserve custom PHP version config when securing
         $phpVersion = $this->customPhpVersion($url);
 
-        $this->unsecure($url);
-
+        // Create the CA if it doesn't exist.
+        // If the user cancels the trust operation, the old certificate will be not removed.
         $this->files->ensureDirExists($this->caPath(), user());
+        $caExpireInDate = (new \DateTime())->diff(new \DateTime("+{$caExpireInYears} years"));
+        $this->createCa($caExpireInDate->format('%a'));
+
+        $this->unsecure($url);
 
         $this->files->ensureDirExists($this->certificatesPath(), user());
 
         $this->files->ensureDirExists($this->nginxPath(), user());
 
-        $caExpireInDate = (new \DateTime())->diff(new \DateTime("+{$caExpireInYears} years"));
-
-        $this->createCa($caExpireInDate->format('%a'));
         $this->createCertificate($url, $certificateExpireInDays);
 
         $siteConf = $this->buildSecureNginxServer($url, $siteConf);

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -640,9 +640,14 @@ class Site
      */
     public function trustCa(string $caPemPath): void
     {
-        $this->cli->run(sprintf(
-            'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "%s"', $caPemPath
+        info('Trusting Laravel Valet Certificate Authority...');
+        $result = $this->cli->run(sprintf(
+            'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "%s"',
+            $caPemPath
         ));
+        if ($result) {
+            throw new DomainException('The Certificate Authority must be trusted. Please run the command again.');
+        }
     }
 
     /**


### PR DESCRIPTION
When trying to reproduce https://github.com/laravel/valet/issues/1487, I was able to get a Site in this state by following these steps:

1. Fresh install of brew and Valet on macOS 14.5 (via [VirtualBuddy](https://github.com/insidegui/VirtualBuddy))
2. Install valet v4.6.0
3. secure a site
4. Manually remove the CA from Keychain Access.app
5. Site should still be valid, since its own cert is trusted.
6. Upgrade Valet to v4.7.0
7. Run `valet install`
8. This calls renew, which also calls secure on every site. Since the CA is not trusted, the user will be prompted for their password to trust the CA in the System Keychain. Instead of approving, **Click "Cancel"**
9. This will yield the NET::ERR_CERT_AUTHORITY_INVALID error, since the old site cert was removed from the System Keychain.

This PR aims to prevent this state by doing the following:

1. Prevent users from proceeding with the secure command if they cancel the Trust CA operation.
2. Within the `secure` command, moves the `createCa` invocation above the `unsecure` command to prevent the old site's certificates from being removed if the Trust CA command is canceled. This prevents the site from being in an unpredictable state. If the command fails, it should leave the site alone. Otherwise, the site will be unsecured unexpectedly. 

cc @driesvints 