### PR TITLE
Fix extra parameters for share tool, fixes #1494

### DIFF
--- a/valet
+++ b/valet
@@ -52,7 +52,7 @@ then
 
     for PARAM in ${PARAMS[@]}
     do
-        if [[ ${PARAM:0:1} == '-' ]]; then
+        if [[ ${PARAM:0:1} != '-' ]]; then
             PARAMS=("${PARAMS[@]/$PARAM}") # Quotes when working with strings
         fi
     done


### PR DESCRIPTION
There was a typo in my previous PR that led to a problem passing extra arguments to share tools. Fixes #1494 
