### PR TITLE
Add the ability to renew the Certificate Authority certificate

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -437,9 +437,9 @@ class Site
     /**
      * Get all of the URLs with expiration dates that are currently secured.
      */
-    public function securedWithDates(): array
+    public function securedWithDates($ca = false): array
     {
-        return collect($this->secured())->map(function ($site) {
+        $sites = collect($this->secured())->map(function ($site) {
             $filePath = $this->certificatesPath().'/'.$site.'.crt';
 
             $expiration = $this->cli->run("openssl x509 -enddate -noout -in $filePath");
@@ -450,7 +450,22 @@ class Site
                 'site' => $site,
                 'exp' => new DateTime($expiration),
             ];
-        })->unique()->values()->all();
+        })->unique()->values();
+
+        if ($ca) {
+            $filePath = $this->caPath('LaravelValetCASelfSigned.pem');
+
+            $expiration = $this->cli->run("openssl x509 -enddate -noout -in $filePath");
+
+            $expiration = str_replace('notAfter=', '', $expiration);
+
+            $sites->prepend([
+                'site' => 'Certificate Authority',
+                'exp' => new DateTime($expiration),
+            ]);
+        }
+
+        return $sites->all();
     }
 
     public function isSecured(string $site): bool

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -502,8 +502,11 @@ class Site
     /**
      * Renews all domains with a trusted TLS certificate.
      */
-    public function renew($expireIn = 368): void
+    public function renew($expireIn = 368, $ca = false): void
     {
+        if ($ca) {
+            $this->removeCa();
+        }
         collect($this->securedWithDates())->each(function ($row) use ($expireIn) {
             $url = $this->domain($row['site']);
 

--- a/cli/app.php
+++ b/cli/app.php
@@ -306,11 +306,12 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Renews all domains with a trusted TLS certificate.
      */
-    $app->command('renew [--expireIn=]', function (OutputInterface $output, $expireIn = 368) {
-        Site::renew($expireIn);
+    $app->command('renew [--expireIn=] [--ca]', function (OutputInterface $output, $expireIn = 368, $ca = null) {
+        Site::renew($expireIn, $ca);
         Nginx::restart();
     })->descriptions('Renews all domains with a trusted TLS certificate.', [
         '--expireIn' => 'The amount of days the self signed certificate is valid for. Default is set to "368"',
+        '--ca' => 'Renew the Certificate Authority certificate before renewing the site certificates.',
     ]);
 
     /**

--- a/cli/app.php
+++ b/cli/app.php
@@ -285,9 +285,9 @@ if (is_dir(VALET_HOME_PATH)) {
     /**
      * Display all of the currently secured sites.
      */
-    $app->command('secured [--expiring] [--days=]', function (OutputInterface $output, $expiring = null, $days = 60) {
+    $app->command('secured [--expiring] [--days=] [--ca]', function (OutputInterface $output, $expiring = null, $days = 60, $ca = null) {
         $now = (new Datetime)->add(new DateInterval('P'.$days.'D'));
-        $sites = collect(Site::securedWithDates())
+        $sites = collect(Site::securedWithDates($ca))
             ->when($expiring, fn ($collection) => $collection->filter(fn ($row) => $row['exp'] < $now))
             ->map(function ($row) {
                 return [
@@ -301,6 +301,7 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Display all of the currently secured sites', [
         '--expiring' => 'Limits the results to only sites expiring within the next 60 days.',
         '--days' => 'To be used with --expiring. Limits the results to only sites expiring within the next X days. Default is set to 60.',
+        '--ca' => 'Include the Certificate Authority certificate in the list of site certificates.',
     ]);
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds the ability to renew the Certificate Authority certificate optionally when running the `valet renew --ca` command. Additionally, it adds the ability to view the CA certificate's expiration date through `valet secured --ca`.

This should resolve the issue highlighted in #1496. It may also resolve https://github.com/laravel/valet/issues/1487, but I don't think I was able to verify if the CA expired. 

My comment [here](https://github.com/laravel/valet/issues/1496#issuecomment-2477759775) summarizes the scenario pretty well how users may experience this issue, but I would wager to guess it should be an increasingly uncommon scenario, given new CAs should have 20 years of validity.
