### PR TITLE
Add support for PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2, 8.3]
+        php: ['8.0', 8.1, 8.2, 8.3, 8.4]
 
     name: PHP ${{ matrix.php }}
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><img src="/art/logo.svg"></p>
 
 <p align="center">
-<a href="https://github.com/laravel/valet/actions?query=workflow%3ATests"><img src="https://github.com/laravel/valet/workflows/Tests/badge.svg?branch=master" alt="Build Status"></a>
+<a href="https://github.com/laravel/valet/actions?query=workflow%3ATests"><img src="https://github.com/laravel/valet/actions/workflows/tests.yml/badge.svg?branch=master" alt="Build Status"></a>
 <a href="https://packagist.org/packages/laravel/valet"><img src="https://poser.pugx.org/laravel/valet/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/laravel/valet"><img src="https://poser.pugx.org/laravel/valet/v/stable.svg" alt="Latest Stable Version"></a>
 <a href="https://packagist.org/packages/laravel/valet"><img src="https://poser.pugx.org/laravel/valet/license.svg" alt="License"></a>

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -11,6 +11,7 @@ class Brew
     // This is the array of PHP versions that Valet will attempt to install/configure when requested
     const SUPPORTED_PHP_VERSIONS = [
         'php',
+        'php@8.4',
         'php@8.3',
         'php@8.2',
         'php@8.1',


### PR DESCRIPTION
Include PHP 8.4 in the list of supported PHP versions in both Valet Brew and GitHub Actions test matrix. This ensures compatibility and testing for the latest PHP release.

---
This fixes the `Unable to determine linked PHP when parsing '8.4'` issue when using Valet using PHP version 8.4

<img width="463" alt="Screenshot 2024-11-17 at 20 54 10" src="https://github.com/user-attachments/assets/d57d3407-cddf-42af-84c7-5ddea1738f43">
