### PR TITLE
Add php@8.4

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -11,6 +11,7 @@ class Brew
     // This is the array of PHP versions that Valet will attempt to install/configure when requested
     const SUPPORTED_PHP_VERSIONS = [
         'php',
+        'php@8.4',
         'php@8.3',
         'php@8.2',
         'php@8.1',


### PR DESCRIPTION
Without this change, I get an error when on PHP 8.4 and running `valet php`.

```
Unable to determine linked PHP when parsing '8.4'
```

![CleanShot 2024-11-25 at 10 16 15](https://github.com/user-attachments/assets/41967cc9-9c87-4b59-b120-5eaa76681393)

When adding it, it seems to work fine:

![CleanShot 2024-11-25 at 10 16 57](https://github.com/user-attachments/assets/b37b53f1-3d6a-49d1-9b1e-acdf2cce6cb3)
