### PR TITLE
fix(entry-script): use correct php binary for proxy commands

### DIFF
--- a/valet
+++ b/valet
@@ -140,9 +140,9 @@ elif [[ "$1" = "php" ]]
 then
     if [[ $2 == *"--site="* ]]; then
         SITE=${2#*=}
-        $(php "$DIR/cli/valet.php" which-php $SITE) "${@:3}"
+        $("$PHP" "$DIR/cli/valet.php" which-php $SITE) "${@:3}"
     else
-        $(php "$DIR/cli/valet.php" which-php) "${@:2}"
+        $("$PHP" "$DIR/cli/valet.php" which-php) "${@:2}"
     fi
 
     exit
@@ -152,9 +152,9 @@ elif [[ "$1" = "composer" ]]
 then
     if [[ $2 == *"--site="* ]]; then
         SITE=${2#*=}
-        $(php "$DIR/cli/valet.php" which-php $SITE) $(which composer) "${@:3}"
+        $("$PHP" "$DIR/cli/valet.php" which-php $SITE) $(which composer) "${@:3}"
     else
-        $(php "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
+        $("$PHP" "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
     fi
 
     exit


### PR DESCRIPTION
These are the only instances, where the valet cli script is executed with the default php binary instead of the evaluated binary.

We now use the `$PHP` executable to ensure that the valet cli is always called with the correct binary even when proxying composer / php.
