### PR TITLE
Add PHPUnit 12 support, and upgrade phpunit-polyfills

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,6 @@ jobs:
         run: composer install --no-interaction --prefer-dist
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit
         env:
           APP_ENV: testing

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",
-        "yoast/phpunit-polyfills": "^0.2.0",
+        "yoast/phpunit-polyfills": "^0.2.0|^4.0",
         "laravel/pint": "^1.4"
     },
     "bin": [

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Valet\Brew;
 use Valet\CommandLine;
 use Valet\Filesystem;
@@ -388,6 +389,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     /**
      * @dataProvider supportedPhpLinkPathProvider
      */
+    #[DataProvider('supportedPhpLinkPathProvider')]
     public function test_get_parsed_linked_php_will_return_matches_for_linked_php($path, $matches)
     {
         $getBrewMock = function ($filesystem) {
@@ -405,6 +407,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     /**
      * @dataProvider supportedPhpLinkPathProvider
      */
+    #[DataProvider('supportedPhpLinkPathProvider')]
     public function test_get_linked_php_formula_will_return_linked_php_directory($path, $matches, $expectedLinkFormula)
     {
         $brewMock = Mockery::mock(Brew::class)->makePartial();
@@ -489,7 +492,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     /**
      * Provider of php links and their expected split matches.
      */
-    public function supportedPhpLinkPathProvider(): array
+    public static function supportedPhpLinkPathProvider(): array
     {
         return [
             [


### PR DESCRIPTION
Added `DataProvider` attribute, to support newer PHPUnit, in order to support latest `yoast/phpunit-polyfills`.

Closes #1512 which only did part of the update

