### PR TITLE
fix(php-fpm): correctly reconfigure all versions

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -27,8 +27,9 @@ class PhpFpm
 
         $this->files->ensureDirExists(VALET_HOME_PATH.'/Log', user());
 
-        $phpVersion = $this->brew->linkedPhp();
-        $this->createConfigurationFiles($phpVersion);
+        foreach ($this->utilizedPhpVersions() as $phpVersion) {
+            $this->createConfigurationFiles($phpVersion);
+        }
 
         // Remove old valet.sock
         $this->files->unlink(VALET_HOME_PATH.'/valet.sock');


### PR DESCRIPTION
This previously only reapplied the configuration for the linked version. Because it is recommended to run valet install again after a brew upgrade, it is necessary to update all utilized PHP versions.

On brew upgrades, some versions received the default `www.conf` again. This would leave the user with a broken setup until they either call `valet use php@X.X` for all the versions or isolate a site again with the version.

This commit fixes the behavior by rerunning the configuration step on all php versions. This is more consistent, because in the next line all utilized PHP versions are also restarted.

Seems like this also solves issues like #1410 or at least lets them only rerun a single `valet install`, which is something users would do in a regular troubleshooting session.