### PR TITLE
fix(php-fpm): correct socket creation

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -259,7 +259,7 @@ class Brew
     }
 
     /**
-     * Gets the currently linked formula by identifying the symlink in the hombrew bin directory.
+     * Gets the currently linked formula by identifying the symlink in the homebrew bin directory.
      * Different to ->linkedPhp() in that this will just get the linked directory name,
      * whether that is php, php74 or php@7.4.
      */

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -37,7 +37,8 @@ class PhpFpm
 
         $this->restart();
 
-        $this->symlinkPrimaryValetSock($phpVersion);
+        $linkedPhpVersion = $this->brew->linkedPhp();
+        $this->symlinkPrimaryValetSock($linkedPhpVersion);
     }
 
     /**
@@ -331,6 +332,6 @@ class PhpFpm
                     return $this->normalizePhpVersion(str_replace(['valet', '.sock'], '', $sock));
                 }
             }
-        })->merge([$this->brew->getLinkedPhpFormula()])->filter()->unique()->values()->toArray();
+        })->merge([$this->brew->linkedPhp()])->filter()->unique()->values()->toArray();
     }
 }

--- a/tests/PhpFpmTest.php
+++ b/tests/PhpFpmTest.php
@@ -122,7 +122,7 @@ class PhpFpmTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             'php@7.4',
         ]));
 
-        $brewMock->shouldReceive('getLinkedPhpFormula')->andReturn('php@7.3');
+        $brewMock->shouldReceive('linkedPhp')->andReturn('php@7.3');
 
         $nginxMock->shouldReceive('configuredSites')
             ->once()


### PR DESCRIPTION
While my PR #1514 fixed recreating the FPM configs, it introduced a different issue:

Due to the use of `utilizedPhpVersions()`, the code now also configured the FPM config for the alias `php` version. 

So e.g. on my system it returned these versions:
- php
- php@8.4
- php@8.3
- php@8.2

This caused it to invoke the configure function 4 times, once for each version.
For `php` it was invoked with an empty version string argument and thus caused overwriting the FPM config for (in my case) php@8.4, templated with `valet.sock`, instead of the correct `valet84.sock`.

The nginx sites that were configured to proxy their requests to the `valet84.sock` then failed because it did not exist anymore.

We fixed this by always including the actual linked PHP version via the `linkedPhp` function. This returns `php8.4` instead of `php`, so we only get the 3 actual PHP versions.

`php` is an alias anyway and this also removes another unnecessary service restart call. 
Previously, this would also try to restart the `php` service via brew which was already restarted through the restart of `php@8.4`, which is an alias in brew.

This also fixes an issue with the previous PR, to correctly symlink `valet.sock` again to the linked PHP version, which we oversaw. We also fixed a small comment typo.
