### PR TITLE
Update CraftValetDriver for compatbility with craftcms/security-patches

### DIFF
--- a/cli/Valet/Drivers/Specific/CraftValetDriver.php
+++ b/cli/Valet/Drivers/Specific/CraftValetDriver.php
@@ -193,6 +193,10 @@ class CraftValetDriver extends ValetDriver
         $_SERVER['PHP_SELF'] = $scriptName;
         $_SERVER['DOCUMENT_ROOT'] = $sitePath.'/'.$frontControllerDirectory;
 
+        if (isset($_SERVER['argv'])) {
+            unset($_SERVER['argv']);
+        }
+
         return $indexPath;
     }
 }


### PR DESCRIPTION
When applying https://github.com/craftcms/security-patches to a Craft project, the fix for [CVE-2024-56145](https://github.com/advisories/GHSA-2p6p-9rc9-62j9) breaks sites served by Valet (and Herd). 

This fix allows these sites to work when using Valet (and Herd).

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
