### PR TITLE
Update Nginx rules to serve favicon and robots.txt from /public directory

### DIFF
--- a/cli/stubs/secure.valet-legacy.conf
+++ b/cli/stubs/secure.valet-legacy.conf
@@ -27,8 +27,8 @@ server {
         rewrite ^ "VALET_SERVER_PATH" last;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /public/favicon.ico { access_log off; log_not_found off; }
+    location = /public/robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "VALET_HOME_PATH/Log/nginx-error.log";
@@ -69,8 +69,8 @@ server {
         rewrite ^ "VALET_SERVER_PATH" last;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /public/favicon.ico { access_log off; log_not_found off; }
+    location = /public/robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "VALET_HOME_PATH/Log/nginx-error.log";

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -27,8 +27,8 @@ server {
         rewrite ^ "VALET_SERVER_PATH" last;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /public/favicon.ico { access_log off; log_not_found off; }
+    location = /public/robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "VALET_HOME_PATH/Log/nginx-error.log";
@@ -69,8 +69,8 @@ server {
         rewrite ^ "VALET_SERVER_PATH" last;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /public/favicon.ico { access_log off; log_not_found off; }
+    location = /public/robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "VALET_HOME_PATH/Log/nginx-error.log";

--- a/cli/stubs/site.valet.conf
+++ b/cli/stubs/site.valet.conf
@@ -17,8 +17,8 @@ server {
         rewrite ^ "VALET_SERVER_PATH" last;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /public/favicon.ico { access_log off; log_not_found off; }
+    location = /public/robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "VALET_HOME_PATH/Log/nginx-error.log";

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -16,8 +16,8 @@ server {
         rewrite ^ "VALET_SERVER_PATH" last;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /public/favicon.ico { access_log off; log_not_found off; }
+    location = /public/robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "VALET_HOME_PATH/Log/nginx-error.log";

--- a/tests/fixtures/Proxies/Nginx/not-a-proxy.com.test
+++ b/tests/fixtures/Proxies/Nginx/not-a-proxy.com.test
@@ -23,8 +23,7 @@ server {
     ssl_certificate "/home/nobody/.config/valet/Certificates/not-a-proxy.com.test.crt";
     ssl_certificate_key "/home/nobody/.config/valet/Certificates/not-a-proxy.com.test.key";
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    serve favicon.ico and robots.txt from /public directory
 
     access_log off;
     error_log "/home/nobody/.config/valet/Log/not-a-proxy.com.test-error.log";
@@ -63,8 +62,8 @@ server {
         try_files $uri $uri/;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /public/favicon.ico { access_log off; log_not_found off; }
+    location = /public/robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
     error_log "/home/nobody/.config/valet/Log/not-a-proxy.com.test-error.log";


### PR DESCRIPTION
### Summary

This pull request resolves [Issue #375](https://github.com/laravel/valet/issues/375), which highlights a problem where Valet fails to serve `favicon.ico` and `robots.txt` unless they are placed in the project root. This contradicts Laravel’s convention of placing such files in the `/public` directory.

### Changes Made

```nginx
- location = /favicon.ico { access_log off; log_not_found off; }
- location = /robots.txt  { access_log off; log_not_found off; }

+ location = /public/favicon.ico { access_log off; log_not_found off; }
+ location = /public/robots.txt  { access_log off; log_not_found off; }