### PR TITLE
Fix PHP PATH_INFO

### DIFF
--- a/server.php
+++ b/server.php
@@ -1,5 +1,22 @@
 <?php
 
+
+// FIX PHP PATH_INFO
+
+$originalRequestUri = $_SERVER['REQUEST_URI'];
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+// Needs patch
+if (substr($path, -strlen($_SERVER['PATH_INFO'])) == $_SERVER['PATH_INFO']) {
+    // Cut away PHP PATH_INFO from REQUEST_URI to find the correct file later
+    $_SERVER['REQUEST_URI'] =
+        substr($path, 0, -strlen($_SERVER['PATH_INFO'])) // Remove PATH_INFO: page.php/remove/additional/path
+        . substr($_SERVER['REQUEST_URI'], strlen($path)); // Restore GET parameters '?param=what&ever=floats'
+}
+unset($path); // Don't leave global garbage around
+
+// END FIX PHP PATH_INFO
+
 require_once './cli/includes/require-drivers.php';
 require_once './cli/Valet/Server.php';
 
@@ -106,5 +123,9 @@ if (! $frontControllerPath) {
 }
 
 chdir(dirname($frontControllerPath));
+
+// After the file is found recover the original REQUEST_URI
+$_SERVER['REQUEST_URI'] = $originalRequestUri;
+unset($originalRequestUri); // Don't leave useless globals around
 
 require $frontControllerPath;


### PR DESCRIPTION
The PHP PATH_INFO is a well established although not often used mechanism, supported by most webserver, and even when it is not supported it is patchable so that it works.

You can add data after the base url and before the GET parameters. When you call a page like this

path/to/page.php/some/path/info?parameter=value

PHP will put the string 'some/path/info' into $_SERVER['PATH_INFO].

Without this patch Valet tries to find the file path/to/page.php/some/path/info on disk, without finding it and returning a 404.

The patch removes the PATH_INFO string from $_SERVER['REQUEST_URI'] at the very beginning of server.php so Valet can find the correct file, then recovers the original $_SERVER['REQUEST_URI'] just before the final require.

Although the PATH_INFO mechanism is not often known and used, it is sometimes useful and there is no reason not to follow PHP on this, by failing to include the correct file.
