### PR TITLE
feat: add support for PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2, 8.3, 8.4]
+        php: ['8.0', 8.1, 8.2, 8.3, 8.4, 8.5]
 
     name: PHP ${{ matrix.php }}
 

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -11,7 +11,8 @@ class Brew
     // This is the array of PHP versions that Valet will attempt to install/configure when requested
     const SUPPORTED_PHP_VERSIONS = [
         'php',
-        'php@8.4',
+        'php@8.5',
+        'ea',
         'php@8.3',
         'php@8.2',
         'php@8.1',


### PR DESCRIPTION
- Add `php@8.5` to Valet's supported PHP versions list in Brew
- Update GitHub Actions matrix to include PHP 8.5 for CI testing

PHP 8.5.0alpha1 has been tagged:
https://github.com/php/php-src/releases/tag/php-8.5.0alpha1