### PR TITLE
fix(php): ignore warnings in CLI parsing

### DIFF
--- a/find-usable-php.php
+++ b/find-usable-php.php
@@ -4,7 +4,7 @@ $minimumPhpVersion = '8.0';
 
 // First, check if the system's linked "php" is 8+; if so, return that. This
 // is the most likely, most ideal, and fastest possible case
-$linkedPhpVersion = shell_exec('php -r "echo phpversion();"');
+$linkedPhpVersion = shell_exec('php -d error_reporting=1 -r "echo phpversion();"');
 
 if (version_compare($linkedPhpVersion, $minimumPhpVersion) >= 0) {
     echo exec('which php');

--- a/valet
+++ b/valet
@@ -7,7 +7,7 @@ SOURCE="${BASH_SOURCE[0]}"
 # do it in pure Bash. So, we'll call into PHP CLI here to resolve.
 if [[ -L "$SOURCE" ]]
 then
-    DIR=$(php -r "echo dirname(realpath('$SOURCE'));")
+    DIR=$(php -d error_reporting=1 -r "echo dirname(realpath('$SOURCE'));")
 else
     DIR="$( cd "$( dirname "$SOURCE" )" && pwd )"
 fi
@@ -17,7 +17,7 @@ fi
 # Valet CLI script which is written in PHP. Will use PHP to do it.
 if [ ! -f "$DIR/cli/valet.php" ]
 then
-    DIR=$(php -r "echo realpath('$DIR/../laravel/valet');")
+    DIR=$(php -d error_reporting=1 -r "echo realpath('$DIR/../laravel/valet');")
 fi
 
 # Get a command-line executable we can use for php that's 8+; if this
@@ -25,7 +25,7 @@ fi
 # checking and pulling again by reading the exported env var
 if [[ "$PHP_EXECUTABLE" = "" ]]
 then
-    PHP="$(php $DIR/find-usable-php.php)"
+    PHP="$(php -d error_reporting=1 $DIR/find-usable-php.php)"
 
     # Validate output before running it on the CLI
     if [[ ! -f "$PHP" ]]; then
@@ -45,7 +45,7 @@ fi
 # process to retrieve the live the share tool tunnel URL in the background.
 if [[ "$1" = "share" ]]
 then
-    SHARETOOL="$("$PHP" "$DIR/cli/valet.php" share-tool)"
+    SHARETOOL="$("$PHP" -d error_reporting=1 "$DIR/cli/valet.php" share-tool)"
 
     # Check for parameters to pass through to share tool (these will start with '-' or '--')
     PARAMS=(${@:2})
@@ -72,7 +72,7 @@ then
 
     # Lowercase the host to match how the rest of our domains are looked up
     HOST=$(echo "$HOST" | tr '[:upper:]' '[:lower:]')
-    TLD=$("$PHP" "$DIR/cli/valet.php" tld)
+    TLD=$("$PHP" -d error_reporting=1 "$DIR/cli/valet.php" tld)
     $(grep --quiet --no-messages 443 ~/.config/valet/Nginx/$HOST*)
     SECURED=$?
 
@@ -140,9 +140,9 @@ elif [[ "$1" = "php" ]]
 then
     if [[ $2 == *"--site="* ]]; then
         SITE=${2#*=}
-        $("$PHP" "$DIR/cli/valet.php" which-php $SITE) "${@:3}"
+        $("$PHP" -d error_reporting=1 "$DIR/cli/valet.php" which-php $SITE) "${@:3}"
     else
-        $("$PHP" "$DIR/cli/valet.php" which-php) "${@:2}"
+        $("$PHP" -d error_reporting=1 "$DIR/cli/valet.php" which-php) "${@:2}"
     fi
 
     exit
@@ -152,9 +152,9 @@ elif [[ "$1" = "composer" ]]
 then
     if [[ $2 == *"--site="* ]]; then
         SITE=${2#*=}
-        $("$PHP" "$DIR/cli/valet.php" which-php $SITE) $(which composer) "${@:3}"
+        $("$PHP" -d error_reporting=1 "$DIR/cli/valet.php" which-php $SITE) $(which composer) "${@:3}"
     else
-        $("$PHP" "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
+        $("$PHP" -d error_reporting=1 "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
     fi
 
     exit
@@ -169,5 +169,5 @@ else
         exit
     fi
 
-    "$PHP" "$DIR/cli/valet.php" "$@"
+    "$PHP" -d error_reporting=1 "$DIR/cli/valet.php" "$@"
 fi


### PR DESCRIPTION
When running PHP with extensions like imagick, sometimes the extension needs a rebuild after `brew upgrade`. Otherwise, it will throw a warning:
```
Warning: Version warning: Imagick was compiled against ImageMagick version 1809 but version 1810 is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
```

This warning is also printed, within the shell executions in Valet. But we use the output of those PHP CLI invocations. With those warnings being printed out, the parsing on the output fails and Valet cannot be used until the pecl extension is rebuilt.

With this patch, all CLI PHP invocations use ` -d error_reporting=1`. This suppresses warnings, but will still report errors.

It makes valet more robust in case a system package update causes warnings.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
