### PR TITLE
fix(TLS): create OpenSSL strict-mode compliant certs

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -570,7 +570,7 @@ class Site
         ));
 
         $this->cli->runAsUser(sprintf(
-            'openssl req -new -newkey rsa:2048 -days %s -nodes -x509 -subj "/C=/ST=/O=%s/localityName=/commonName=%s/organizationalUnitName=Developers/emailAddress=%s/" -keyout "%s" -out "%s"',
+            'openssl req -new -newkey rsa:2048 -days %s -nodes -x509 -subj "/C=/ST=/O=%s/localityName=/commonName=%s/organizationalUnitName=Developers/emailAddress=%s/" -keyout "%s" -out "%s" -addext "basicConstraints=critical,CA:TRUE" -addext "keyUsage=critical,digitalSignature,keyCertSign" -addext "subjectKeyIdentifier=hash"',
             $caExpireInDays, $oName, $cName, 'rootcertificate@laravel.valet', $caKeyPath, $caPemPath
         ));
         $this->trustCa($caPemPath);
@@ -649,7 +649,7 @@ class Site
     public function createSigningRequest(string $url, string $keyPath, string $csrPath, string $confPath): void
     {
         $this->cli->runAsUser(sprintf(
-            'openssl req -new -key "%s" -out "%s" -subj "/C=/ST=/O=/localityName=/commonName=%s/organizationalUnitName=/emailAddress=%s%s/" -config "%s"',
+            'openssl req -new -key "%s" -out "%s" -subj "/C=/ST=/O=/localityName=/commonName=%s/organizationalUnitName=/emailAddress=%s%s/"',
             $keyPath, $csrPath, $url, $url, '@laravel.valet', $confPath
         ));
     }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -614,7 +614,7 @@ class Site
 
         $this->buildCertificateConf($confPath, $url);
         $this->createPrivateKey($keyPath);
-        $this->createSigningRequest($url, $keyPath, $csrPath, $confPath);
+        $this->createSigningRequest($url, $keyPath, $csrPath);
 
         $caSrlParam = '-CAserial "'.$caSrlPath.'"';
         if (! $this->files->exists($caSrlPath)) {
@@ -646,11 +646,11 @@ class Site
     /**
      * Create the signing request for the TLS certificate.
      */
-    public function createSigningRequest(string $url, string $keyPath, string $csrPath, string $confPath): void
+    public function createSigningRequest(string $url, string $keyPath, string $csrPath): void
     {
         $this->cli->runAsUser(sprintf(
             'openssl req -new -key "%s" -out "%s" -subj "/C=/ST=/O=/localityName=/commonName=%s/organizationalUnitName=/emailAddress=%s%s/"',
-            $keyPath, $csrPath, $url, $url, '@laravel.valet', $confPath
+            $keyPath, $csrPath, $url, $url, '@laravel.valet'
         ));
     }
 

--- a/cli/stubs/openssl.conf
+++ b/cli/stubs/openssl.conf
@@ -16,9 +16,11 @@ commonName_max	= 64
 
 [ v3_req ]
 # Extensions to add to a certificate request
-basicConstraints = CA:FALSE
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+basicConstraints = critical,CA:FALSE
+keyUsage = critical,nonRepudiation, digitalSignature, keyEncipherment
 subjectAltName = @alt_names
+authorityKeyIdentifier = keyid
+subjectKeyIdentifier = hash
 
 [alt_names]
 DNS.1 = VALET_DOMAIN


### PR DESCRIPTION
As mentioned in #1530, I recently ran into some issues with Valet certs not passing OpenSSL's X509 strict mode, which was enabled by default in Python 3.13. This made it difficult for python apps to communicate with php apps run under Valet during development.

This PR adds the necessary X509 extensions to both the CA and per-site leaf certificates to satisfy strict mode.

Note that the reference to the extension config file has been removed from the CSR creation command as the AKID extension can't be added without the CA certificate present (which it isn't when running this command). This has no effect on the final certificate as the CSR extensions were being overwritten when the certificate was signed anyway.

I have tested the migration pathway of this change under VirtualBuddy, and securing sites after this change continues to work regardless of whether the CA certificate was generated before or after this change.

The only thing to note is if the CA cert was generated prior to this change (and therefore doesn't have a SKID extension), generated leaf certificates will have a blank AKID, which shouldn't impact their validity to non-strict mode clients, however they will not pass strict mode validation until the CA is deleted and re-created with the new extensions.

If desired, logic could be added to detect the presence of the SKID extension in the CA certificate and forcibly re-create it if not found, however I didn't think this was wise as a default as it would disrupt the trust of other Valet site certificates until they too were re-created, which would likely be unexpected behaviour.