### PR TITLE
Update `ContaoValetDriver` to support current Contao versions

### DIFF
--- a/tests/Drivers/ContaoValetDriverTest.php
+++ b/tests/Drivers/ContaoValetDriverTest.php
@@ -23,6 +23,6 @@ class ContaoValetDriverTest extends BaseDriverTestCase
         $driver = new ContaoValetDriver;
 
         $projectPath = $this->projectDir('contao');
-        $this->assertEquals($projectPath.'/web/app.php', $driver->frontControllerPath($projectPath, 'my-site', '/'));
+        $this->assertEquals($projectPath.'/public/index.php', $driver->frontControllerPath($projectPath, 'my-site', '/'));
     }
 }


### PR DESCRIPTION
This PR updates the `ContaoValetDriver` to support current Contao versions (from Contao 4.9).
`/web/app.php` was used until to Contao 4.8, which was released in August 2019, later versions use `index.php` instead of `app.php`.
I don't think it makes sense to still support older versions than 4.8, because they all are unsupported since 2019. But if you still want to support them, I can add it again.
Current versions also use the `public` directory, but `web` is still supported and is probably still in use by a few people.

I have also added support for the [Contao Manager](https://github.com/contao/contao-manager), which usually resides in `/public/contao-manager.phar.php` and the preview mode, which uses the `preview.php` file.