### PR TITLE
Allow laravel/valet to be use as dependency inside another project

### DIFF
--- a/cli/Valet/WebContext.php
+++ b/cli/Valet/WebContext.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Valet;
+
+class WebContext
+{
+    public function __construct(public Filesystem $files)
+    {
+    }
+
+    public function guessHomebrewPath(string $phpBinary): bool
+    {
+        $parts = array_values(array_filter(explode(DIRECTORY_SEPARATOR, $phpBinary)));
+
+        $currentDirectory = '';
+
+        while($folder = array_shift($parts)) {
+            $currentDirectory .= DIRECTORY_SEPARATOR . $folder;
+            $brewExists = $currentDirectory . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'brew';
+            $cellarExists = $currentDirectory . DIRECTORY_SEPARATOR . 'Cellar';
+
+            $found = $this->files->exists($brewExists) && $this->files->isDir($cellarExists);
+
+            if (! $found) {
+                continue;
+            }
+
+            return $currentDirectory;
+        }
+
+        throw new \LogicException('Unable to guess homebrew path. Define a constant with BREW_PREFIX with your local homebrew path.');
+    }
+}
+

--- a/cli/Valet/WebContext.php
+++ b/cli/Valet/WebContext.php
@@ -9,7 +9,6 @@ class WebContext
     public function guessHomebrewPath(string $phpBinary): string
     {
         $parts = array_values(array_filter(explode(DIRECTORY_SEPARATOR, $phpBinary)));
-
         $currentDirectory = '';
 
         while ($folder = array_shift($parts)) {

--- a/cli/Valet/WebContext.php
+++ b/cli/Valet/WebContext.php
@@ -4,9 +4,7 @@ namespace Valet;
 
 class WebContext
 {
-    public function __construct(public Filesystem $files)
-    {
-    }
+    public function __construct(public Filesystem $files) {}
 
     public function guessHomebrewPath(string $phpBinary): string
     {
@@ -14,10 +12,10 @@ class WebContext
 
         $currentDirectory = '';
 
-        while($folder = array_shift($parts)) {
-            $currentDirectory .= DIRECTORY_SEPARATOR . $folder;
-            $brewExists = $currentDirectory . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'brew';
-            $cellarExists = $currentDirectory . DIRECTORY_SEPARATOR . 'Cellar';
+        while ($folder = array_shift($parts)) {
+            $currentDirectory .= DIRECTORY_SEPARATOR.$folder;
+            $brewExists = $currentDirectory.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'brew';
+            $cellarExists = $currentDirectory.DIRECTORY_SEPARATOR.'Cellar';
 
             $found = $this->files->exists($brewExists) && $this->files->isDir($cellarExists);
 
@@ -31,4 +29,3 @@ class WebContext
         throw new \LogicException('Unable to guess homebrew path. Define a constant with BREW_PREFIX with your local homebrew path.');
     }
 }
-

--- a/cli/Valet/WebContext.php
+++ b/cli/Valet/WebContext.php
@@ -8,7 +8,7 @@ class WebContext
     {
     }
 
-    public function guessHomebrewPath(string $phpBinary): bool
+    public function guessHomebrewPath(string $phpBinary): string
     {
         $parts = array_values(array_filter(explode(DIRECTORY_SEPARATOR, $phpBinary)));
 

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -25,8 +25,10 @@ if (! defined('VALET_STATIC_PREFIX')) {
 define('VALET_LOOPBACK', '127.0.0.1');
 define('VALET_SERVER_PATH', realpath(__DIR__.'/../../server.php'));
 
-if (! defined('BREW_PREFIX')) {
-    define('BREW_PREFIX', (new CommandLine)->runAsUser('printf $(brew --prefix)'));
+if (php_sapi_name() === 'cli') {
+    define('BREW_PREFIX',  (new CommandLine)->runAsUser('printf $(brew --prefix)'));
+} else if (! defined('BREW_PREFIX')) {
+    define('BREW_PREFIX', WebContext::guessHomebrewPath(PHP_BINARY));
 }
 
 define('ISOLATED_PHP_VERSION', 'ISOLATED_PHP_VERSION');

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -28,7 +28,7 @@ define('VALET_SERVER_PATH', realpath(__DIR__.'/../../server.php'));
 if (php_sapi_name() === 'cli') {
     define('BREW_PREFIX',  (new CommandLine)->runAsUser('printf $(brew --prefix)'));
 } else if (! defined('BREW_PREFIX')) {
-    define('BREW_PREFIX', WebContext::guessHomebrewPath(PHP_BINARY));
+    define('BREW_PREFIX', (new WebContext(resolve(Filesystem::class)))->guessHomebrewPath(PHP_BINARY));
 }
 
 define('ISOLATED_PHP_VERSION', 'ISOLATED_PHP_VERSION');

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -26,8 +26,8 @@ define('VALET_LOOPBACK', '127.0.0.1');
 define('VALET_SERVER_PATH', realpath(__DIR__.'/../../server.php'));
 
 if (php_sapi_name() === 'cli') {
-    define('BREW_PREFIX',  (new CommandLine)->runAsUser('printf $(brew --prefix)'));
-} else if (! defined('BREW_PREFIX')) {
+    define('BREW_PREFIX', (new CommandLine)->runAsUser('printf $(brew --prefix)'));
+} elseif (! defined('BREW_PREFIX')) {
     define('BREW_PREFIX', (new WebContext(resolve(Filesystem::class)))->guessHomebrewPath(PHP_BINARY));
 }
 

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -25,7 +25,9 @@ if (! defined('VALET_STATIC_PREFIX')) {
 define('VALET_LOOPBACK', '127.0.0.1');
 define('VALET_SERVER_PATH', realpath(__DIR__.'/../../server.php'));
 
-define('BREW_PREFIX', (new CommandLine)->runAsUser('printf $(brew --prefix)'));
+if (! defined('BREW_PREFIX')) {
+    define('BREW_PREFIX', (new CommandLine)->runAsUser('printf $(brew --prefix)'));
+}
 
 define('ISOLATED_PHP_VERSION', 'ISOLATED_PHP_VERSION');
 

--- a/tests/WebContextTest.php
+++ b/tests/WebContextTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Valet\Filesystem;
+use Valet\WebContext;
+
+final class WebContextTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+    public function tear_down()
+    {
+        Mockery::close();
+    }
+
+    public function test_it_can_guess_correctly_web_context()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')->once()->with('/not-exits/bin/brew')->andReturn(true);
+        $files->shouldReceive('isDir')->once()->with('/not-exits/Cellar')->andReturn(true);
+
+        $webContext = new WebContext($files);
+
+        $found = $webContext->guessHomebrewPath('/not-exits/');
+
+        $this->assertContains('a', ['a', 'b', 'c']);
+    }
+}

--- a/tests/WebContextTest.php
+++ b/tests/WebContextTest.php
@@ -22,4 +22,17 @@ final class WebContextTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertSame('/not-exits', $found);
     }
+
+    public function test_if_cant_find_throw_an_exception()
+    {
+        $this->expectException(\LogicException::class);
+
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')->once()->with('/not-exits/bin/brew')->andReturn(false);
+        // DUH!!!  $files->shouldReceive('isDir')->once()->with('/not-exits/Cellar')->andReturn(false);
+
+        $webContext = new WebContext($files);
+
+        $webContext->guessHomebrewPath('/not-exits/'); // ??
+    }
 }

--- a/tests/WebContextTest.php
+++ b/tests/WebContextTest.php
@@ -20,6 +20,6 @@ final class WebContextTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $found = $webContext->guessHomebrewPath('/not-exits/');
 
-        $this->assertContains('a', ['a', 'b', 'c']);
+        $this->assertSame('/not-exits', $found);
     }
 }


### PR DESCRIPTION
Hello,

I've a few free time on my hand and I was hacking and testing some hidden features inside Laravel Valet, but only work in CLI Enviroment, just by change one line I can call facades methods in Web Enviroment. 

Just by change one line I can unlock so much hacking for a new control panel for Valet in my personal computer. 

Just asking if any one could read my pull request? If this break any policy, I'm sorry, I did read some links to how to make a pull request. 
