### PR TITLE
Added support to determine php versions using composer.json

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -2,6 +2,7 @@
 
 namespace Valet;
 
+use Composer\Semver\Semver;
 use DateTime;
 use DomainException;
 use Illuminate\Support\Collection;
@@ -1163,5 +1164,43 @@ class Site
         $valetRc = $this->valetRc($siteName, $cwd);
 
         return PhpFpm::normalizePhpVersion(data_get($valetRc, 'php'));
+    }
+
+    /**
+     * Get PHP version from composer.json for a site.
+     */
+    public function phpComposerVersion(string $siteName, ?string $cwd = null): ?string
+    {
+        if ($cwd) {
+            $path = $cwd.'/composer.json';
+        } elseif ($site = $this->parked()->merge($this->links())->where('site', $siteName)->first()) {
+            $path = data_get($site, 'path').'/composer.json';
+        } else {
+            return null;
+        }
+
+        if (! $this->files->exists($path)) {
+            return null;
+        }
+
+        $composer = json_decode($this->files->get($path), true);
+        $constraint = data_get($composer, 'require.php', data_get($composer, 'require.php-64bit', data_get($composer, 'config.platform.php')));
+
+        if (empty($constraint)) {
+            return null;
+        }
+
+        // Find the lowest supported PHP version that satisfies the constraint (We do not suddenly want to raise the php version if a new one comes out)
+        $phpVersion = $this->brew->supportedPhpVersions()->reverse()->first(function ($formula) use ($constraint) {
+            if ($formula === 'php') {
+                return false;
+            }
+
+            $version = substr($formula, 4);
+
+            return Semver::satisfies($version, $constraint);
+        });
+
+        return $phpVersion ? PhpFpm::normalizePhpVersion($phpVersion) : null;
     }
 }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1186,7 +1186,7 @@ class Site
         $composer = json_decode($this->files->get($path), true);
         $constraint = data_get($composer, 'require.php', data_get($composer, 'require.php-64bit', data_get($composer, 'config.platform.php')));
 
-        if (empty($constraint)  || Semver::satisfies(substr($this->brew->linkedPhp(), 4), $constraint)) {
+        if (empty($constraint) || Semver::satisfies(substr($this->brew->linkedPhp(), 4), $constraint)) {
             return null;
         }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1186,12 +1186,16 @@ class Site
 
         $composer = json_decode($this->files->get($path), true);
         $constraint = data_get($composer, 'require.php', data_get($composer, 'require.php-64bit', data_get($composer, 'config.platform.php')));
+        if (empty($constraint)) {
+            return null;
+        }
 
         try {
-            if (empty($constraint) || Semver::satisfies(substr($this->brew->linkedPhp(), 4), $constraint)) {
-                return null;
+            $linkedVersion = $this->brew->linkedPhp();
+            if (Semver::satisfies(substr($linkedVersion, 4), $constraint)) {
+                return $linkedVersion;
             }
-        } catch (UnexpectedValueException $e) {
+        } catch (UnexpectedValueException|DomainException $e) {
             return null;
         }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -7,6 +7,7 @@ use DateTime;
 use DomainException;
 use Illuminate\Support\Collection;
 use PhpFpm;
+use UnexpectedValueException;
 
 class Site
 {
@@ -1186,7 +1187,11 @@ class Site
         $composer = json_decode($this->files->get($path), true);
         $constraint = data_get($composer, 'require.php', data_get($composer, 'require.php-64bit', data_get($composer, 'config.platform.php')));
 
-        if (empty($constraint) || Semver::satisfies(substr($this->brew->linkedPhp(), 4), $constraint)) {
+        try {
+            if (empty($constraint) || Semver::satisfies(substr($this->brew->linkedPhp(), 4), $constraint)) {
+                return null;
+            }
+        } catch (UnexpectedValueException $e) {
             return null;
         }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1186,7 +1186,7 @@ class Site
         $composer = json_decode($this->files->get($path), true);
         $constraint = data_get($composer, 'require.php', data_get($composer, 'require.php-64bit', data_get($composer, 'config.platform.php')));
 
-        if (empty($constraint)) {
+        if (empty($constraint)  || Semver::satisfies(substr($this->brew->linkedPhp(), 4), $constraint)) {
             return null;
         }
 

--- a/cli/app.php
+++ b/cli/app.php
@@ -208,7 +208,7 @@ if (is_dir(VALET_HOME_PATH)) {
         }
 
         if ($isolate) {
-            if (Site::phpRcVersion($name, getcwd())) {
+            if (Site::phpRcVersion($name, getcwd()) || Site::phpComposerVersion($name, getcwd())) {
                 $this->runCommand('isolate --site='.$name);
             } else {
                 warning('Valet could not determine which PHP version to use for this site.');
@@ -628,6 +628,8 @@ if (is_dir(VALET_HOME_PATH)) {
             if ($phpVersion = Site::phpRcVersion($site, getcwd())) {
                 info("Found '{$site}/.valetrc' or '{$site}/.valetphprc' specifying version: {$phpVersion}");
                 info("Found '{$site}/.valetphprc' specifying version: {$phpVersion}");
+            } else if ($phpVersion = Site::phpComposerVersion($site, getcwd())) {
+                info("Found php version in '{$site}/composer.json' specifying version: {$phpVersion}");
             } else {
                 $domain = $site.'.'.data_get(Configuration::read(), 'tld');
                 if ($phpVersion = PhpFpm::normalizePhpVersion(Site::customPhpVersion($domain))) {
@@ -660,6 +662,8 @@ if (is_dir(VALET_HOME_PATH)) {
         if (is_null($phpVersion)) {
             if ($phpVersion = Site::phpRcVersion($site, getcwd())) {
                 info("Found '{$site}/.valetrc' or '{$site}/.valetphprc' specifying version: {$phpVersion}");
+            } else if ($phpVersion = Site::phpComposerVersion($site, getcwd())) {
+                info("Found php version in '{$site}/composer.json' specifying version: {$phpVersion}");
             } else {
                 info(PHP_EOL.'Please provide a version number. E.g.:');
                 info('valet isolate php@8.2');
@@ -705,7 +709,7 @@ if (is_dir(VALET_HOME_PATH)) {
         );
 
         if (! $phpVersion) {
-            $phpVersion = Site::phpRcVersion($site ?: basename(getcwd()));
+            $phpVersion = Site::phpRcVersion($site ?: basename(getcwd())) ?: Site::phpComposerVersion($site ?: basename(getcwd()));;
         }
 
         return output(Brew::getPhpExecutablePath($phpVersion));

--- a/cli/app.php
+++ b/cli/app.php
@@ -709,7 +709,7 @@ if (is_dir(VALET_HOME_PATH)) {
         );
 
         if (! $phpVersion) {
-            $phpVersion = Site::phpRcVersion($site ?: basename(getcwd())) ?: Site::phpComposerVersion($site ?: basename(getcwd()));;
+            $phpVersion = Site::phpRcVersion($site ?: basename(getcwd())) ?: Site::phpComposerVersion($site ?: basename(getcwd()));
         }
 
         return output(Brew::getPhpExecutablePath($phpVersion));

--- a/cli/app.php
+++ b/cli/app.php
@@ -628,7 +628,7 @@ if (is_dir(VALET_HOME_PATH)) {
             if ($phpVersion = Site::phpRcVersion($site, getcwd())) {
                 info("Found '{$site}/.valetrc' or '{$site}/.valetphprc' specifying version: {$phpVersion}");
                 info("Found '{$site}/.valetphprc' specifying version: {$phpVersion}");
-            } else if ($phpVersion = Site::phpComposerVersion($site, getcwd())) {
+            } elseif ($phpVersion = Site::phpComposerVersion($site, getcwd())) {
                 info("Found php version in '{$site}/composer.json' specifying version: {$phpVersion}");
             } else {
                 $domain = $site.'.'.data_get(Configuration::read(), 'tld');
@@ -662,7 +662,7 @@ if (is_dir(VALET_HOME_PATH)) {
         if (is_null($phpVersion)) {
             if ($phpVersion = Site::phpRcVersion($site, getcwd())) {
                 info("Found '{$site}/.valetrc' or '{$site}/.valetphprc' specifying version: {$phpVersion}");
-            } else if ($phpVersion = Site::phpComposerVersion($site, getcwd())) {
+            } elseif ($phpVersion = Site::phpComposerVersion($site, getcwd())) {
                 info("Found php version in '{$site}/composer.json' specifying version: {$phpVersion}");
             } else {
                 info(PHP_EOL.'Please provide a version number. E.g.:');

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     },
     "require": {
         "php": "^7.1|^8.0",
+        "composer/semver": "^3.0",
         "illuminate/collections": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/container": "~5.1|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "mnapoli/silly": "^1.5",

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -1151,6 +1151,7 @@ class CliTest extends BaseApplicationTestCase
 
         $site = Mockery::mock(RealSite::class);
         $site->shouldReceive('phpRcVersion')->andReturn(null);
+        $site->shouldReceive('phpComposerVersion')->andReturn(null);
         $site->shouldReceive('customPhpVersion')->andReturn('php@8.0');
 
         swap(RealSite::class, $site);
@@ -1172,6 +1173,7 @@ class CliTest extends BaseApplicationTestCase
 
         $site = Mockery::mock(RealSite::class);
         $site->shouldReceive('phpRcVersion')->andReturn(null);
+        $site->shouldReceive('phpComposerVersion')->andReturn(null);
         $site->shouldReceive('customPhpVersion')->andReturn(null);
 
         swap(RealSite::class, $site);

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -1159,6 +1159,241 @@ class SiteTest extends TestCase
         $this->assertEquals('php@8.2', $site->phpRcVersion('site-w-valetrc-3'));
         $this->assertEquals('php@8.2', $site->phpRcVersion('blabla', __DIR__.'/fixtures/Parked/Sites/site-w-valetrc-3'));
     }
+
+    public function test_it_returns_null_when_composer_file_is_missing()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(false);
+
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldNotReceive('linkedPhp');
+        $brew->shouldNotReceive('supportedPhpVersions');
+
+        $site = new Site(
+            $brew,
+            Mockery::mock(Configuration::class),
+            Mockery::mock(CommandLine::class),
+            $files
+        );
+
+        $this->assertNull($site->phpComposerVersion('my-site', '/sites/my-site'));
+    }
+
+    public function test_it_returns_null_when_linked_php_satisfies_composer_constraint()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(true);
+        $files->shouldReceive('get')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(json_encode([
+                'require' => [
+                    'php' => '^8.2',
+                ],
+            ]));
+
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')
+            ->once()
+            ->andReturn('php@8.4');
+        $brew->shouldNotReceive('supportedPhpVersions');
+
+        $site = new Site(
+            $brew,
+            Mockery::mock(Configuration::class),
+            Mockery::mock(CommandLine::class),
+            $files
+        );
+
+        $this->assertNull($site->phpComposerVersion('my-site', '/sites/my-site'));
+    }
+
+    public function test_it_uses_semver_to_find_lowest_supported_composer_php_version()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(true);
+        $files->shouldReceive('get')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(json_encode([
+                'require' => [
+                    'php' => '>=8.1',
+                ],
+            ]));
+
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')
+            ->once()
+            ->andReturn('php@8.0');
+        $brew->shouldReceive('supportedPhpVersions')
+            ->once()
+            ->andReturn(collect([
+                'php@8.3',
+                'php@8.2',
+                'php@8.1',
+                'php@8.0',
+            ]));
+
+        $site = new Site(
+            $brew,
+            Mockery::mock(Configuration::class),
+            Mockery::mock(CommandLine::class),
+            $files
+        );
+
+        $this->assertSame('php@8.1', $site->phpComposerVersion('my-site', '/sites/my-site'));
+    }
+
+    public function test_it_resolves_compound_composer_semver_constraints()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(true);
+        $files->shouldReceive('get')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(json_encode([
+                'require' => [
+                    'php' => '^7.4 || ^8.0',
+                ],
+            ]));
+
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')
+            ->once()
+            ->andReturn('php@7.3');
+        $brew->shouldReceive('supportedPhpVersions')
+            ->once()
+            ->andReturn(collect([
+                'php@8.2',
+                'php@8.1',
+                'php@7.4',
+                'php@7.3',
+            ]));
+
+        $site = new Site(
+            $brew,
+            Mockery::mock(Configuration::class),
+            Mockery::mock(CommandLine::class),
+            $files
+        );
+
+        $this->assertSame('php@7.4', $site->phpComposerVersion('my-site', '/sites/my-site'));
+    }
+
+    public function test_it_resolves_composer_semver_with_upper_bound_constraint()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(true);
+        $files->shouldReceive('get')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(json_encode([
+                'require' => [
+                    'php' => '^8.0 <=8.3',
+                ],
+            ]));
+
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')
+            ->once()
+            ->andReturn('php@8.4');
+        $brew->shouldReceive('supportedPhpVersions')
+            ->once()
+            ->andReturn(collect([
+                'php@8.4',
+                'php@8.3',
+                'php@8.2'
+            ]));
+
+        $site = new Site(
+            $brew,
+            Mockery::mock(Configuration::class),
+            Mockery::mock(CommandLine::class),
+            $files
+        );
+
+        $this->assertSame('php@8.2', $site->phpComposerVersion('my-site', '/sites/my-site'));
+    }
+
+    public function test_it_returns_null_when_no_supported_php_versions_match_composer_constraint()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(true);
+        $files->shouldReceive('get')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(json_encode([
+                'require' => [
+                    'php' => '^7.4',
+                ],
+            ]));
+
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')
+            ->once()
+            ->andReturn('php@8.2');
+        $brew->shouldReceive('supportedPhpVersions')
+            ->once()
+            ->andReturn(collect([
+                'php@8.3',
+                'php@8.2',
+                'php@8.1',
+                'php',
+            ]));
+
+        $site = new Site(
+            $brew,
+            Mockery::mock(Configuration::class),
+            Mockery::mock(CommandLine::class),
+            $files
+        );
+
+        $this->assertNull($site->phpComposerVersion('my-site', '/sites/my-site'));
+    }
+
+    public function test_it_handles_malformed_composer_json_in_php_composer_version()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(true);
+        $files->shouldReceive('get')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn('{"require": {"php": "^8.1"');
+
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldNotReceive('linkedPhp');
+        $brew->shouldNotReceive('supportedPhpVersions');
+
+        $site = new Site(
+            $brew,
+            Mockery::mock(Configuration::class),
+            Mockery::mock(CommandLine::class),
+            $files
+        );
+
+        $this->assertNull($site->phpComposerVersion('my-site', '/sites/my-site'));
+    }
 }
 
 class CommandLineFake extends CommandLine

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -1317,7 +1317,7 @@ class SiteTest extends TestCase
             ->andReturn(collect([
                 'php@8.4',
                 'php@8.3',
-                'php@8.2'
+                'php@8.2',
             ]));
 
         $site = new Site(
@@ -1384,6 +1384,37 @@ class SiteTest extends TestCase
         $brew = Mockery::mock(Brew::class);
         $brew->shouldNotReceive('linkedPhp');
         $brew->shouldNotReceive('supportedPhpVersions');
+
+        $site = new Site(
+            $brew,
+            Mockery::mock(Configuration::class),
+            Mockery::mock(CommandLine::class),
+            $files
+        );
+
+        $this->assertNull($site->phpComposerVersion('my-site', '/sites/my-site'));
+    }
+
+    public function test_it_handles_malformed_constraint_in_php_composer_version()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $files->shouldReceive('exists')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(true);
+        $files->shouldReceive('get')
+            ->once()
+            ->with('/sites/my-site/composer.json')
+            ->andReturn(json_encode([
+                'require' => [
+                    'php' => 'abc7.4sss',
+                ],
+            ]));
+
+        $brew = Mockery::mock(Brew::class);
+        $brew->shouldReceive('linkedPhp')
+            ->once()
+            ->andReturn('php@8.2');
 
         $site = new Site(
             $brew,

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -1182,7 +1182,7 @@ class SiteTest extends TestCase
         $this->assertNull($site->phpComposerVersion('my-site', '/sites/my-site'));
     }
 
-    public function test_it_returns_null_when_linked_php_satisfies_composer_constraint()
+    public function test_it_returns_current_version_when_linked_php_satisfies_composer_constraint()
     {
         $files = Mockery::mock(Filesystem::class);
         $files->shouldReceive('exists')
@@ -1211,7 +1211,7 @@ class SiteTest extends TestCase
             $files
         );
 
-        $this->assertNull($site->phpComposerVersion('my-site', '/sites/my-site'));
+        $this->assertSame('php@8.4', $site->phpComposerVersion('my-site', '/sites/my-site'));
     }
 
     public function test_it_uses_semver_to_find_lowest_supported_composer_php_version()


### PR DESCRIPTION
This PR adds support to fall back to the php version defined in the composer.json
Due to using composer/semver all combination of php requirements are possible (though the match is not exact as we only care about the x.x version, no patch versions)

Requirements like `^8.3`, `8.3`, `<8.5`, `>=8.4` are all supported.
Priority is still given to the valetrc files, and we pick the lowest matching version so `^8.3` could not suddenly switch to 8.6 once it comes out.
This is the same way [rectorphp/rector](https://github.com/rectorphp/rector/blob/a6a70cce35f29cb34a7874a518caf48b7f8d5fc5/src/Configuration/RectorConfigBuilder.php#L388) handles php constraints.

docs: https://github.com/laravel/docs/pull/11301