### PR TITLE
fix(nginx): listen on [::1] so the IPv6 .test DNS answer from #1545 serves

### DIFF
--- a/cli/stubs/proxy.valet.conf
+++ b/cli/stubs/proxy.valet.conf
@@ -2,6 +2,7 @@
 
 server {
     listen 127.0.0.1:80;
+    listen [::1]:80;
     #listen VALET_LOOPBACK:80; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
@@ -47,6 +48,7 @@ server {
 
 server {
     listen 127.0.0.1:60;
+    listen [::1]:60;
     #listen VALET_LOOPBACK:60; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;

--- a/cli/stubs/secure.proxy.valet-legacy.conf
+++ b/cli/stubs/secure.proxy.valet-legacy.conf
@@ -2,6 +2,7 @@
 
 server {
     listen 127.0.0.1:80;
+    listen [::1]:80;
     #listen VALET_LOOPBACK:80; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
@@ -9,6 +10,7 @@ server {
 
 server {
     listen 127.0.0.1:443 ssl http2;
+    listen [::1]:443 ssl http2;
     #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;

--- a/cli/stubs/secure.proxy.valet.conf
+++ b/cli/stubs/secure.proxy.valet.conf
@@ -2,6 +2,7 @@
 
 server {
     listen 127.0.0.1:80;
+    listen [::1]:80;
     #listen VALET_LOOPBACK:80; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
@@ -9,6 +10,7 @@ server {
 
 server {
     listen 127.0.0.1:443 ssl;
+    listen [::1]:443 ssl;
     #listen VALET_LOOPBACK:443 ssl; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;

--- a/cli/stubs/secure.valet-legacy.conf
+++ b/cli/stubs/secure.valet-legacy.conf
@@ -1,5 +1,6 @@
 server {
     listen 127.0.0.1:80;
+    listen [::1]:80;
     #listen VALET_LOOPBACK:80; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
@@ -7,6 +8,7 @@ server {
 
 server {
     listen 127.0.0.1:443 ssl http2;
+    listen [::1]:443 ssl http2;
     #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
@@ -51,6 +53,7 @@ server {
 
 server {
     listen 127.0.0.1:60;
+    listen [::1]:60;
     #listen VALET_LOOPBACK:60; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,5 +1,6 @@
 server {
     listen 127.0.0.1:80;
+    listen [::1]:80;
     #listen VALET_LOOPBACK:80; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
@@ -7,6 +8,7 @@ server {
 
 server {
     listen 127.0.0.1:443 ssl;
+    listen [::1]:443 ssl;
     #listen VALET_LOOPBACK:443 ssl; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
@@ -51,6 +53,7 @@ server {
 
 server {
     listen 127.0.0.1:60;
+    listen [::1]:60;
     #listen VALET_LOOPBACK:60; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;

--- a/cli/stubs/site.valet.conf
+++ b/cli/stubs/site.valet.conf
@@ -1,6 +1,7 @@
 # ISOLATED_PHP_VERSION=VALET_ISOLATED_PHP_VERSION
 server {
     listen 127.0.0.1:80;
+    listen [::1]:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     #listen VALET_LOOPBACK:80; # valet loopback
     root /;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -1,5 +1,6 @@
 server {
     listen 127.0.0.1:80 default_server;
+    listen [::1]:80 default_server;
     #listen VALET_LOOPBACK:80; # valet loopback
     server_name "!valet!" "";
     root /;

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -989,7 +989,9 @@ class SiteTest extends TestCase
                 Mockery::on(function ($argument) {
                     return preg_match('/^# '.ISOLATED_PHP_VERSION.'=php@8.0/', $argument)
                         && preg_match('#fastcgi_pass "unix:.*/valet80.sock#', $argument)
-                        && strpos($argument, 'server_name site2.test www.site2.test *.site2.test;') !== false;
+                        && strpos($argument, 'server_name site2.test www.site2.test *.site2.test;') !== false
+                        && strpos($argument, 'listen 127.0.0.1:80;') !== false
+                        && strpos($argument, 'listen [::1]:80;') !== false;
                 }),
             ]);
 


### PR DESCRIPTION
Fixes #1558.

## Problem

#1545 ("Add IPV6 lookup for Safari Happy Eyeballs") made dnsmasq answer every `.test` host with both `127.0.0.1` (A) and `::1` (AAAA):

```
address=/.test/127.0.0.1
address=/.test/::1
listen-address=127.0.0.1
```

But the nginx site/proxy stubs still `listen` on IPv4 only. When the OS follows Happy Eyeballs / RFC 6724 and connects to `::1` first, nginx has nothing bound there, so the request falls through to the catch-all and returns `404 page not found` for every site.

## Fix

Add a `listen [::1]:PORT;` line next to each `listen 127.0.0.1:PORT;` line in all four stubs (`site`, `secure`, `proxy`, `secure.proxy`), so nginx serves the same vhost over IPv6 loopback.

The new `[::1]` lines carry no `# valet loopback` comment, so neither `replaceLoopback()` nor `replaceOldLoopbackWithNew()` matches them — the custom-loopback mechanism is unaffected.

## Testing

Extended `test_can_install_nginx_site_config_for_specific_php_version` to assert the rendered config listens on both `127.0.0.1:80` and `[::1]:80`. Neither listen line was covered before, which is how the IPv4-only gap went unnoticed. Confirmed the assertion fails if the `[::1]` line is removed from the stub.

- Full suite green (283 tests)
- `pint` clean
- Verified end-to-end locally: with the patched stubs, a secured `.test` site returns `200` over both IPv4 and `[::1]`, where it previously 404'd over IPv6.

## Note for reviewers

With a custom loopback set (`valet loopback <ip>`), the rendered config now contains both the custom `listen <ip>:PORT;` line and the always-on `listen [::1]:PORT;` line. This is additive and matches #1545's intent of always answering IPv6, but if you'd prefer the `[::1]` listener to be gated by config instead of always-on, happy to adjust.
