### PR TITLE
Unset $path after requiring drivers to prevent scope leak

### DIFF
--- a/cli/includes/require-drivers.php
+++ b/cli/includes/require-drivers.php
@@ -8,3 +8,5 @@ foreach (scandir('./cli/Valet/Drivers') as $file) {
         require_once $path;
     }
 }
+
+unset($path);


### PR DESCRIPTION
Fixes #1546

`cli/includes/require-drivers.php` uses a `$path` variable while iterating and requiring driver files. Because `server.php` (and the chain of includes leading into a project's `index.php`) runs in a shared global scope, `$path` remained set after the driver loop finished and leaked into user project scope — so calling `$path` in a project's `index.php` unexpectedly returned the last driver file path (e.g. `./cli/Valet/Drivers/ValetDriver.php`).

This adds `unset($path);` after the loop, matching the fix suggested in the issue and confirmed safe by maintainers in the issue thread.

## Test plan
- Read through `require-drivers.php`, `server.php`, and the driver `serve()` chain to confirm `$path` is not referenced anywhere after the loop.
- No existing PHPUnit test exercises `server.php`/`require-drivers.php` as an executed entry script (existing `ServerTest.php` only covers the `Valet\Server` class), so no automated test was added; this is a one-line scope fix in a script that has no test harness in this repo. PHP is not available in the environment this change was authored in, so the change was verified by code inspection only, not by running Valet locally.