### PR TITLE
Un-set variables to keep them out of user project scope

### DIFF
--- a/cli/includes/require-drivers.php
+++ b/cli/includes/require-drivers.php
@@ -8,3 +8,6 @@ foreach (scandir('./cli/Valet/Drivers') as $file) {
         require_once $path;
     }
 }
+
+// Unset our loop variables to keep them from leaking into the user's app.
+unset($file, $path);

--- a/server.php
+++ b/server.php
@@ -105,6 +105,22 @@ if (! $frontControllerPath) {
     Server::show404();
 }
 
+/**
+ * Unset our variables to avoid leakage into the user's application.
+ */
+unset(
+    $valetConfig,
+    $uriForIpAddressExtraction,
+    $host,
+    $server,
+    $uri,
+    $siteName,
+    $valetSitePath,
+    $valetDriver,
+    $isPhpFile,
+    $staticFilePath,
+);
+
 chdir(dirname($frontControllerPath));
 
 require $frontControllerPath;


### PR DESCRIPTION
Fixes #1546, closes #1560.

@wakqasahmed thanks for your PR; but if we're going to unset them, we should unset them all. 

@drbyte can you think of any reason folks we know will have any issue with this? I consider these more a private API than a public API, so I don't really think of this as a breaking change, but just want to make sure there's not a practical use case we've heard of that I'm forgetting.