### PR TITLE
Allow guzzlehttp/guzzle ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "mnapoli/silly": "^1.5",
         "symfony/console": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "symfony/process": "^3.0|^4.0|^5.0|^6.0|^7.0",
-        "guzzlehttp/guzzle": "^6.0|^7.4",
+        "guzzlehttp/guzzle": "^6.0|^7.4|^8.0",
         "symfony/event-dispatcher": "^3.0|^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Guzzle 8 has been out since May and is currently blocked for projects (and global Composer installs) that have Valet alongside packages already allowing Guzzle 8. This widens the constraint so Composer can resolve either major.

## Summary

- Adds `^8.0` to the `guzzlehttp/guzzle` constraint, keeping `^6.0|^7.4` intact.
- Guzzle 8 requires PHP `^7.4 || ^8.0`, which fits within Valet's existing `php: ^7.1|^8.0` requirement, so no platform change is needed.
- Valet's Guzzle usage is untouched by the v8 breaking changes. The four call sites (`Cloudflared`, `Expose`, `Ngrok`, `Valet`) all use `(new Client)->get(...)->getBody()`, and `get()` is a typed `ClientTrait` method in v8. The `ConnectException` and `GuzzleException` classes used in `Expose` and `Valet` still exist. None of the removed APIs (magic `__call`, `ClientInterface::getConfig()`, `Utils::json*`, the `handler` request option) are used.

## Test plan

- `composer update` resolves `guzzlehttp/guzzle` to 8.1.0 with this constraint.
- Full test suite passes with Guzzle 8 installed: 293 tests, 561 assertions.