### PR TITLE
Allow Symfony 8 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,10 +47,10 @@
         "illuminate/collections": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/container": "~5.1|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "mnapoli/silly": "^1.5",
-        "symfony/console": "^3.0|^4.0|^5.0|^6.0|^7.0",
-        "symfony/process": "^3.0|^4.0|^5.0|^6.0|^7.0",
+        "symfony/console": "^3.0|^4.0|^5.0|^6.0|^7.0|^8.0",
+        "symfony/process": "^3.0|^4.0|^5.0|^6.0|^7.0|^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.4|^8.0",
-        "symfony/event-dispatcher": "^3.0|^4.0|^5.0|^6.0|^7.0"
+        "symfony/event-dispatcher": "^3.0|^4.0|^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",


### PR DESCRIPTION
Symfony 8 has been out since late 2025 and is currently blocked for projects (and global Composer installs) that have Valet alongside packages already allowing Symfony 8. This widens the constraints for the three Symfony components so Composer can resolve either major. Related: #1563 does the same for Guzzle 8.

## Summary

- Adds `^8.0` to the `symfony/console`, `symfony/process`, and `symfony/event-dispatcher` constraints, keeping the existing ranges intact.
- Symfony 8 requires PHP >= 8.4.1, which fits within Valet's existing `php: ^7.1|^8.0` requirement. On older PHP versions Composer simply resolves Symfony <= 7, so no platform change is needed.
- `mnapoli/silly` 1.10.1 (within the existing `^1.5` constraint) already allows `symfony/console ~8.0`, so the console Application/Command integration is covered upstream.
- Valet's direct Symfony usage is limited to stable APIs that remain unchanged in v8: `Process` (`CommandLine`), `ProgressBar` and `ConsoleOutput` (`Diagnose`), `Table`, `ConsoleOutput` and `OutputInterface` (`helpers.php`), and `ConsoleEvents`, `ConsoleCommandEvent`, `ConfirmationQuestion` and `EventDispatcher` (`app.php`).

## Test plan

- `composer update` resolves symfony/console, symfony/process, and symfony/event-dispatcher to 8.1.5 with silly 1.10.1.
- Full test suite passes with Symfony 8 installed: 293 tests, 561 assertions.