### PR TITLE
Run read-only commands without sudo

### DIFF
--- a/valet
+++ b/valet
@@ -163,6 +163,17 @@ then
 # and let it handle the request. These are commands which can be run
 # without sudo and don't require taking over terminals like Ngrok.
 else
+    # Read-only commands never need root, so run them directly. This keeps
+    # them from triggering a sudo password prompt, which matters for
+    # editors, language servers, and scripts calling things like
+    # "valet --version" or "valet links".
+    case "$1" in
+        ""|--version|-V|--help|-h|help|list|links|parked|paths|which|which-php|isolated|proxies|secured|on-latest-version|latest)
+            "$PHP" -d error_reporting=1 "$DIR/cli/valet.php" "$@"
+            exit
+            ;;
+    esac
+
     if [[ "$EUID" -ne 0 ]]
     then
         sudo USER="$USER" --preserve-env "$SOURCE" "$@"


### PR DESCRIPTION
Every command other than `share`, `php`, and `composer` currently re-executes itself through `sudo`, so even `valet --version` and `valet links` trigger a password prompt. That is painful for anything that shells out to Valet non-interactively: editors, language servers (the Laravel language server had to work around this), CI scripts, and shell prompts.

## Summary

- Adds a whitelist to the wrapper's final branch: `--version`, `--help`, `help`, `list`, `links`, `parked`, `paths`, `which`, `which-php`, `isolated`, `proxies`, `secured`, `on-latest-version`/`latest`, and the bare `valet` invocation now run directly without elevating.
- These commands only read state and print output (tables from `Site::links()`, `Site::parked()`, `Site::proxies()`, `Configuration::read()`, etc.); none of them touch Brew services, Nginx, dnsmasq, or anything else that requires root. The per-run `Upgrader::onEveryRun()` housekeeping only writes inside the user-owned `~/.config/valet`.
- All other commands keep the existing sudo behavior.

## Test plan

- `bash ./valet --version`, `valet paths`, and `valet links` run as a regular user without a password prompt and produce the same output as before.
- `bash -n valet` passes.
- The elevation path for the remaining commands is unchanged.