### PR TITLE
Remove deprecated PHPUnit configuration attributes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertDeprecationsToExceptions="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
          beStrictAboutTestsThatDoNotTestAnything="false"


### PR DESCRIPTION
Every test run on PHPUnit 10+ currently reports a test runner deprecation: "Your XML configuration validates against a deprecated schema." The `backupStaticAttributes` and `convert*ToExceptions` attributes were removed in PHPUnit 10, and they are the only parts of the configuration that still fail current schema validation.

## Summary

- Removes `backupStaticAttributes` and the four `convert*ToExceptions` attributes from `phpunit.xml.dist`.
- The remaining configuration is valid for both the modern schema and PHPUnit 9, so the PHP 8.0 leg of the CI matrix (which resolves PHPUnit 9.6 via yoast/phpunit-polyfills) is unaffected. A full `--migrate-configuration` was deliberately avoided for that reason.

## Test plan

- PHPUnit 12.5: suite now reports a clean `OK (293 tests, 561 assertions)` with no deprecation.
- PHPUnit 9.6 (temporarily pinned to mirror the PHP 8.0 CI leg): same clean `OK (293 tests, 561 assertions)`.