### PR TITLE
Require PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "mnapoli/silly": ">=1.8.1 <1.8.3"
     },
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.0",
         "composer/semver": "^3.0",
         "illuminate/collections": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/container": "~5.1|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",


### PR DESCRIPTION
`composer.json` still advertises PHP 7.1 support, but Valet 4 cannot run on PHP 7: the CLI classes use constructor property promotion (14 constructors across `cli/Valet/`, e.g. `Cloudflared`, `Upgrader`), which is PHP 8.0 syntax and produces a parse error on any PHP 7 runtime. Because the dependency constraints can still resolve on PHP 7.4, `composer require laravel/valet` currently succeeds there and only fails at runtime. The CI matrix has tested PHP 8.0+ exclusively for a while.

## Summary

- Changes the `php` requirement from `^7.1|^8.0` to `^8.0` so Composer fails fast with a clear platform error instead of installing a package that cannot parse.

## Test plan

- `composer validate` passes.
- `composer update` and the full test suite pass: 293 tests, 561 assertions.