### PR TITLE
Use PHP 8 features in CLI code

### DIFF
--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Diagnose
 {
-    public $commands = [
+    public array $commands = [
         'sw_vers',
         'valet --version',
         'cat ~/.config/valet/config.json',
@@ -51,9 +51,9 @@ class Diagnose
         'sh -c \'for file in ~/.config/valet/nginx/*; do echo "------\n~/.config/valet/nginx/$(basename $file)\n---\n"; cat $file | grep -n "# valet loopback"; echo "\n------\n"; done\'',
     ];
 
-    public $print;
+    public bool $print = false;
 
-    public $progressBar;
+    public ?ProgressBar $progressBar = null;
 
     public function __construct(public CommandLine $cli, public Filesystem $files) {}
 

--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -113,7 +113,7 @@ class Diagnose
 
     public function runCommand(string $command): string
     {
-        return strpos($command, 'sudo ') === 0
+        return str_starts_with($command, 'sudo ')
             ? $this->cli->run($command)
             : $this->cli->runAsUser($command);
     }
@@ -136,7 +136,7 @@ class Diagnose
 
     public function ignoreOutput(string $command): bool
     {
-        return strpos($command, '> /dev/null 2>&1') !== false;
+        return str_contains($command, '> /dev/null 2>&1');
     }
 
     public function format(Collection $results, bool $plainText): string

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -4,11 +4,11 @@ namespace Valet;
 
 class DnsMasq
 {
-    public $dnsmasqMasterConfigFile = BREW_PREFIX.'/etc/dnsmasq.conf';
+    public string $dnsmasqMasterConfigFile = BREW_PREFIX.'/etc/dnsmasq.conf';
 
-    public $dnsmasqSystemConfDir = BREW_PREFIX.'/etc/dnsmasq.d';
+    public string $dnsmasqSystemConfDir = BREW_PREFIX.'/etc/dnsmasq.d';
 
-    public $resolverPath = '/etc/resolver';
+    public string $resolverPath = '/etc/resolver';
 
     public function __construct(public Brew $brew, public CommandLine $cli, public Filesystem $files, public Configuration $configuration) {}
 

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -76,7 +76,7 @@ class DnsMasq
         // set primary config to look for configs in /usr/local/etc/dnsmasq.d/*.conf
         $contents = $this->files->get($this->dnsmasqMasterConfigFile);
         // ensure the line we need to use is present, and uncomment it if needed
-        if (strpos($contents, 'conf-dir='.BREW_PREFIX.'/etc/dnsmasq.d/,*.conf') === false) {
+        if (! str_contains($contents, 'conf-dir='.BREW_PREFIX.'/etc/dnsmasq.d/,*.conf')) {
             $contents .= PHP_EOL.'conf-dir='.BREW_PREFIX.'/etc/dnsmasq.d/,*.conf'.PHP_EOL;
         }
         $contents = str_replace('#conf-dir='.BREW_PREFIX.'/etc/dnsmasq.d/,*.conf', 'conf-dir='.BREW_PREFIX.'/etc/dnsmasq.d/,*.conf', $contents);

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -8,7 +8,7 @@ use GuzzleHttp\Client;
 
 class Ngrok
 {
-    public $tunnelsEndpoints = [
+    public array $tunnelsEndpoints = [
         'http://127.0.0.1:4040/api/tunnels',
         'http://127.0.0.1:4041/api/tunnels',
     ];

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 
 class PhpFpm
 {
-    public $taps = [
+    public array $taps = [
         'shivammathur/php',
     ];
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -211,7 +211,7 @@ class PhpFpm
     public function isolatedDirectories(): Collection
     {
         return $this->nginx->configuredSites()->filter(function ($item) {
-            return strpos($this->files->get(VALET_HOME_PATH.'/Nginx/'.$item), ISOLATED_PHP_VERSION) !== false;
+            return str_contains($this->files->get(VALET_HOME_PATH.'/Nginx/'.$item), ISOLATED_PHP_VERSION);
         })->map(function ($item) {
             return ['url' => $item, 'version' => $this->normalizePhpVersion($this->site->customPhpVersion($item))];
         });
@@ -328,7 +328,7 @@ class PhpFpm
 
             // Get the normalized PHP version for this config file, if it's defined
             foreach ($fpmSockFiles as $sock) {
-                if (strpos($content, $sock) !== false) {
+                if (str_contains($content, $sock)) {
                     // Extract the PHP version number from a custom .sock path and normalize it to, e.g., "php@7.4"
                     return $this->normalizePhpVersion(str_replace(['valet', '.sock'], '', $sock));
                 }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -350,7 +350,7 @@ class Site
             $newUrl = str_replace('.'.$oldTld, '.'.$tld, $url);
             $siteConf = $this->getSiteConfigFileContents($url, '.'.$oldTld);
 
-            if (! empty($siteConf) && strpos($siteConf, '# valet stub: secure.proxy.valet.conf') === 0) {
+            if (! empty($siteConf) && str_starts_with($siteConf, '# valet stub: secure.proxy.valet.conf')) {
                 // proxy config
                 $this->unsecure($url);
                 $this->secure(
@@ -408,7 +408,7 @@ class Site
             foreach ($matches as $match) {
                 $replaced = str_replace($old, $new, $match);
 
-                if ($shouldComment && strpos($replaced, '#') !== 0) {
+                if ($shouldComment && ! str_starts_with($replaced, '#')) {
                     $replaced = '#'.$replaced;
                 }
 
@@ -549,7 +549,7 @@ class Site
                 'security verify-cert -c "%s"', $caPemPath
             ));
 
-            if (strpos($isTrusted, '...certificate verification successful.') === false) {
+            if (! str_contains($isTrusted, '...certificate verification successful.')) {
                 $this->trustCa($caPemPath);
             }
 
@@ -629,7 +629,7 @@ class Site
         ));
 
         // If cert could not be created using runAsUser(), use run().
-        if (strpos($result, 'Permission denied') !== false) {
+        if (str_contains($result, 'Permission denied')) {
             $this->cli->run(sprintf(
                 'openssl x509 -req -sha256 -days %s -CA "%s" -CAkey "%s" %s -in "%s" -out "%s" -extensions v3_req -extfile "%s"',
                 $caExpireInDays, $caPemPath, $caKeyPath, $caSrlParam, $csrPath, $crtPath, $confPath

--- a/cli/Valet/Status.php
+++ b/cli/Valet/Status.php
@@ -4,11 +4,11 @@ namespace Valet;
 
 class Status
 {
-    public $brewServicesUserOutput;
+    public ?array $brewServicesUserOutput = null;
 
-    public $brewServicesRootOutput;
+    public ?array $brewServicesRootOutput = null;
 
-    public $debugInstructions = [];
+    public array $debugInstructions = [];
 
     public function __construct(public Configuration $config, public Brew $brew, public CommandLine $cli, public Filesystem $files) {}
 

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Exception\GuzzleException;
 
 class Valet
 {
-    public $valetBin = BREW_PREFIX.'/bin/valet';
+    public string $valetBin = BREW_PREFIX.'/bin/valet';
 
     public function __construct(public CommandLine $cli, public Filesystem $files) {}
 

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -82,7 +82,7 @@ function table(array $headers = [], array $rows = []): void
  */
 function testing(): bool
 {
-    return strpos($_SERVER['SCRIPT_NAME'], 'phpunit') !== false;
+    return str_contains($_SERVER['SCRIPT_NAME'], 'phpunit');
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1567 (require PHP 8.0). The CLI already guarantees PHP 8.0+ at runtime (`find-usable-php.php` enforces a `8.0` minimum), and parts of the CLI already use `str_contains` and constructor property promotion. This brings the rest of the CLI code in line, in two mechanical commits.

## Summary

- Replaces `strpos` comparisons with `str_contains`/`str_starts_with` in CLI code, only where the semantics are identical (`=== 0`, `!== 0`, `=== false`, `!== false`). Three call sites were deliberately left alone because they are not equivalent: the truthy checks in `PhpFpm::isolate()` and `Expose::findHttpTunnelUrl()`, and the offset use in `Status::jsonFromCli()`.
- Adds native property types to the untyped properties in the CLI classes (`Diagnose`, `DnsMasq`, `Ngrok`, `PhpFpm`, `Status`, `Valet`).

**Scope note:** everything loaded by `server.php` (`cli/Valet/Server.php`, `cli/Valet/Drivers/**`, `cli/includes/require-drivers.php`, `cli/includes/compatibility.php`) is untouched. That code runs under the site's FPM PHP without the Composer autoloader, and site isolation supports down to `php@7.1`, so it intentionally keeps using `strpos` and stays PHP 7-parseable.

The three `switch` statements in the service commands were also left as-is: their `case ''` relies on loose comparison to match an omitted (`null`) service argument, which a strict `match` would silently break.

## Test plan

- Full test suite passes after each commit: 293 tests, 561 assertions.
- `php cli/valet.php --version` and `php cli/valet.php paths` behave unchanged.
- `git diff --name-only` confirms no server-context file is modified.