### PR TITLE
Add missing share server block to secure proxy stubs

### DIFF
--- a/cli/stubs/secure.proxy.valet-legacy.conf
+++ b/cli/stubs/secure.proxy.valet-legacy.conf
@@ -57,3 +57,38 @@ server {
         deny all;
     }
 }
+
+server {
+    listen 127.0.0.1:60;
+    listen [::1]:60;
+    #listen VALET_LOOPBACK:60; # valet loopback
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/VALET_SITE-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location / {
+        proxy_pass VALET_PROXY_HOST;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/cli/stubs/secure.proxy.valet.conf
+++ b/cli/stubs/secure.proxy.valet.conf
@@ -57,3 +57,38 @@ server {
         deny all;
     }
 }
+
+server {
+    listen 127.0.0.1:60;
+    listen [::1]:60;
+    #listen VALET_LOOPBACK:60; # valet loopback
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/VALET_SITE-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location / {
+        proxy_pass VALET_PROXY_HOST;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -1015,6 +1015,24 @@ class SiteTest extends TestCase
         $this->assertStringContainsString('listen [::1]:443 ssl;', $rewritten);
     }
 
+    public function test_secure_proxy_stubs_include_share_server_block()
+    {
+        /** @var Site $site */
+        $site = resolve(Site::class);
+
+        foreach (['secure.proxy.valet.conf', 'secure.proxy.valet-legacy.conf'] as $stub) {
+            $contents = file_get_contents(__DIR__.'/../cli/stubs/'.$stub);
+
+            // The port-60 server block is what `valet share` tunnels to.
+            $this->assertStringContainsString('listen 127.0.0.1:60;', $contents, $stub);
+            $this->assertStringContainsString('listen [::1]:60;', $contents, $stub);
+
+            // A custom loopback must activate the port-60 listener too.
+            $rewritten = $site->replaceOldLoopbackWithNew($contents, 'VALET_LOOPBACK', '10.0.0.1');
+            $this->assertStringContainsString('listen 10.0.0.1:60;', $rewritten, $stub);
+        }
+    }
+
     public function test_it_removes_isolation()
     {
         $files = Mockery::mock(Filesystem::class);


### PR DESCRIPTION
## Summary

`valet share` tunnels to the plaintext server block on port 60. That block exists in `secure.valet.conf`, `secure.valet-legacy.conf`, and `proxy.valet.conf`, but both secure proxy stubs end without it, so sites created with `valet proxy --secure` cannot be shared.

- Adds the port-60 server block to `secure.proxy.valet.conf` and `secure.proxy.valet-legacy.conf`, mirroring the one in `proxy.valet.conf` (including the `X-Robots-Tag` header the share port sets everywhere else)
- Adds a test asserting both stubs contain the block and that `replaceOldLoopbackWithNew()` activates its custom loopback listener, matching the coverage added in #1561

## Test plan

- `./vendor/bin/phpunit` green (294 tests)
- Rendered the stub with all `VALET_*` tokens substituted and verified `nginx -t` reports `syntax is ok` on nginx 1.31.4