### PR TITLE
Match client_max_body_size to Valet's PHP upload limits

### DIFF
--- a/cli/stubs/proxy.valet.conf
+++ b/cli/stubs/proxy.valet.conf
@@ -7,7 +7,7 @@ server {
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
-    client_max_body_size 128M;
+    client_max_body_size 512M;
 
     location /VALET_STATIC_PREFIX/ {
         internal;
@@ -53,7 +53,7 @@ server {
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
-    client_max_body_size 128M;
+    client_max_body_size 512M;
 
     add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
 

--- a/cli/stubs/secure.proxy.valet-legacy.conf
+++ b/cli/stubs/secure.proxy.valet-legacy.conf
@@ -15,7 +15,7 @@ server {
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
-    client_max_body_size 128M;
+    client_max_body_size 512M;
     http2_push_preload on;
 
     location /VALET_STATIC_PREFIX/ {

--- a/cli/stubs/secure.proxy.valet.conf
+++ b/cli/stubs/secure.proxy.valet.conf
@@ -15,7 +15,7 @@ server {
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
-    client_max_body_size 128M;
+    client_max_body_size 512M;
     http2 on;
 
     location /VALET_STATIC_PREFIX/ {

--- a/cli/stubs/secure.valet-legacy.conf
+++ b/cli/stubs/secure.valet-legacy.conf
@@ -58,7 +58,7 @@ server {
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
-    client_max_body_size 128M;
+    client_max_body_size 512M;
 
     add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
 

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -58,7 +58,7 @@ server {
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
-    client_max_body_size 128M;
+    client_max_body_size 512M;
 
     add_header X-Robots-Tag 'noindex, nofollow, nosnippet, noarchive';
 

--- a/cli/stubs/site.valet.conf
+++ b/cli/stubs/site.valet.conf
@@ -6,7 +6,7 @@ server {
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
-    client_max_body_size 128M;
+    client_max_body_size 512M;
 
     location /VALET_STATIC_PREFIX/ {
         internal;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -5,7 +5,7 @@ server {
     server_name "!valet!" "";
     root /;
     charset utf-8;
-    client_max_body_size 128M;
+    client_max_body_size 512M;
 
     location /VALET_STATIC_PREFIX/ {
         internal;


### PR DESCRIPTION
## Summary

`php-memory-limits.ini` sets `upload_max_filesize = 512M` / `post_max_size = 512M` and even carries the comment that changes need to be reflected in nginx with `client_max_body_size`. But only the top-level `nginx.conf` and the HTTPS block of `secure.valet.conf` say 512M; every other server block (plain HTTP sites, isolated sites, proxies, and the share blocks) still caps at 128M.

Net effect: an upload between 128M and 512M succeeds on `https://site.test` but returns 413 on `http://site.test`, even though PHP would happily accept it.

- Sets `client_max_body_size 512M;` consistently across all server blocks in the site, proxy, and legacy stubs

## Test plan

- `./vendor/bin/phpunit` green (293 tests)
- Rendered the stubs with all `VALET_*` tokens substituted and verified `nginx -t` reports `syntax is ok` on nginx 1.31.4