### PR TITLE
Enable TLS session resumption for secured sites

### DIFF
--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -17,6 +17,9 @@ http {
 
     server_names_hash_bucket_size 128;
 
+    ssl_session_cache shared:valet:10m;
+    ssl_session_timeout 1h;
+
     ssi on;
 
     gzip  on;


### PR DESCRIPTION
## Summary

The stubs configure `ssl_certificate`/`ssl_certificate_key` but no `ssl_session_cache`, and nginx's default is `none`. TLS 1.3 clients that accept session tickets still resume (tickets are on by default), but any client resuming via session IDs, and any connection where the ticket path is not used, falls back to a full handshake on every connection.

- Adds `ssl_session_cache shared:valet:10m;` and `ssl_session_timeout 1h;` to the `http` block in `nginx.conf`, shared by all secured sites, complementing the default ticket-based resumption

Easy to observe with `openssl s_client -connect site.test:443 -tls1_2 -no_ticket -reconnect`: without the cache all reconnects report `New`; with it, they report `Reused`.

## Test plan

- `./vendor/bin/phpunit` green (293 tests)
- Rendered `nginx.conf` + `secure.valet.conf` with tokens substituted, `nginx -t` reports `syntax is ok` on nginx 1.31.4
- Verified live: `s_client -tls1_2 -no_ticket -reconnect` against a secured site reports 1x `New` followed by 5x `Reused`