### PR TITLE
Modernize gzip configuration

### DIFF
--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -20,6 +20,7 @@ http {
     ssi on;
 
     gzip  on;
+    gzip_static on;
     gzip_comp_level 5;
     gzip_min_length 256;
     gzip_proxied any;
@@ -28,18 +29,21 @@ http {
     application/atom+xml
     application/javascript
     application/json
+    application/ld+json
+    application/manifest+json
     application/rss+xml
     application/vnd.ms-fontobject
-    application/x-font-ttf
-    application/x-web-app-manifest+json
+    application/wasm
     application/xhtml+xml
     application/xml
-    font/opentype
+    font/otf
+    font/ttf
     image/svg+xml
     image/x-icon
     text/css
+    text/javascript
     text/plain
-    text/x-component;
+    text/xml;
 
     include "VALET_HOME_PATH/Nginx/*";
     include servers/*;


### PR DESCRIPTION
## Summary

The `gzip_types` list in `nginx.conf` predates a few MIME registrations and misses types common in today's Laravel apps:

- `.xml` files are emitted as `text/xml` by nginx's own `mime.types`, but the list only had `application/xml`, so static XML (sitemaps, feeds) was never compressed
- Adds `text/javascript` (nginx has flip-flopped between it and `application/javascript` across releases; listing both covers either mapping), `application/wasm`, `application/ld+json`, and `application/manifest+json`
- Swaps the legacy names for their registered successors: `application/x-font-ttf` -> `font/ttf`, `font/opentype` -> `font/otf`, `application/x-web-app-manifest+json` -> `application/manifest+json`, and drops `text/x-component` (IE HTC behaviors)

Also enables `gzip_static`, which is compiled into the Homebrew nginx build (`--with-http_gzip_static_module`) and serves precompressed `.gz` siblings when a build step emits them, at zero cost otherwise.

## Test plan

- `./vendor/bin/phpunit` green (293 tests)
- Rendered `nginx.conf` with tokens substituted, `nginx -t` reports `syntax is ok` on nginx 1.31.4