### PR TITLE
Make dnsmasq authoritative for the Valet TLD

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -110,8 +110,9 @@ class DnsMasq
         $loopback = $this->configuration->read()['loopback'];
 
         $this->files->putAsUser($tldConfigFile,
-            'address=/.'.$tld.'/'.$loopback.PHP_EOL
-            .'address=/.'.$tld.'/::1'.PHP_EOL // IPV6 loopback prevents Safari "Happy Eyeballs" slow load
+            'address=/'.$tld.'/'.$loopback.PHP_EOL
+            .'address=/'.$tld.'/::1'.PHP_EOL // IPV6 loopback prevents Safari "Happy Eyeballs" slow load
+            .'local=/'.$tld.'/'.PHP_EOL // answer authoritatively; never forward .tld queries upstream
             .'listen-address='.$loopback.PHP_EOL
         );
     }

--- a/tests/DnsMasqTest.php
+++ b/tests/DnsMasqTest.php
@@ -52,7 +52,7 @@ class DnsMasqTest extends TestCase
         $dnsMasq->install('test');
 
         $this->assertSame('nameserver '.VALET_LOOPBACK.PHP_EOL, file_get_contents(__DIR__.'/output/resolver/test'));
-        $this->assertSame('address=/.test/'.VALET_LOOPBACK.PHP_EOL.'address=/.test/::1'.PHP_EOL.'listen-address='.VALET_LOOPBACK.PHP_EOL, file_get_contents(__DIR__.'/output/tld-test.conf'));
+        $this->assertSame('address=/test/'.VALET_LOOPBACK.PHP_EOL.'address=/test/::1'.PHP_EOL.'local=/test/'.PHP_EOL.'listen-address='.VALET_LOOPBACK.PHP_EOL, file_get_contents(__DIR__.'/output/tld-test.conf'));
         $this->assertSame('test-contents
 '.PHP_EOL.'conf-dir='.BREW_PREFIX.'/etc/dnsmasq.d/,*.conf'.PHP_EOL,
             file_get_contents($dnsMasq->dnsmasqMasterConfigFile)


### PR DESCRIPTION
## Summary

The generated `tld-*.conf` only sets `address=` entries, which cover A and AAAA lookups. Any other record type for a `.test` name is not answered locally and gets forwarded to the upstream servers from `/etc/resolv.conf`. Safari and current Chrome send an HTTPS (type 65) query alongside A/AAAA on every navigation, so each fresh `.test` lookup leaks to public resolvers and waits on a round trip (or a timeout, if the upstream is unreachable) before the browser settles. Same spirit as #1545, which fixed the AAAA half of this.

- Adds `local=/tld/` so dnsmasq answers every record type for the Valet TLD authoritatively, with an immediate local answer and nothing forwarded upstream
- Switches `address=/.test/` to the canonical `address=/test/` form, matching the `local=` syntax (dnsmasq treats both the same; the docs use the dotless form)

Scoped deliberately to the per-TLD config file: no changes to the shared `dnsmasq.conf` or the `dnsmasq.d` layout, so setups where the same dnsmasq serves other tools (Herd, custom forwarding) are untouched.

## Test plan

- `./vendor/bin/phpunit` green, including the updated `DnsMasqTest` content assertion
- `dnsmasq --test` reports `syntax check OK` on the generated config (dnsmasq 2.93)
