### PR TITLE
Raise fastcgi_read_timeout so debugger pauses do not 504

### DIFF
--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -13,6 +13,8 @@ http {
     keepalive_timeout  65;
     types_hash_max_size 2048;
 
+    fastcgi_read_timeout 3600;
+
     client_max_body_size 512M;
 
     server_names_hash_bucket_size 128;


### PR DESCRIPTION
## Summary

No stub sets `fastcgi_read_timeout`, so nginx's 60 second default applies. Sit on an Xdebug breakpoint for more than a minute and nginx gives up on PHP-FPM, returns 504, and the debug session dies mid-step. Long-running artisan-triggered requests and slow first-hit cache warms trip the same wire.

- Adds `fastcgi_read_timeout 3600;` to the `http` block in `nginx.conf`, covering every site stub with one line

This is a deliberate divergence from production defaults, but pausing a request in a debugger is a dev-only workflow with no production equivalent, and Valet is the tool where that workflow has to work. `max_execution_time` still bounds actual runaway scripts; this only stops nginx from abandoning a request PHP is intentionally holding.

## Test plan

- `./vendor/bin/phpunit` green (293 tests)
- Rendered `nginx.conf` with tokens substituted, `nginx -t` reports `syntax is ok` on nginx 1.31.4